### PR TITLE
Create control plane for workflows

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
@@ -16,11 +16,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-/** A class that holds information about model status. */
-public class DescribeModelResponse {
+/** A class that holds information about workflow status. */
+public class DescribeWorkflowResponse {
 
-    private String modelName;
-    private String modelUrl;
+    private String workflowName;
+    private String workflowUrl;
     private int minWorkers;
     private int maxWorkers;
     private int batchSize;
@@ -32,33 +32,33 @@ public class DescribeModelResponse {
 
     private List<Worker> workers;
 
-    /** Constructs a {@code DescribeModelResponse} instance. */
-    public DescribeModelResponse() {
+    /** Constructs a {@code DescribeWorkflowResponse} instance. */
+    public DescribeWorkflowResponse() {
         workers = new ArrayList<>();
     }
 
     /**
-     * Returns the model name.
+     * Returns the workflow name.
      *
-     * @return the model name
+     * @return the workflow name
      */
-    public String getModelName() {
-        return modelName;
+    public String getWorkflowName() {
+        return workflowName;
     }
 
     /**
-     * Sets the model name.
+     * Sets the workflow name.
      *
-     * @param modelName the model name
+     * @param workflowName the workflow name
      */
-    public void setModelName(String modelName) {
-        this.modelName = modelName;
+    public void setWorkflowName(String workflowName) {
+        this.workflowName = workflowName;
     }
 
     /**
-     * Returns if the models was loaded at startup.
+     * Returns if the workflows was loaded at startup.
      *
-     * @return {@code true} if the models was loaded at startup
+     * @return {@code true} if the workflows was loaded at startup
      */
     public boolean isLoadedAtStartup() {
         return loadedAtStartup;
@@ -67,28 +67,28 @@ public class DescribeModelResponse {
     /**
      * Sets the load at startup status.
      *
-     * @param loadedAtStartup {@code true} if the models was loaded at startup
+     * @param loadedAtStartup {@code true} if the workflows was loaded at startup
      */
     public void setLoadedAtStartup(boolean loadedAtStartup) {
         this.loadedAtStartup = loadedAtStartup;
     }
 
     /**
-     * Returns the model URL.
+     * Returns the workflow URL.
      *
-     * @return the model URL
+     * @return the workflow URL
      */
-    public String getModelUrl() {
-        return modelUrl;
+    public String getWorkflowUrl() {
+        return workflowUrl;
     }
 
     /**
-     * Sets the model URL.
+     * Sets the workflow URL.
      *
-     * @param modelUrl the model URL
+     * @param workflowUrl the workflow URL
      */
-    public void setModelUrl(String modelUrl) {
-        this.modelUrl = modelUrl;
+    public void setWorkflowUrl(String workflowUrl) {
+        this.workflowUrl = workflowUrl;
     }
 
     /**
@@ -182,18 +182,18 @@ public class DescribeModelResponse {
     }
 
     /**
-     * Returns the model's status.
+     * Returns the workflow's status.
      *
-     * @return the model's status
+     * @return the workflow's status
      */
     public String getStatus() {
         return status;
     }
 
     /**
-     * Sets the model's status.
+     * Sets the workflow's status.
      *
-     * @param status the model's status
+     * @param status the workflow's status
      */
     public void setStatus(String status) {
         this.status = status;
@@ -218,9 +218,9 @@ public class DescribeModelResponse {
     }
 
     /**
-     * Returns all workers information of the model.
+     * Returns all workers information of the workflow.
      *
-     * @return all workers information of the model
+     * @return all workers information of the workflow
      */
     public List<Worker> getWorkers() {
         return workers;
@@ -229,7 +229,7 @@ public class DescribeModelResponse {
     /**
      * Adds worker to the worker list.
      *
-     * @param version the model version
+     * @param version the workflow version
      * @param id the worker's ID
      * @param startTime the worker's start time
      * @param isRunning {@code true} if worker is running

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -148,7 +148,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
         if (workflow == null) {
             String regex = config.getModelUrlPattern();
             if (regex == null) {
-                throw new ModelNotFoundException("Model not found: " + workflowName);
+                throw new ModelNotFoundException("Model or workflow not found: " + workflowName);
             }
             String modelUrl = input.getProperty("model_url", null);
             if (modelUrl == null) {

--- a/serving/src/main/java/ai/djl/serving/http/ListWorkflowsResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/ListWorkflowsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/serving/src/main/java/ai/djl/serving/http/ListWorkflowsResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/ListWorkflowsResponse.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** A class that holds information about the current registered workflows. */
+public class ListWorkflowsResponse {
+
+    private String nextPageToken;
+    private List<WorkflowItem> workflows;
+
+    /** Constructs a new {@code ListWorkflowsResponse} instance. */
+    public ListWorkflowsResponse() {
+        workflows = new ArrayList<>();
+    }
+
+    /**
+     * Returns the next page token.
+     *
+     * @return the next page token
+     */
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+
+    /**
+     * Sets the next page token.
+     *
+     * @param nextPageToken the next page token
+     */
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+
+    /**
+     * Returns a list of workflows.
+     *
+     * @return a list of workflows
+     */
+    public List<WorkflowItem> getWorkflows() {
+        return workflows;
+    }
+
+    /**
+     * Adds the workflow tp the list.
+     *
+     * @param workflowName the workflow name
+     * @param version the mode version
+     */
+    public void addWorkflow(String workflowName, String version) {
+        workflows.add(new WorkflowItem(workflowName, version));
+    }
+
+    /** A class that holds workflow name and url. */
+    public static final class WorkflowItem {
+
+        private String workflowName;
+        private String version;
+
+        /** Constructs a new {@code WorkflowItem} instance. */
+        public WorkflowItem() {}
+
+        /**
+         * Constructs a new {@code WorkflowItem} instance with workflow name and url.
+         *
+         * @param workflowName the workflow name
+         * @param version the workflow version
+         */
+        public WorkflowItem(String workflowName, String version) {
+            this.workflowName = workflowName;
+            this.version = version;
+        }
+
+        /**
+         * Returns the workflow name.
+         *
+         * @return the workflow name
+         */
+        public String getWorkflowName() {
+            return workflowName;
+        }
+
+        /**
+         * Returns the workflow version.
+         *
+         * @return the workflow version
+         */
+        public String getVersion() {
+            return version;
+        }
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
@@ -69,7 +69,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
     /** HTTP Parameter "min_worker". */
     private static final String MIN_WORKER_PARAMETER = "min_worker";
 
-    private static final Pattern PATTERN = Pattern.compile("^/(models|workflows)([/?].*)?");
+    private static final Pattern WORKFLOWS_PATTERN = Pattern.compile("^/workflows([/?].*)?");
     private static final Pattern MODELS_PATTERN = Pattern.compile("^/models([/?].*)?");
 
     /** {@inheritDoc} */
@@ -77,7 +77,8 @@ public class ManagementRequestHandler extends HttpRequestHandler {
     public boolean acceptInboundMessage(Object msg) throws Exception {
         if (super.acceptInboundMessage(msg)) {
             FullHttpRequest req = (FullHttpRequest) msg;
-            return PATTERN.matcher(req.uri()).matches();
+            return WORKFLOWS_PATTERN.matcher(req.uri()).matches()
+                    || MODELS_PATTERN.matcher(req.uri()).matches();
         }
         return false;
     }

--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -16,7 +16,7 @@ import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.serving.http.BadRequestException;
-import ai.djl.serving.http.DescribeModelResponse;
+import ai.djl.serving.http.DescribeWorkflowResponse;
 import ai.djl.serving.http.StatusResponse;
 import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.wlm.ModelInfo;
@@ -254,7 +254,7 @@ public final class ModelManager {
      * @return a list of worker information for specified workflow
      * @throws ModelNotFoundException if specified workflow not found
      */
-    public List<DescribeModelResponse> describeWorkflow(String workflowName, String version)
+    public List<DescribeWorkflowResponse> describeWorkflow(String workflowName, String version)
             throws ModelNotFoundException {
         Endpoint endpoint = endpoints.get(workflowName);
         if (endpoint == null) {
@@ -265,12 +265,12 @@ public final class ModelManager {
             throw new ModelNotFoundException("Workflow not found: " + workflowName);
         }
 
-        List<DescribeModelResponse> resps = new ArrayList<>();
+        List<DescribeWorkflowResponse> resps = new ArrayList<>();
         for (Workflow workflow : list) {
             for (ModelInfo model : workflow.getModels()) {
-                DescribeModelResponse resp = new DescribeModelResponse();
-                resp.setModelName(model.getModelId());
-                resp.setModelUrl(model.getModelUrl());
+                DescribeWorkflowResponse resp = new DescribeWorkflowResponse();
+                resp.setWorkflowName(model.getModelId());
+                resp.setWorkflowUrl(model.getModelUrl());
                 resp.setBatchSize(model.getBatchSize());
                 resp.setMaxBatchDelay(model.getMaxBatchDelay());
                 resp.setMaxIdleTime(model.getMaxIdleTime());

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -101,7 +101,7 @@ public final class ConfigManager {
             prop.setProperty(LOAD_MODELS, String.join(",", models));
         }
         String[] workflows = args.getWorkflows();
-        if (models != null) {
+        if (workflows != null) {
             prop.setProperty(LOAD_WORKFLOWS, String.join(",", workflows));
         }
         for (Map.Entry<String, String> env : System.getenv().entrySet()) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -177,6 +177,7 @@ public class WorkLoadManager implements AutoCloseable {
     /** {@inheritDoc} */
     @Override
     public void close() {
+        threadPool.shutdownNow();
         for (WorkerPool wp : workerPools.values()) {
             wp.close();
         }


### PR DESCRIPTION
This updates the management request handler to add a control plane for
workflows. It shares a number of routes between the old models and workflows,
while some routes have different behaviors for each.

Specifically, there is a separate register and list command for both models and
workflows, while all other commands including describe, unregister, and scale
only work on workflows but will still accept "/models/..." routes. The precise
behavior is documented in management_api.md.

There are also a few refactors for ModelServerTest including cleaning up test
client connections, a shared list reader, a shared model registration checking function.

Finally, it also fixes a bug with the WorkLoadManager close not closing the
threadpool. This can result in the tests hanging.