### PR TITLE
Upgrade log4j to 2.16.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ djl_version=0.15.0
 commons_cli_version=1.4
 netty_version=4.1.70.Final
 slf4j_version=1.7.32
-log4j_slf4j_version=2.15.0
+log4j_slf4j_version=2.16.0
 
 # testng 7.4.0 has bug, we have to keep it as 7.3.0 for now
 testng_version=7.3.0


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
