### PR TITLE
ModelInfo from Criteria

### DIFF
--- a/wlm/build.gradle
+++ b/wlm/build.gradle
@@ -11,6 +11,9 @@ dependencies {
     testImplementation("org.testng:testng:${testng_version}") {
         exclude group: "junit", module: "junit"
     }
+
+    testRuntimeOnly "ai.djl:model-zoo"
+    testRuntimeOnly "ai.djl.mxnet:mxnet-model-zoo"
 }
 
 java {

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -12,17 +12,55 @@
  */
 package ai.djl.serving.wlm;
 
+import ai.djl.Device;
+import ai.djl.ModelException;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import ai.djl.util.Utils;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 
 public class ModelInfoTest {
 
     @Test
     public void testQueueSizeIsSet() {
-        ModelInfo modelInfo = new ModelInfo("", null, null, "MXNet", 4711, 1, 300, 1);
-        Assert.assertEquals(4711, modelInfo.getQueueSize());
-        Assert.assertEquals(1, modelInfo.getMaxIdleTime());
-        Assert.assertEquals(300, modelInfo.getMaxBatchDelay());
-        Assert.assertEquals(1, modelInfo.getBatchSize());
+        try (ModelInfo modelInfo = new ModelInfo("", null, null, "MXNet", 4711, 1, 300, 1)) {
+            Assert.assertEquals(4711, modelInfo.getQueueSize());
+            Assert.assertEquals(1, modelInfo.getMaxIdleTime());
+            Assert.assertEquals(300, modelInfo.getMaxBatchDelay());
+            Assert.assertEquals(1, modelInfo.getBatchSize());
+        }
+    }
+
+    @Test
+    public void testCriteriaModelInfo() throws ModelException, IOException, TranslateException {
+        String modelUrl = "djl://ai.djl.zoo/mlp/0.0.3/mlp";
+        Criteria<Input, Output> criteria =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optModelUrls(modelUrl)
+                        .build();
+        try (ModelInfo modelInfo = new ModelInfo(criteria)) {
+            modelInfo.load(Device.cpu());
+            try (ZooModel<Input, Output> model = modelInfo.getModel(Device.cpu())) {
+                try (Predictor<Input, Output> predictor = model.newPredictor()) {
+                    Input input = new Input();
+                    URL url = new URL("https://resources.djl.ai/images/0.png");
+                    try (InputStream is = url.openStream()) {
+                        input.add(Utils.toByteArray(is));
+                    }
+                    predictor.predict(input);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a new constructor for ModelInfo based on a Criteria. This can be used when
using the WLM as a standalone tool to create jobs to run.