### PR TITLE
Disable python alternative engine by default

### DIFF
--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -132,6 +132,11 @@ public final class ConfigManager {
                     "log4j2.contextSelector",
                     "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
         }
+
+        // Disable alternative engine for Python in djl-serving
+        if (System.getProperty("ai.djl.python.disable_alternative") == null) {
+            System.setProperty("ai.djl.python.disable_alternative", "true");
+        }
     }
 
     /**


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
