### PR TITLE
support more python use cases

### DIFF
--- a/engines/python/setup/djl_python/inputs.py
+++ b/engines/python/setup/djl_python/inputs.py
@@ -109,6 +109,8 @@ class Input(object):
         content_type = self.get_property("content-type")
         if content_type == "tensor/ndlist":
             return self.get_as_numpy(key)
+        if content_type == "tensor/npz":
+            return self.get_as_npz(key)
         elif content_type == "application/json":
             return self.get_as_json(key)
         elif content_type is not None and content_type.startswith("text/"):
@@ -149,6 +151,12 @@ class Input(object):
         :return: list of numpy array
         """
         return from_nd_list(self.get_as_bytes(key=key))
+
+    def get_as_npz(self, key=None) -> list:
+        import numpy
+        npz = numpy.load(io.BytesIO(self.get_as_bytes(key=key)))
+        result = [npz[name] for name in npz.files]
+        return result
 
     def is_empty(self):
         return self.content.is_empty()

--- a/engines/python/setup/djl_python/outputs.py
+++ b/engines/python/setup/djl_python/outputs.py
@@ -41,12 +41,15 @@ class Output(object):
 
     def set_code(self, code):
         self.code = code
+        return self
 
     def set_message(self, message):
         self.message = message
+        return self
 
     def add_property(self, key, val):
         self.properties[key] = val
+        return self
 
     def add(self, value, key=None):
         if value is str:
@@ -57,13 +60,16 @@ class Output(object):
             self.add(key=key, value=bytearray(value))
         else:
             self.add_as_json(value, key=key)
+        return self
 
     def add_as_numpy(self, np_list, key=None):
         self.content.add(key=key, value=to_nd_list(np_list))
+        return self
 
     def add_as_json(self, val, key=None):
         json_value = json.dumps(val, indent=2).encode("utf-8")
         self.content.add(key=key, value=json_value)
+        return self
 
     @staticmethod
     def write_utf8(msg, val):

--- a/engines/python/setup/djl_python/test_model.py
+++ b/engines/python/setup/djl_python/test_model.py
@@ -17,6 +17,8 @@ import sys
 
 from .arg_parser import ArgParser
 from .inputs import Input
+from .outputs import Output
+from .np_util import to_nd_list
 from .service_loader import load_model_service
 
 
@@ -58,6 +60,54 @@ def create_request(input_files):
         request.properties["content-type"] = "tensor/ndlist"
 
     return request
+
+
+def create_text_request(text: str, key: str = None) -> Input:
+    request = Input()
+    request.properties["device_id"] = "-1"
+    request.properties["content-type"] = "text/plain"
+    request.content.add(key=key, value=text.encode("utf-8"))
+    return request
+
+
+def create_numpy_request(list, key: str = None) -> Input:
+    request = Input()
+    request.properties["device_id"] = "-1"
+    request.properties["content-type"] = "tensor/ndlist"
+    request.content.add(key=key, value=to_nd_list(list))
+    return request
+
+
+def create_npz_request(list, key: str = None) -> Input:
+    import io
+    import numpy as np
+    request = Input()
+    request.properties["device_id"] = "-1"
+    request.properties["content-type"] = "tensor/npz"
+    memory_file = io.BytesIO()
+    np.savez(memory_file, *list)
+    memory_file.seek(0)
+    request.content.add(key=key, value=memory_file.read(-1))
+    return request
+
+
+def _extract_output(outputs: Output) -> Input:
+    inputs = Input()
+    inputs.properties = outputs.properties
+    inputs.content = outputs.content
+    return inputs
+
+
+def extract_output_as_bytes(outputs: Output, key=None):
+    return _extract_output(outputs).get_as_bytes(key)
+
+
+def extract_output_as_numpy(outputs: Output, key=None):
+    return _extract_output(outputs).get_as_numpy(key)
+
+
+def extract_output_as_string(outputs: Output, key=None):
+    return _extract_output(outputs).get_as_string(key)
 
 
 def run():


### PR DESCRIPTION
## Description ##

Add test methods for handle functions and support more python use cases for output extractions. Support incoming inputs decoding. Sample request from client can send as:

```
def create_npz_request(list, key: str = None) -> Input:
    request = Input()
    request.properties["device_id"] = "-1"
    request.properties["content-type"] = "tensor/npz"
    memory_file = io.BytesIO()
    np.savez(memory_file, *list)
    memory_file.seek(0)
    request.content.add(key=key, value=memory_file.read(-1))
    return request
```

Customer can also construct the data on their own to build the client