### PR TITLE
Add model registration to WLM

### DIFF
--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -102,6 +102,7 @@ public final class ModelManager {
                                 DependencyManager dm = DependencyManager.getInstance();
                                 dm.installEngine(engine);
                             }
+                            wlm.registerModel(model);
                         } catch (IOException e) {
                             throw new CompletionException(e);
                         }

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -109,7 +109,7 @@ public class WorkflowTest {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
             for (ModelInfo<Input, Output> model : workflow.getModels()) {
-                wlm.getWorkerPoolForModel(model).scaleWorkers(Device.cpu(), 1, 1);
+                wlm.registerModel(model).scaleWorkers(Device.cpu(), 1, 1);
             }
 
             Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -79,6 +79,23 @@ public class WorkLoadManager implements AutoCloseable {
     }
 
     /**
+     * Registers a model and returns the {@link WorkerPool} for it.
+     *
+     * <p>This operation is idempotent and will return the existing workerpool if the model was
+     * already registered.
+     *
+     * @param <I> the model input class
+     * @param <O> the model output class
+     * @param modelInfo the model to create the worker pool for
+     * @return the {@link WorkerPool}
+     */
+    @SuppressWarnings("unchecked")
+    public <I, O> WorkerPool<I, O> registerModel(ModelInfo<I, O> modelInfo) {
+        return (WorkerPool<I, O>)
+                workerPools.computeIfAbsent(modelInfo, k -> new WorkerPool<>(modelInfo));
+    }
+
+    /**
      * Removes a model from management.
      *
      * @param model the model to remove
@@ -184,8 +201,7 @@ public class WorkLoadManager implements AutoCloseable {
      */
     @SuppressWarnings("unchecked")
     public <I, O> WorkerPool<I, O> getWorkerPoolForModel(ModelInfo<I, O> modelInfo) {
-        return (WorkerPool<I, O>)
-                workerPools.computeIfAbsent(modelInfo, k -> new WorkerPool<>(modelInfo));
+        return (WorkerPool<I, O>) workerPools.get(modelInfo);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This modifies the WLM to require explicit registration. This makes a clearer
picture with the explicit unregister as well as the management APIcalls to
register both models and workflows.