### PR TITLE
Create ServingModel

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -14,6 +14,7 @@ package ai.djl.serving;
 
 import ai.djl.repository.FilenameUtils;
 import ai.djl.serving.models.ModelManager;
+import ai.djl.serving.models.ServingModel;
 import ai.djl.serving.plugins.FolderScanPluginManager;
 import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.util.Connector;
@@ -348,7 +349,7 @@ public class ModelServer {
                 } else {
                     modelVersion = version;
                 }
-                CompletableFuture<ModelInfo> future =
+                CompletableFuture<ServingModel> future =
                         modelManager.registerModel(
                                 modelName,
                                 modelVersion,
@@ -358,8 +359,8 @@ public class ModelServer {
                                 configManager.getBatchSize(),
                                 configManager.getMaxBatchDelay(),
                                 configManager.getMaxIdleTime());
-                ModelInfo modelInfo = future.join();
-                modelManager.triggerModelUpdated(modelInfo.scaleWorkers(1, -1));
+                ServingModel sm = future.join();
+                modelManager.triggerModelUpdated(sm.getModelInfo().scaleWorkers(1, -1));
             }
             startupModels.add(modelName);
         }

--- a/serving/src/main/java/ai/djl/serving/models/Endpoint.java
+++ b/serving/src/main/java/ai/djl/serving/models/Endpoint.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.serving.models;
 
