### PR TITLE
Multi-device model support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 # FIXME: Workaround gradle publish issue: https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
-djl_version=0.15.0
+djl_version=0.16.0
 commons_cli_version=1.4
 netty_version=4.1.72.Final
 slf4j_version=1.7.32

--- a/serving/src/main/java/ai/djl/serving/http/DescribeModelResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeModelResponse.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving.http;
 
+import ai.djl.Device;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -233,15 +234,16 @@ public class DescribeModelResponse {
      * @param id the worker's ID
      * @param startTime the worker's start time
      * @param isRunning {@code true} if worker is running
-     * @param gpuId the GPU id assigned to the worker, -1 for CPU
+     * @param device the device assigned to the worker
      */
-    public void addWorker(String version, int id, long startTime, boolean isRunning, int gpuId) {
+    public void addWorker(
+            String version, int id, long startTime, boolean isRunning, Device device) {
         Worker worker = new Worker();
         worker.setVersion(version);
         worker.setId(id);
         worker.setStartTime(new Date(startTime));
         worker.setStatus(isRunning ? "READY" : "UNLOADING");
-        worker.setGpu(gpuId >= 0);
+        worker.setDevice(device);
         workers.add(worker);
     }
 
@@ -252,7 +254,7 @@ public class DescribeModelResponse {
         private int id;
         private Date startTime;
         private String status;
-        private boolean gpu;
+        private Device device;
 
         /**
          * Returns the model version.
@@ -332,16 +334,16 @@ public class DescribeModelResponse {
          * @return {@code true} if the worker using GPU
          */
         public boolean isGpu() {
-            return gpu;
+            return device.isGpu();
         }
 
         /**
-         * Sets if the worker using GPU.
+         * Sets the worker device.
          *
-         * @param gpu if the worker using GPU
+         * @param device the worker device
          */
-        public void setGpu(boolean gpu) {
-            this.gpu = gpu;
+        public void setDevice(Device device) {
+            this.device = device;
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving.http;
 
+import ai.djl.Device;
 import ai.djl.ModelException;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -170,6 +171,8 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             String engineName = input.getProperty("engine_name", null);
             String deviceName = input.getProperty("device", "-1");
 
+            Device device = Device.fromName(deviceName);
+
             logger.info("Loading model {} from: {}", workflowName, modelUrl);
 
             modelManager
@@ -178,11 +181,11 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                             version,
                             modelUrl,
                             engineName,
-                            deviceName,
+                            device,
                             config.getBatchSize(),
                             config.getMaxBatchDelay(),
                             config.getMaxIdleTime())
-                    .thenApply(p -> modelManager.scaleWorkers(p, deviceName, 1, -1))
+                    .thenApply(p -> modelManager.scaleWorkers(p, device, 1, -1))
                     .thenAccept(p -> runJob(modelManager, ctx, p, input));
             return;
         }

--- a/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving.http;
 
+import ai.djl.Device;
 import ai.djl.ModelException;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.serving.models.Endpoint;
@@ -185,6 +186,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                 Boolean.parseBoolean(
                         NettyUtils.getParameter(decoder, SYNCHRONOUS_PARAMETER, "true"));
 
+        Device device = Device.fromName(deviceName);
         final ModelManager modelManager = ModelManager.getInstance();
         CompletableFuture<Workflow> future =
                 modelManager.registerWorkflow(
@@ -192,7 +194,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                         version,
                         modelUrl,
                         engineName,
-                        deviceName,
+                        device,
                         batchSize,
                         maxBatchDelay,
                         maxIdleTime);
@@ -202,7 +204,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                             for (ModelInfo m : p.getModels()) {
                                 m.configurePool(maxIdleTime)
                                         .configureModelBatch(batchSize, maxBatchDelay);
-                                modelManager.scaleWorkers(m, deviceName, minWorkers, maxWorkers);
+                                modelManager.scaleWorkers(m, device, minWorkers, maxWorkers);
                             }
                         });
 

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving;
 
+import ai.djl.Device;
 import ai.djl.MalformedModelException;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -116,7 +117,7 @@ public class WorkflowTest {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
             for (ModelInfo model : workflow.getModels()) {
-                wlm.getWorkerPoolForModel(model).scaleWorkers("cpu", 1, 1);
+                wlm.getWorkerPoolForModel(model).scaleWorkers(Device.cpu(), 1, 1);
             }
 
             Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerThread.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerThread.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving.wlm;
 
+import ai.djl.Device;
 import ai.djl.inference.Predictor;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -36,7 +37,7 @@ public final class WorkerThread implements Runnable {
     private AtomicBoolean running = new AtomicBoolean(true);
 
     private BatchAggregator aggregator;
-    private int gpuId;
+    private Device device;
     private AtomicReference<Thread> currentThread = new AtomicReference<>();
     private WorkerState state;
     private int workerId;
@@ -54,9 +55,11 @@ public final class WorkerThread implements Runnable {
         this.workerId = new WorkerIdGenerator().generate();
         this.startTime = System.currentTimeMillis();
         this.fixPoolThread = builder.fixPoolThread;
+        this.device = builder.device;
         ZooModel<Input, Output> model = builder.model.getModel();
-        predictor = model.newPredictor();
-        this.gpuId = model.getNDManager().getDevice().getDeviceId();
+
+        Device predictorDevice = "nc".equals(device.getDeviceType()) ? Device.cpu() : device;
+        predictor = model.newPredictor(predictorDevice);
     }
 
     /** {@inheritDoc} */
@@ -117,12 +120,12 @@ public final class WorkerThread implements Runnable {
     }
 
     /**
-     * Returns the gpu id used by the thread.
+     * Returns the device used by the thread.
      *
-     * @return the gpu id used by the thread
+     * @return the device used by the thread
      */
-    public int getGpuId() {
-        return gpuId;
+    public Device getDevice() {
+        return device;
     }
 
     /**
@@ -200,6 +203,7 @@ public final class WorkerThread implements Runnable {
     public static class Builder {
 
         private ModelInfo model;
+        private Device device;
         private BatchAggregator aggregator;
         private LinkedBlockingDeque<WorkerJob> jobQueue;
         private boolean fixPoolThread;
@@ -228,8 +232,11 @@ public final class WorkerThread implements Runnable {
         }
 
         protected void validate() {
+            if (device == null) {
+                throw new IllegalArgumentException("Must set device for worker thread");
+            }
             if (model == null) {
-                throw new IllegalArgumentException("model must not be null");
+                throw new IllegalArgumentException("Must set model for worker thread");
             }
             if (jobQueue == null && aggregator == null) {
                 throw new IllegalArgumentException(
@@ -256,6 +263,17 @@ public final class WorkerThread implements Runnable {
          */
         public Builder setModel(ModelInfo model) {
             this.model = model;
+            return self();
+        }
+
+        /**
+         * RSets the device to run operations on.
+         *
+         * @param device the device to run operations on
+         * @return self-reference to this builder
+         */
+        public Builder setDevice(Device device) {
+            this.device = device;
             return self();
         }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -42,17 +42,17 @@ public final class WlmConfigManager {
      * Returns the default number of workers for a new registered model.
      *
      * @param manager the {@code NDManager} the model uses
-     * @param deviceName the device that model loaded on
+     * @param device the device that model loaded on
      * @param target the target number of worker
      * @return the default number of workers for a new registered model
      */
-    public int getDefaultWorkers(NDManager manager, String deviceName, int target) {
+    public int getDefaultWorkers(NDManager manager, Device device, int target) {
         if (target == 0) {
             return 0;
         } else if (target == -1 && isDebug()) {
             return 1;
         }
-        if (deviceName != null && deviceName.startsWith("nc")) {
+        if (device != null && "nc".equals(device.getDeviceType())) {
             if ("Python".equals(manager.getEngine().getEngineName())) {
                 return 1;
             }


### PR DESCRIPTION
This modifies server to support models with workers on multiple devices rather
than using the previous system of having it as multiple models with versions
indicating the device.

As part of this, it also tries to replace ad-hoc device usages with actual
device. This includes systematically converting device names into Device and
storing device rather than device name or gpu boolean.