### PR TITLE
Create test of standalone WLM

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -34,6 +34,7 @@ import ai.djl.serving.util.Connector;
 import ai.djl.serving.util.NeuronUtils;
 import ai.djl.serving.util.ServerGroups;
 import ai.djl.serving.wlm.ModelInfo;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.workflow.BadWorkflowException;
 import ai.djl.serving.workflow.Workflow;
 import ai.djl.serving.workflow.WorkflowDefinition;
@@ -386,6 +387,7 @@ public class ModelServer implements AutoCloseable {
                 engineName = inferEngineFromUrl(modelUrl);
             }
 
+            WlmConfigManager wlmc = WlmConfigManager.getInstance();
             ModelInfo<Input, Output> modelInfo =
                     new ModelInfo<>(
                             modelName,
@@ -394,10 +396,10 @@ public class ModelServer implements AutoCloseable {
                             engineName,
                             Input.class,
                             Output.class,
-                            configManager.getJobQueueSize(),
-                            configManager.getMaxIdleTime(),
-                            configManager.getMaxBatchDelay(),
-                            configManager.getBatchSize());
+                            wlmc.getJobQueueSize(),
+                            wlmc.getMaxIdleTime(),
+                            wlmc.getMaxBatchDelay(),
+                            wlmc.getBatchSize());
             Workflow workflow = new Workflow(modelInfo);
             Device[] finalDevices = devices;
             CompletableFuture<Void> f =

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -24,6 +24,7 @@ import ai.djl.serving.models.ModelManager;
 import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.util.NettyUtils;
 import ai.djl.serving.wlm.ModelInfo;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.wlm.util.WlmException;
 import ai.djl.serving.workflow.Workflow;
 import ai.djl.translate.TranslateException;
@@ -180,6 +181,8 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             Device device = Device.fromName(deviceName, engine);
 
             logger.info("Loading model {} from: {}", workflowName, modelUrl);
+
+            WlmConfigManager wlmc = WlmConfigManager.getInstance();
             ModelInfo<Input, Output> modelInfo =
                     new ModelInfo<>(
                             workflowName,
@@ -188,10 +191,10 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                             engineName,
                             Input.class,
                             Output.class,
-                            config.getJobQueueSize(),
-                            config.getMaxIdleTime(),
-                            config.getMaxBatchDelay(),
-                            config.getBatchSize());
+                            wlmc.getJobQueueSize(),
+                            wlmc.getMaxIdleTime(),
+                            wlmc.getMaxBatchDelay(),
+                            wlmc.getBatchSize());
             Workflow wf = new Workflow(modelInfo);
 
             modelManager

--- a/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
@@ -20,10 +20,10 @@ import ai.djl.modality.Output;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.serving.models.Endpoint;
 import ai.djl.serving.models.ModelManager;
-import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.util.NettyUtils;
 import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.wlm.WorkLoadManager.WorkerPool;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.workflow.BadWorkflowException;
 import ai.djl.serving.workflow.Workflow;
 import ai.djl.serving.workflow.WorkflowDefinition;
@@ -241,7 +241,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                         engineName,
                         Input.class,
                         Output.class,
