### PR TITLE
Multi-device model support

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving.http;
 
+import ai.djl.Device;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -233,15 +234,16 @@ public class DescribeWorkflowResponse {
      * @param id the worker's ID
      * @param startTime the worker's start time
      * @param isRunning {@code true} if worker is running
-     * @param gpuId the GPU id assigned to the worker, -1 for CPU
+     * @param device the device assigned to the worker
      */
-    public void addWorker(String version, int id, long startTime, boolean isRunning, int gpuId) {
+    public void addWorker(
+            String version, int id, long startTime, boolean isRunning, Device device) {
         Worker worker = new Worker();
         worker.setVersion(version);
         worker.setId(id);
         worker.setStartTime(new Date(startTime));
         worker.setStatus(isRunning ? "READY" : "UNLOADING");
-        worker.setGpu(gpuId >= 0);
+        worker.setDevice(device);
         workers.add(worker);
     }
 
@@ -252,7 +254,7 @@ public class DescribeWorkflowResponse {
         private int id;
         private Date startTime;
         private String status;
-        private boolean gpu;
+        private Device device;
 
         /**
          * Returns the model version.
@@ -332,16 +334,16 @@ public class DescribeWorkflowResponse {
          * @return {@code true} if the worker using GPU
          */
         public boolean isGpu() {
-            return gpu;
+            return device.isGpu();
         }
 
         /**
-         * Sets if the worker using GPU.
+         * Sets the worker device.
          *
-         * @param gpu if the worker using GPU
+         * @param device the worker device
          */
-        public void setGpu(boolean gpu) {
-            this.gpu = gpu;
+        public void setDevice(Device device) {
+            this.device = device;
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -12,17 +12,14 @@
  */
 package ai.djl.serving.workflow;
 
-import ai.djl.ModelException;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
-import ai.djl.serving.plugins.DependencyManager;
 import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.wlm.WorkLoadManager;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 import ai.djl.serving.workflow.function.IdentityWF;
 import ai.djl.serving.workflow.function.ModelWorkflowFunction;
 import ai.djl.serving.workflow.function.WorkflowFunction;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -103,32 +99,6 @@ public class Workflow implements AutoCloseable {
      */
     public Collection<ModelInfo> getModels() {
         return models.values();
-    }
-
-    /**
-     * Load all the models in this workflow.
-     *
-     * @param device the device to load the models
-     * @return a {@code CompletableFuture} instance
-     */
-    public CompletableFuture<Void> load(String device) {
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    try {
-                        for (ModelInfo modelInfo : models.values()) {
-                            String engine = modelInfo.getEngineName();
-                            if (engine != null) {
-                                DependencyManager dm = DependencyManager.getInstance();
-                                dm.installEngine(engine);
-                            }
-
-                            modelInfo.load(device);
-                        }
-                    } catch (ModelException | IOException e) {
-                        throw new CompletionException(e);
-                    }
-                    return null;
-                });
     }
 
     /**

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving;
 
+import ai.djl.Device;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.serving.util.ConfigManager;
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.commons.cli.CommandLine;
 import org.testng.Assert;
@@ -103,13 +103,11 @@ public class WorkflowTest {
     }
 
     private Input runWorkflow(Path workflowFile, Input input)
-            throws IOException, BadWorkflowException, ExecutionException, InterruptedException {
+            throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
-        CompletableFuture<Void> future = workflow.load("-1");
-        future.get();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
             for (ModelInfo model : workflow.getModels()) {
-                wlm.getWorkerPoolForModel(model).scaleWorkers("cpu", 1, 1);
+                wlm.getWorkerPoolForModel(model).scaleWorkers(Device.cpu(), 1, 1);
             }
 
             Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.serving.wlm;
 
+import ai.djl.Device;
+import ai.djl.ModelException;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.NDManager;
 import ai.djl.serving.wlm.util.WlmCapacityException;
@@ -19,9 +21,13 @@ import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.wlm.util.WlmException;
 import ai.djl.serving.wlm.util.WlmShutdownException;
 import ai.djl.serving.wlm.util.WorkerJob;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
@@ -115,14 +121,14 @@ public class WorkLoadManager implements AutoCloseable {
         int currentWorkers = getNumRunningWorkers(modelInfo);
         if (currentWorkers == 0
                 || currentWorkers < maxWorkers && queue.size() > modelInfo.getBatchSize() * 2) {
-            synchronized (modelInfo.getModel()) {
+            synchronized (pool) {
                 currentWorkers = getNumRunningWorkers(modelInfo); // check again
                 if (currentWorkers < maxWorkers) {
                     logger.info(
                             "Scaling up workers for model {} to {} ",
                             modelInfo,
                             currentWorkers + 1);
-                    pool.addThreads(modelInfo, 1, false);
+                    pool.addThreads(1);
                 }
             }
         }
@@ -191,10 +197,8 @@ public class WorkLoadManager implements AutoCloseable {
     public final class WorkerPool implements AutoCloseable {
 
         private final ModelInfo model;
-        private List<WorkerThread> workers;
+        private Map<Device, WorkerPoolDevice> devices;
         private LinkedBlockingDeque<WorkerJob> jobQueue;
-        private int minWorkers;
-        private int maxWorkers;
 
         /**
          * Construct and initial data structure.
@@ -203,7 +207,7 @@ public class WorkLoadManager implements AutoCloseable {
          */
         public WorkerPool(ModelInfo model) {
             this.model = model;
-            workers = new CopyOnWriteArrayList<>();
+            devices = new ConcurrentHashMap<>();
             jobQueue = new LinkedBlockingDeque<>(model.getQueueSize());
         }
 
@@ -213,7 +217,10 @@ public class WorkLoadManager implements AutoCloseable {
          * @return the workers
          */
         public List<WorkerThread> getWorkers() {
-            return workers;
+            return devices.values()
+                    .stream()
+                    .flatMap(d -> d.workers.stream())
+                    .collect(Collectors.toList());
         }
 
         /**
@@ -226,41 +233,50 @@ public class WorkLoadManager implements AutoCloseable {
         }
 
         /**
-         * Returns the minimum number of workers for a model.
+         * Returns the minimum number of workers for a model across all devices.
          *
-         * @return the minimum number of workers for a model
+         * @return the minimum number of workers for a model across all devices
          */
         public int getMinWorkers() {
-            return minWorkers;
+            return devices.values().stream().mapToInt(d -> d.minWorkers).reduce(0, Integer::sum);
         }
 
         /**
-         * Returns the maximum number of workers for a model.
+         * Returns the maximum number of workers for a model across all devices.
          *
-         * @return the maximum number of workers for a model
+         * @return the maximum number of workers for a model across all devices
          */
         public int getMaxWorkers() {
-            return maxWorkers;
+            return devices.values().stream().mapToInt(d -> d.maxWorkers).reduce(0, Integer::sum);
         }
 
         /**
          * Sets new worker capcities for this model.
          *
-         * @param deviceName the device for the model
+         * @param device the device for the model or cpu if null
          * @param newMinWorkers minimum amount of workers.
          * @param newMaxWorkers maximum amount of workers.
          * @return this {@link ModelInfo}
          */
-        public WorkerPool scaleWorkers(String deviceName, int newMinWorkers, int newMaxWorkers) {
+        public WorkerPool scaleWorkers(Device device, int newMinWorkers, int newMaxWorkers) {
             synchronized (model) {
+                try {
+                    model.load(device);
+                } catch (ModelException | IOException e) {
+                    throw new CompletionException(e);
+                }
                 if (model.getStatus() != ModelInfo.Status.READY) {
                     logger.warn("Cannot scale workers while model is not READY: {}", model);
                     return this;
                 }
-                NDManager manager = model.getModel().getNDManager();
+                device = model.withDefaultDevice(device);
+                NDManager manager = model.getModel(device).getNDManager();
                 WlmConfigManager configManager = WlmConfigManager.getInstance();
-                maxWorkers = configManager.getDefaultWorkers(manager, deviceName, newMaxWorkers);
-                minWorkers = Math.min(newMinWorkers, maxWorkers);
+                newMaxWorkers = configManager.getDefaultWorkers(manager, device, newMaxWorkers);
+                newMinWorkers = Math.min(newMinWorkers, newMaxWorkers);
+
+                WorkerPoolDevice wpd = new WorkerPoolDevice(device, newMinWorkers, newMaxWorkers);
+                devices.put(device, wpd);
 
                 cleanup();
 
@@ -274,13 +290,13 @@ public class WorkLoadManager implements AutoCloseable {
 
                 int numberOfCurrentFixedWorkers = fixedPoolThread.size();
 
-                if (numberOfCurrentFixedWorkers < minWorkers) {
+                if (numberOfCurrentFixedWorkers < newMinWorkers) {
                     // scale up the fixed pool
-                    addThreads(model, minWorkers - numberOfCurrentFixedWorkers, true);
+                    wpd.addThreads(newMinWorkers - numberOfCurrentFixedWorkers, true);
                 } else {
                     // scale down the fixed pool
                     fixedPoolThread
-                            .subList(minWorkers, numberOfCurrentFixedWorkers)
+                            .subList(newMinWorkers, numberOfCurrentFixedWorkers)
                             .forEach(
                                     t -> {
                                         threads.remove(t);
@@ -293,20 +309,14 @@ public class WorkLoadManager implements AutoCloseable {
             }
         }
 
-        private void addThreads(ModelInfo model, int count, boolean permanent) {
-
-            for (int i = 0; i < count; ++i) {
-
-                WorkerThread thread =
-                        WorkerThread.builder()
-                                .setModel(model)
-                                .setJobQueue(jobQueue)
-                                .optFixPoolThread(permanent)
-                                .build();
-
-                workers.add(thread);
-                threadPool.submit(thread);
-            }
+        /**
+         * Returns the {@link WorkerPoolDevice} for a particular {@link Device}.
+         *
+         * @param device the device for a worker pool
+         * @return the {@link WorkerPoolDevice} or null if device is not used
+         */
+        public WorkerPoolDevice forDevice(Device device) {
+            return devices.get(device);
         }
 
         /**
@@ -317,36 +327,118 @@ public class WorkLoadManager implements AutoCloseable {
         public void log() {
             if (logger.isDebugEnabled()) {
                 StringBuffer buf = new StringBuffer();
-                workers.forEach(
-                        w -> {
-                            buf.append(w.getWorkerId());
-                            if (w.isFixPoolThread()) {
-                                buf.append("-fixedPool\n");
-                            } else {
-                                buf.append("-tmpPool\n");
-                            }
-                        });
+                getWorkers()
+                        .forEach(
+                                w -> {
+                                    buf.append(w.getWorkerId());
+                                    if (w.isFixPoolThread()) {
+                                        buf.append("-fixedPool\n");
+                                    } else {
+                                        buf.append("-tmpPool\n");
+                                    }
+                                });
                 logger.debug("worker pool for model {}:\n {}", model, buf);
             }
         }
 
         /** removes all stopped workers and workers in state error from the pool. */
         public void cleanup() {
-            workers.removeIf(
-                    t ->
-                            t.getState() == WorkerState.WORKER_STOPPED
-                                    || t.getState() == WorkerState.WORKER_ERROR);
+            for (WorkerPoolDevice wpd : devices.values()) {
+                wpd.workers.removeIf(
+                        t ->
+                                t.getState() == WorkerState.WORKER_STOPPED
+                                        || t.getState() == WorkerState.WORKER_ERROR);
+            }
         }
 
         /** {@inheritDoc} */
         @Override
         public void close() {
             model.close();
-            for (WorkerThread worker : workers) {
-                worker.shutdown(WorkerState.WORKER_STOPPED);
+            for (WorkerPoolDevice wpd : devices.values()) {
+                for (WorkerThread worker : wpd.workers) {
+                    worker.shutdown(WorkerState.WORKER_STOPPED);
+                }
             }
             for (WorkerJob wj : jobQueue) {
                 wj.getFuture().cancel(true);
+            }
+        }
+
+        /**
+         * Adds temporary threads across existing devices.
+         *
+         * <p>Only supports temporary threads because permanent threads are managed per-device, so
+         * it doesn't need a multi-device version.
+         *
+         * @param count number of threads to add
+         */
+        private void addThreads(int count) {
+            // Add threads to devices in a random order for now
+            List<WorkerPoolDevice> shuffled = new ArrayList<>(devices.values());
+            Collections.shuffle(shuffled);
+
+            for (WorkerPoolDevice wpd : devices.values()) {
+                int toAdd = Math.min(count, wpd.getMaxWorkers() - wpd.workers.size());
+                wpd.addThreads(toAdd, false);
+                count -= toAdd;
+                if (count == 0) {
+                    return;
+                }
+            }
+        }
+
+        /**
+         * The {@link WorkerPoolDevice} manages the {@link WorkerPool} for a particular {@link
+         * Device}.
+         */
+        public final class WorkerPoolDevice {
+
+            private Device device;
+            private int minWorkers;
+            private int maxWorkers;
+            private List<WorkerThread> workers;
+
+            private WorkerPoolDevice(Device device, int minWorkers, int maxWorkers) {
+                this.device = device;
+                this.minWorkers = minWorkers;
+                this.maxWorkers = maxWorkers;
+                workers = new CopyOnWriteArrayList<>();
+            }
+
+            /**
+             * Returns the min number of workers for the model and device.
+             *
+             * @return the min number of workers for the model and device
+             */
+            public int getMinWorkers() {
+                return minWorkers;
+            }
+
+            /**
+             * Returns the max number of workers for the model and device.
+             *
+             * @return the max number of workers for the model and device
+             */
+            public int getMaxWorkers() {
+                return maxWorkers;
+            }
+
+            private void addThreads(int count, boolean permanent) {
+
+                for (int i = 0; i < count; ++i) {
+
+                    WorkerThread thread =
+                            WorkerThread.builder()
+                                    .setModel(model)
+                                    .setDevice(device)
+                                    .setJobQueue(jobQueue)
+                                    .optFixPoolThread(permanent)
+                                    .build();
+
+                    workers.add(thread);
+                    threadPool.submit(thread);
+                }
             }
         }
     }

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -42,17 +42,17 @@ public final class WlmConfigManager {
      * Returns the default number of workers for a new registered model.
      *
      * @param manager the {@code NDManager} the model uses
-     * @param deviceName the device that model loaded on
+     * @param device the device that model loaded on
      * @param target the target number of worker
      * @return the default number of workers for a new registered model
      */
-    public int getDefaultWorkers(NDManager manager, String deviceName, int target) {
+    public int getDefaultWorkers(NDManager manager, Device device, int target) {
         if (target == 0) {
             return 0;
         } else if (target == -1 && isDebug()) {
             return 1;
         }
-        if (deviceName != null && deviceName.startsWith("nc")) {
+        if (device != null && "nc".equals(device.getDeviceType())) {
             if ("Python".equals(manager.getEngine().getEngineName())) {
                 return 1;
             }


### PR DESCRIPTION
This modifies server to support models with workers on multiple devices rather
than using the previous system of having it as multiple models with versions
indicating the device. The models then share a single work queue. I tested it
with a queue per each device and found this way had slightly better performance.

As part of this, it also tries to replace ad-hoc device usages with actual
device. This includes systematically converting device names into Device and
storing device rather than device name or gpu boolean.

It also makes some changes to model loading. This moves the model loading to a
part of the workflow scaling. Because loading is device dependent, and you can
scale a model on multiple devices, the loading should occur during the scaling
for each device.

The remaining part of installing dependencies, as it is part of serving and not
wlm, has been kept in model registration.

This is largely a rewrite of #59 using `ModelInfo.load()` rather than `model.newPredictor(device)`.
