### PR TITLE
Parameterize WLM

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -18,6 +18,8 @@ import ai.djl.engine.Engine;
 import ai.djl.metric.Dimension;
 import ai.djl.metric.Metric;
 import ai.djl.metric.Unit;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
 import ai.djl.repository.Artifact;
 import ai.djl.repository.FilenameUtils;
 import ai.djl.repository.MRL;
@@ -382,12 +384,14 @@ public class ModelServer implements AutoCloseable {
                 engineName = inferEngineFromUrl(modelUrl);
             }
 
-            ModelInfo modelInfo =
-                    new ModelInfo(
+            ModelInfo<Input, Output> modelInfo =
+                    new ModelInfo<>(
                             modelName,
                             modelUrl,
                             version,
                             engineName,
+                            Input.class,
+                            Output.class,
                             configManager.getJobQueueSize(),
                             configManager.getMaxIdleTime(),
                             configManager.getMaxBatchDelay(),

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -180,12 +180,14 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             Device device = Device.fromName(deviceName, engine);
 
             logger.info("Loading model {} from: {}", workflowName, modelUrl);
-            ModelInfo modelInfo =
-                    new ModelInfo(
+            ModelInfo<Input, Output> modelInfo =
+                    new ModelInfo<>(
                             workflowName,
                             modelUrl,
                             version,
                             engineName,
+                            Input.class,
+                            Output.class,
                             config.getJobQueueSize(),
                             config.getMaxIdleTime(),
                             config.getMaxBatchDelay(),

--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -51,7 +51,7 @@ public class Workflow implements AutoCloseable {
 
     String name;
     String version;
-    Map<String, ModelInfo> models;
+    Map<String, ModelInfo<Input, Output>> models;
     Map<String, WorkflowExpression> expressions;
     Map<String, WorkflowFunction> funcs;
 
@@ -60,7 +60,7 @@ public class Workflow implements AutoCloseable {
      *
      * @param model the model for the workflow
      */
-    public Workflow(ModelInfo model) {
+    public Workflow(ModelInfo<Input, Output> model) {
         String modelName = "model";
         this.name = model.getModelId();
         this.version = model.getVersion();
@@ -84,7 +84,7 @@ public class Workflow implements AutoCloseable {
     public Workflow(
             String name,
             String version,
-            Map<String, ModelInfo> models,
+            Map<String, ModelInfo<Input, Output>> models,
             Map<String, WorkflowExpression> expressions,
             Map<String, WorkflowFunction> funcs) {
         this.name = name;
@@ -99,7 +99,7 @@ public class Workflow implements AutoCloseable {
      *
      * @return the models used in the workflow
      */
-    public Collection<ModelInfo> getModels() {
+    public Collection<ModelInfo<Input, Output>> getModels() {
         return models.values();
     }
 
@@ -170,7 +170,7 @@ public class Workflow implements AutoCloseable {
     /** {@inheritDoc} * */
     @Override
     public void close() {
-        for (ModelInfo m : getModels()) {
+        for (ModelInfo<Input, Output> m : getModels()) {
             m.close();
         }
     }
@@ -267,7 +267,7 @@ public class Workflow implements AutoCloseable {
          * @return the function to execute the found executable
          */
         public WorkflowFunction getExecutable(String name) {
-            ModelInfo model = models.get(name);
+            ModelInfo<Input, Output> model = models.get(name);
             if (model != null) {
                 return new ModelWorkflowFunction(model);
             }

--- a/serving/src/main/java/ai/djl/serving/workflow/function/ModelWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/ModelWorkflowFunction.java
@@ -13,6 +13,7 @@
 package ai.djl.serving.workflow.function;
 
 import ai.djl.modality.Input;
+import ai.djl.modality.Output;
 import ai.djl.serving.wlm.Job;
 import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.workflow.Workflow;
@@ -23,14 +24,14 @@ import java.util.concurrent.CompletableFuture;
 /** An internal {@link WorkflowFunction} that is used to execute models in the workflow. */
 public class ModelWorkflowFunction extends WorkflowFunction {
 
-    ModelInfo model;
+    ModelInfo<Input, Output> model;
 
     /**
      * Constructs a {@link ModelWorkflowFunction} with a given model.
      *
      * @param model the model to run
      */
-    public ModelWorkflowFunction(ModelInfo model) {
+    public ModelWorkflowFunction(ModelInfo<Input, Output> model) {
         this.model = model;
     }
 
@@ -51,7 +52,7 @@ public class ModelWorkflowFunction extends WorkflowFunction {
                 .thenComposeAsync(
                         processedArgs ->
                                 executor.getWlm()
-                                        .runJob(new Job(model, processedArgs.get(0)))
+                                        .runJob(new Job<>(model, processedArgs.get(0)))
                                         .thenApply(o -> o));
     }
 }

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -84,7 +84,7 @@ public class WorkflowTest {
     public void testGlobalPerf() throws IOException, BadWorkflowException {
         Path workflowFile = Paths.get("src/test/resources/workflows/globalPerf.json");
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
-        ModelInfo m = workflow.getModels().stream().findFirst().get();
+        ModelInfo<Input, Output> m = workflow.getModels().stream().findFirst().get();
 
         Assert.assertEquals(m.getQueueSize(), 101);
         Assert.assertEquals(m.getMaxIdleTime(), 61);
@@ -96,7 +96,7 @@ public class WorkflowTest {
     public void testLocalPerf() throws IOException, BadWorkflowException {
         Path workflowFile = Paths.get("src/test/resources/workflows/localPerf.json");
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
-        ModelInfo m = workflow.getModels().stream().findFirst().get();
+        ModelInfo<Input, Output> m = workflow.getModels().stream().findFirst().get();
 
         Assert.assertEquals(m.getQueueSize(), 102);
         Assert.assertEquals(m.getMaxIdleTime(), 62);
@@ -108,7 +108,7 @@ public class WorkflowTest {
             throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
-            for (ModelInfo model : workflow.getModels()) {
+            for (ModelInfo<Input, Output> model : workflow.getModels()) {
                 wlm.getWorkerPoolForModel(model).scaleWorkers(Device.cpu(), 1, 1);
             }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/Job.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Job.java
@@ -12,13 +12,11 @@
  */
 package ai.djl.serving.wlm;
 
-import ai.djl.modality.Input;
-
 /** A class represents an inference job. */
-public class Job {
+public class Job<I, O> {
 
-    private ModelInfo modelInfo;
-    private Input input;
+    private ModelInfo<I, O> modelInfo;
+    private I input;
     private long begin;
 
     /**
@@ -27,7 +25,7 @@ public class Job {
      * @param modelInfo the model to run the job
      * @param input the input data
      */
-    public Job(ModelInfo modelInfo, Input input) {
+    public Job(ModelInfo<I, O> modelInfo, I input) {
         this.modelInfo = modelInfo;
         this.input = input;
 
@@ -39,7 +37,7 @@ public class Job {
      *
      * @return the model that associated with this job
      */
-    public ModelInfo getModel() {
+    public ModelInfo<I, O> getModel() {
         return modelInfo;
     }
 
@@ -48,7 +46,7 @@ public class Job {
      *
      * @return the input data
      */
-    public Input getInput() {
+    public I getInput() {
         return input;
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/PermanentBatchAggregator.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PermanentBatchAggregator.java
@@ -27,7 +27,7 @@ import java.util.concurrent.LinkedBlockingDeque;
  *
  * @author erik.bamberg@web.de
  */
-public class PermanentBatchAggregator extends BatchAggregator {
+public class PermanentBatchAggregator<I, O> extends BatchAggregator<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(TemporaryBatchAggregator.class);
 
@@ -37,15 +37,16 @@ public class PermanentBatchAggregator extends BatchAggregator {
      * @param model the model to use.
      * @param jobQueue the job queue for polling data from.
      */
-    public PermanentBatchAggregator(ModelInfo model, LinkedBlockingDeque<WorkerJob> jobQueue) {
+    public PermanentBatchAggregator(
+            ModelInfo<I, O> model, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
         super(model, jobQueue);
     }
 
     /** {@inheritDoc} */
     @Override
-    protected List<WorkerJob> pollBatch() throws InterruptedException {
-        List<WorkerJob> list = new ArrayList<>(batchSize);
-        WorkerJob wj = jobQueue.take();
+    protected List<WorkerJob<I, O>> pollBatch() throws InterruptedException {
+        List<WorkerJob<I, O>> list = new ArrayList<>(batchSize);
+        WorkerJob<I, O> wj = jobQueue.take();
         list.add(wj);
         drainTo(list, maxBatchDelay);
         logger.trace("sending jobs, size: {}", list.size());

--- a/wlm/src/main/java/ai/djl/serving/wlm/TemporaryBatchAggregator.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/TemporaryBatchAggregator.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author erik.bamberg@web.de
  */
-public class TemporaryBatchAggregator extends BatchAggregator {
+public class TemporaryBatchAggregator<I, O> extends BatchAggregator<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(TemporaryBatchAggregator.class);
 
@@ -40,7 +40,8 @@ public class TemporaryBatchAggregator extends BatchAggregator {
      * @param model the model to run for.
      * @param jobQueue reference to external job queue for polling.
      */
-    public TemporaryBatchAggregator(ModelInfo model, LinkedBlockingDeque<WorkerJob> jobQueue) {
+    public TemporaryBatchAggregator(
+            ModelInfo<I, O> model, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
         super(model, jobQueue);
         this.idleSince = System.currentTimeMillis();
         this.maxIdleTime = model.getMaxIdleTime();
@@ -48,9 +49,9 @@ public class TemporaryBatchAggregator extends BatchAggregator {
 
     /** {@inheritDoc} */
     @Override
-    protected List<WorkerJob> pollBatch() throws InterruptedException {
-        List<WorkerJob> list = new ArrayList<>(batchSize);
-        WorkerJob wj = jobQueue.poll(maxIdleTime, TimeUnit.SECONDS);
+    protected List<WorkerJob<I, O>> pollBatch() throws InterruptedException {
+        List<WorkerJob<I, O>> list = new ArrayList<>(batchSize);
+        WorkerJob<I, O> wj = jobQueue.poll(maxIdleTime, TimeUnit.SECONDS);
         if (wj != null && wj.getJob() != null) {
             list.add(wj);
             drainTo(list, maxBatchDelay);

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -50,7 +50,7 @@ public final class WlmConfigManager {
      * @return the calculated minimum number of workers for a new registered model
      */
     public int getDefaultMinWorkers(
-            ModelInfo modelInfo, Device device, int minWorkers, int maxWorkers) {
+            ModelInfo<?, ?> modelInfo, Device device, int minWorkers, int maxWorkers) {
         Model model = modelInfo.getModel(device);
         minWorkers = getWorkersProperty(model, device, "minWorkers", minWorkers);
         return Math.min(minWorkers, maxWorkers);
@@ -64,7 +64,7 @@ public final class WlmConfigManager {
      * @param target the target number of worker
      * @return the default number of workers for a new registered model
      */
-    public int getDefaultMaxWorkers(ModelInfo modelInfo, Device device, int target) {
+    public int getDefaultMaxWorkers(ModelInfo<?, ?> modelInfo, Device device, int target) {
         Model model = modelInfo.getModel(device);
         if (target == 0) {
             return 0; // explicitly shutdown

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WorkerJob.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WorkerJob.java
@@ -12,16 +12,15 @@
  */
 package ai.djl.serving.wlm.util;
 
-import ai.djl.modality.Output;
 import ai.djl.serving.wlm.Job;
 
 import java.util.concurrent.CompletableFuture;
 
 /** A {@link Job} containing metadata from the {@link ai.djl.serving.wlm.WorkLoadManager}. */
-public final class WorkerJob {
+public final class WorkerJob<I, O> {
 
-    private final Job job;
-    private final CompletableFuture<Output> future;
+    private final Job<I, O> job;
+    private final CompletableFuture<O> future;
 
     /**
      * Constructs a new {@link WorkerJob}.
@@ -29,7 +28,7 @@ public final class WorkerJob {
      * @param job the job to execute
      * @param future the future containing the job response
      */
-    public WorkerJob(Job job, CompletableFuture<Output> future) {
+    public WorkerJob(Job<I, O> job, CompletableFuture<O> future) {
         this.job = job;
         this.future = future;
     }
@@ -39,7 +38,7 @@ public final class WorkerJob {
      *
      * @return the {@link Job}
      */
-    public Job getJob() {
+    public Job<I, O> getJob() {
         return job;
     }
 
@@ -48,7 +47,7 @@ public final class WorkerJob {
      *
      * @return the future for the job
      */
-    public CompletableFuture<Output> getFuture() {
+    public CompletableFuture<O> getFuture() {
         return future;
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -33,7 +33,9 @@ public class ModelInfoTest {
 
     @Test
     public void testQueueSizeIsSet() {
-        try (ModelInfo modelInfo = new ModelInfo("", null, null, "MXNet", 4711, 1, 300, 1)) {
+        try (ModelInfo<?, ?> modelInfo =
+                new ModelInfo<>(
+                        "", null, null, "MXNet", Input.class, Output.class, 4711, 1, 300, 1)) {
             Assert.assertEquals(4711, modelInfo.getQueueSize());
             Assert.assertEquals(1, modelInfo.getMaxIdleTime());
             Assert.assertEquals(300, modelInfo.getMaxBatchDelay());
@@ -49,7 +51,7 @@ public class ModelInfoTest {
                         .setTypes(Input.class, Output.class)
                         .optModelUrls(modelUrl)
                         .build();
-        try (ModelInfo modelInfo = new ModelInfo(criteria)) {
+        try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>(criteria)) {
             modelInfo.load(Device.cpu());
             try (ZooModel<Input, Output> model = modelInfo.getModel(Device.cpu())) {
                 try (Predictor<Input, Output> predictor = model.newPredictor()) {


### PR DESCRIPTION
Right now, the WorkLoadManager operates only in terms of Input and Output.
However, if it is intended to be more general use, then it should be able to use
model and predictors for arbitrary input and output types. This parameterizes
the WLM to make it possible. Within serving, all parameterized types still use
Input and Output and shouldn't behave any differently.