### PR TITLE
[docker] numpy is required by djl python engine by default

### DIFF
--- a/serving/docker/scripts/install_python.sh
+++ b/serving/docker/scripts/install_python.sh
@@ -6,4 +6,5 @@ set -e
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip
 python3 -m pip --no-cache-dir install -U pip
+python3 -m pip --no-cache-dir install -U numpy
 ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