-                        ConfigManager.getInstance().getJobQueueSize(),
+                        WlmConfigManager.getInstance().getJobQueueSize(),
                         maxIdleTime,
                         maxBatchDelay,
                         batchSize);

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -13,6 +13,7 @@
 package ai.djl.serving.util;
 
 import ai.djl.serving.Arguments;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 /** A class that hold configuration information. */
 public final class ConfigManager {
@@ -139,6 +141,12 @@ public final class ConfigManager {
         if (System.getProperty("ai.djl.python.disable_alternative") == null) {
             System.setProperty("ai.djl.python.disable_alternative", "true");
         }
+
+        WlmConfigManager wlmc = new WlmConfigManager();
+        instance.withIntProperty(JOB_QUEUE_SIZE, wlmc::setJobQueueSize);
+        instance.withIntProperty(MAX_IDLE_TIME, wlmc::setMaxIdleTime);
+        instance.withIntProperty(BATCH_SIZE, wlmc::setBatchSize);
+        instance.withIntProperty(MAX_BATCH_DELAY, wlmc::setMaxBatchDelay);
     }
 
     /**
@@ -173,42 +181,6 @@ public final class ConfigManager {
      */
     public int getNettyThreads() {
         return getIntProperty(NUMBER_OF_NETTY_THREADS, 0);
-    }
-
-    /**
-     * Returns the default job queue size.
-     *
-     * @return the default job queue size
-     */
-    public int getJobQueueSize() {
-        return getIntProperty(JOB_QUEUE_SIZE, 100);
-    }
-
-    /**
-     * Returns the default max idle time for workers.
-     *
-     * @return the default max idle time
-     */
-    public int getMaxIdleTime() {
-        return getIntProperty(MAX_IDLE_TIME, 60);
-    }
-
-    /**
-     * Returns the default batchSize for workers.
-     *
-     * @return the default max idle time
-     */
-    public int getBatchSize() {
-        return getIntProperty(BATCH_SIZE, 1);
-    }
-
-    /**
-     * Returns the default maxBatchDelay for the working queue.
-     *
-     * @return the default max batch delay
-     */
-    public int getMaxBatchDelay() {
-        return getIntProperty(MAX_BATCH_DELAY, 300);
     }
 
     /**
@@ -474,6 +446,12 @@ public final class ConfigManager {
             return def;
         }
         return Integer.parseInt(value);
+    }
+
+    private void withIntProperty(String key, Consumer<Integer> f) {
+        if (prop.containsKey(key)) {
+            f.accept(Integer.parseInt(prop.getProperty(key)));
+        }
     }
 
     private Path getPathProperty(String key) {

--- a/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
@@ -14,8 +14,8 @@ package ai.djl.serving.workflow;
 
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
-import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.wlm.ModelInfo;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 import ai.djl.serving.workflow.function.WorkflowFunction;
 import ai.djl.util.JsonUtils;
@@ -127,22 +127,16 @@ public class WorkflowDefinition {
      */
     public Workflow toWorkflow() throws BadWorkflowException {
         if (models != null) {
-            ConfigManager configManager = ConfigManager.getInstance();
+            WlmConfigManager wlmc = WlmConfigManager.getInstance();
             for (Entry<String, ModelInfo<Input, Output>> emd : models.entrySet()) {
                 ModelInfo<Input, Output> md = emd.getValue();
                 md.setModelId(emd.getKey());
-                md.setQueueSize(
-                        firstValid(md.getQueueSize(), queueSize, configManager.getJobQueueSize()));
+                md.setQueueSize(firstValid(md.getQueueSize(), queueSize, wlmc.getJobQueueSize()));
                 md.setMaxIdleTime(
-                        firstValid(
-                                md.getMaxIdleTime(), maxIdleTime, configManager.getMaxIdleTime()));
+                        firstValid(md.getMaxIdleTime(), maxIdleTime, wlmc.getMaxIdleTime()));
                 md.setMaxBatchDelay(
-                        firstValid(
-                                md.getMaxBatchDelay(),
-                                maxBatchDelay,
-                                configManager.getMaxBatchDelay()));
-                md.setBatchSize(
-                        firstValid(md.getBatchSize(), batchSize, configManager.getBatchSize()));
+                        firstValid(md.getMaxBatchDelay(), maxBatchDelay, wlmc.getMaxBatchDelay()));
+                md.setBatchSize(firstValid(md.getBatchSize(), batchSize, wlmc.getBatchSize()));
                 if (name == null) {
                     name = emd.getKey();
                 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -20,6 +20,7 @@ import ai.djl.engine.Engine;
 import ai.djl.repository.FilenameUtils;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ZooModel;
+import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.translate.ServingTranslator;
 import ai.djl.translate.Translator;
 import ai.djl.translate.TranslatorFactory;
@@ -71,6 +72,7 @@ public final class ModelInfo<I, O> implements AutoCloseable {
      * @param modelUrl the model Url
      */
     public ModelInfo(String modelUrl, Class<I> inputClass, Class<O> outputClass) {
+        this.id = modelUrl;
         this.modelUrl = modelUrl;
         this.inputClass = inputClass;
         this.outputClass = outputClass;
@@ -79,12 +81,20 @@ public final class ModelInfo<I, O> implements AutoCloseable {
     /**
      * Constructs a {@link ModelInfo} based on a {@link Criteria}.
      *
+     * @param id the id for the created {@link ModelInfo}
      * @param criteria the model criteria
      */
-    public ModelInfo(Criteria<I, O> criteria) {
+    public ModelInfo(String id, Criteria<I, O> criteria) {
+        this.id = id;
         this.criteria = criteria;
         inputClass = criteria.getInputClass();
         outputClass = criteria.getOutputClass();
+
+        WlmConfigManager config = WlmConfigManager.getInstance();
+        queueSize = config.getJobQueueSize();
+        maxIdleTime = config.getMaxIdleTime();
+        batchSize = config.getBatchSize();
+        maxBatchDelay = config.getMaxBatchDelay();
     }
 
     /**

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -20,6 +20,11 @@ import ai.djl.serving.wlm.ModelInfo;
 /** This manages some configurations used by the {@link ai.djl.serving.wlm.WorkLoadManager}. */
 public final class WlmConfigManager {
 
+    private int jobQueueSize = 100;
+    private int maxIdleTime = 60;
+    private int batchSize = 1;
+    private int maxBatchDelay = 300;
+
     private static final WlmConfigManager INSTANCE = new WlmConfigManager();
 
     /**
@@ -38,6 +43,78 @@ public final class WlmConfigManager {
      */
     public boolean isDebug() {
         return Boolean.getBoolean("ai.djl.serving.debug");
+    }
+
+    /**
+     * Returns the default job queue size.
+     *
+     * @return the default job queue size
+     */
+    public int getJobQueueSize() {
+        return jobQueueSize;
+    }
+
+    /**
+     * Sets the default job queue size.
+     *
+     * @param jobQueueSize the new default job queue size
+     */
+    public void setJobQueueSize(int jobQueueSize) {
+        this.jobQueueSize = jobQueueSize;
+    }
+
+    /**
+     * Returns the default max idle time for workers.
+     *
+     * @return the default max idle time
+     */
+    public int getMaxIdleTime() {
+        return maxIdleTime;
+    }
+
+    /**
+     * Sets the default max idle time for workers.
+     *
+     * @param maxIdleTime the new default max idle time
+     */
+    public void setMaxIdleTime(int maxIdleTime) {
+        this.maxIdleTime = maxIdleTime;
+    }
+
+    /**
+     * Returns the default batchSize for workers.
+     *
+     * @return the default max idle time
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Sets the default batchSize for workers.
+     *
+     * @param batchSize the new default batchSize
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Returns the default maxBatchDelay for the working queue.
+     *
+     * @return the default max batch delay
+     */
+    public int getMaxBatchDelay() {
+        return maxBatchDelay;
+    }
+
+    /**
+     * Sets the default maxBatchDelay for the working queue.
+     *
+     * @param maxBatchDelay the new default maxBatchDelay
+     */
+    public void setMaxBatchDelay(int maxBatchDelay) {
+        this.maxBatchDelay = maxBatchDelay;
     }
 
     /**

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -51,7 +51,7 @@ public class ModelInfoTest {
                         .setTypes(Input.class, Output.class)
                         .optModelUrls(modelUrl)
                         .build();
-        try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>(criteria)) {
+        try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria)) {
             modelInfo.load(Device.cpu());
             try (ZooModel<Input, Output> model = modelInfo.getModel(Device.cpu())) {
                 try (Predictor<Input, Output> predictor = model.newPredictor()) {

--- a/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import static org.testng.Assert.assertEquals;
+
+import ai.djl.Device;
+import ai.djl.modality.Classifications;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.util.Utils;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class WorkLoadManagerTest {
+
+    @Test
+    public void testFromCriteria() throws IOException {
+        try (WorkLoadManager wlm = new WorkLoadManager()) {
+            String modelUrl = "djl://ai.djl.zoo/mlp/0.0.3/mlp";
+            Criteria<Input, Output> criteria =
+                    Criteria.builder()
+                            .setTypes(Input.class, Output.class)
+                            .optModelUrls(modelUrl)
+                            .build();
+            try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria)) {
+                wlm.registerModel(modelInfo).scaleWorkers(Device.cpu(), 1, 2);
+                Input input = new Input();
+                URL url = new URL("https://resources.djl.ai/images/0.png");
+                try (InputStream is = url.openStream()) {
+                    input.add(Utils.toByteArray(is));
+                }
+                Output output = wlm.runJob(new Job<>(modelInfo, input)).join();
+
+                Classifications classification = (Classifications) output.get(0);
+                assertEquals(classification.best().getClassName(), "0");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This also moves some of the default model settings from ConfigManager to
WlmConfigManager. These settings are used in the standalone WLM so they need to
be available from it.