-import ai.djl.serving.wlm.ModelInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /** A class that represents a webservice endpoint. */
 public class Endpoint {
 
-    private List<ModelInfo> models;
+    private List<ServingModel> models;
     private Map<String, Integer> map;
     private AtomicInteger position;
 
@@ -36,15 +35,15 @@ public class Endpoint {
     /**
      * Adds a model to the entpoint.
      *
-     * @param modelInfo the model to be added
+     * @param model the model to be added
      * @return true if add success
      */
-    public synchronized boolean add(ModelInfo modelInfo) {
-        String version = modelInfo.getVersion();
+    public synchronized boolean add(ServingModel model) {
+        String version = model.getVersion();
         if (version == null) {
             if (models.isEmpty()) {
                 map.put("default", 0);
-                return models.add(modelInfo);
+                return models.add(model);
             }
             return false;
         }
@@ -53,7 +52,7 @@ public class Endpoint {
         }
 
         map.put(version, models.size());
-        return models.add(modelInfo);
+        return models.add(model);
     }
 
     /**
@@ -61,7 +60,7 @@ public class Endpoint {
      *
      * @return the models associated with the endpoint
      */
-    public List<ModelInfo> getModels() {
+    public List<ServingModel> getModels() {
         return models;
     }
 
@@ -71,12 +70,12 @@ public class Endpoint {
      * @param version the model version
      * @return null if the specified version doesn't exist
      */
-    public synchronized ModelInfo remove(String version) {
+    public synchronized ServingModel remove(String version) {
         if (version == null) {
             if (models.isEmpty()) {
                 return null;
             }
-            ModelInfo model = models.remove(0);
+            ServingModel model = models.remove(0);
             reIndex();
             return model;
         }
@@ -84,18 +83,18 @@ public class Endpoint {
         if (index == null) {
             return null;
         }
-        ModelInfo model = models.remove((int) index);
+        ServingModel model = models.remove((int) index);
         reIndex();
         return model;
     }
 
     /**
-     * Returns the {@code ModelInfo} for the specified version.
+     * Returns the {@code ServingModel} for the specified version.
      *
      * @param version the version of the model to retrieve
-     * @return the {@code ModelInfo} for the specified version
+     * @return the {@code ServingModel} for the specified version
      */
-    public ModelInfo get(String version) {
+    public ServingModel get(String version) {
         Integer index = map.get(version);
         if (index == null) {
             return null;
@@ -108,7 +107,7 @@ public class Endpoint {
      *
      * @return the next version of model to serve the inference request
      */
-    public ModelInfo next() {
+    public ServingModel next() {
         int size = models.size();
         if (size == 1) {
             return models.get(0);
@@ -121,8 +120,8 @@ public class Endpoint {
         map.clear();
         int size = models.size();
         for (int i = 0; i < size; ++i) {
-            ModelInfo modelInfo = models.get(i);
-            String version = modelInfo.getVersion();
+            ServingModel model = models.get(i);
+            String version = model.getVersion();
             if (version != null) {
                 map.put(version, i);
             }

--- a/serving/src/main/java/ai/djl/serving/models/ServingModel.java
+++ b/serving/src/main/java/ai/djl/serving/models/ServingModel.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.models;
+
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.serving.wlm.ModelInfo;
+import java.util.Objects;
+
+/** An extension of {@link ModelInfo} with additional data for serving. */
+public class ServingModel {
+
+    private ModelInfo modelInfo;
+    private String version;
+    private String modelUrl;
+
+    /**
+     * Constructs a new {@code ModelInfo} instance.
+     *
+     * @param modelName the name of the model that will be used as HTTP endpoint
+     * @param version the version of the model
+     * @param modelUrl the model url
+     * @param model the {@link ZooModel}
+     * @param queueSize the maximum request queue size
+     * @param maxIdleTime the initial maximum idle time for workers.
+     * @param maxBatchDelay the initial maximum delay when scaling up before giving up.
+     * @param batchSize the batch size for this model.
+     */
+    public ServingModel(
+            String modelName,
+            String version,
+            String modelUrl,
+            ZooModel<Input, Output> model,
+            int queueSize,
+            int maxIdleTime,
+            int maxBatchDelay,
+            int batchSize) {
+        this.modelInfo =
+                new ModelInfo(modelName, model, queueSize, maxIdleTime, maxBatchDelay, batchSize);
+        this.version = version;
+        this.modelUrl = modelUrl;
+    }
+
+    /**
+     * Returns the model info.
+     *
+     * @return the model info
+     */
+    public ModelInfo getModelInfo() {
+        return modelInfo;
+    }
+
+    /**
+     * Returns the model version.
+     *
+     * @return the model version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Returns the model url.
+     *
+     * @return the model url
+     */
+    public String getModelUrl() {
+        return modelUrl;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ServingModel)) {
+            return false;
+        }
+        ServingModel sm = (ServingModel) o;
+        return modelInfo.equals(sm.modelInfo) && version.equals(sm.getVersion());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelInfo.getModelName(), getVersion());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        if (version != null) {
+            return modelInfo.getModelName() + ':' + version;
+        }
+        return modelInfo.getModelName();
+    }
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -30,9 +30,6 @@ public final class ModelInfo implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(ModelInfo.class);
 
     private String modelName;
-    private String version;
-    private String modelUrl;
-
     private int minWorkers;
     private int maxWorkers;
     private int queueSize;
@@ -46,8 +43,6 @@ public final class ModelInfo implements AutoCloseable {
      * Constructs a new {@code ModelInfo} instance.
      *
      * @param modelName the name of the model that will be used as HTTP endpoint
-     * @param version the version of the model
-     * @param modelUrl the model url
      * @param model the {@link ZooModel}
      * @param queueSize the maximum request queue size
      * @param maxIdleTime the initial maximum idle time for workers.
@@ -56,16 +51,12 @@ public final class ModelInfo implements AutoCloseable {
      */
     public ModelInfo(
             String modelName,
-            String version,
-            String modelUrl,
             ZooModel<Input, Output> model,
             int queueSize,
             int maxIdleTime,
             int maxBatchDelay,
             int batchSize) {
         this.modelName = modelName;
-        this.version = version;
-        this.modelUrl = modelUrl;
         this.model = model;
         this.maxBatchDelay = maxBatchDelay;
         this.maxIdleTime = maxIdleTime; // default max idle time 60s
@@ -133,24 +124,6 @@ public final class ModelInfo implements AutoCloseable {
      */
     public String getModelName() {
         return modelName;
-    }
-
-    /**
-     * Returns the model version.
-     *
-     * @return the model version
-     */
-    public String getVersion() {
-        return version;
-    }
-
-    /**
-     * Returns the model url.
-     *
-     * @return the model url
-     */
-    public String getModelUrl() {
-        return modelUrl;
     }
 
     /**
@@ -262,21 +235,18 @@ public final class ModelInfo implements AutoCloseable {
             return false;
         }
         ModelInfo modelInfo = (ModelInfo) o;
-        return modelName.equals(modelInfo.modelName) && Objects.equals(version, modelInfo.version);
+        return modelName.equals(modelInfo.modelName);
     }
 
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return Objects.hash(modelName, version);
+        return Objects.hash(modelName);
     }
 
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        if (version != null) {
-            return modelName + ':' + version;
-        }
         return modelName;
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -19,7 +19,7 @@ public class ModelInfoTest {
 
     @Test
     public void testQueueSizeIsSet() {
-        ModelInfo modelInfo = new ModelInfo("", null, "", null, 4711, 1, 300, 1);
+        ModelInfo modelInfo = new ModelInfo("", null, 4711, 1, 300, 1);
         Assert.assertEquals(4711, modelInfo.getQueueSize());
     }
 }


### PR DESCRIPTION
This creates an extension of ModelInfo called ServingModel.
It's main use is to simplify the WLM module by removing ModelInfo properties
that are not used by it (specifically the version and modelUrl).
