### PR TITLE
Fix OnnxRuntime Benchmark on GPU

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     runtimeOnly "ai.djl.tensorflow:tensorflow-model-zoo"
     runtimeOnly "ai.djl.mxnet:mxnet-model-zoo"
     runtimeOnly "ai.djl.paddlepaddle:paddlepaddle-model-zoo"
-    runtimeOnly "ai.djl.onnxruntime:onnxruntime-engine"
     runtimeOnly "ai.djl.tflite:tflite-engine"
     runtimeOnly "ai.djl.dlr:dlr-engine"
     runtimeOnly "ai.djl.ml.xgboost:xgboost"
@@ -23,6 +22,23 @@ dependencies {
 
     testImplementation("org.testng:testng:${testng_version}") {
         exclude group: "junit", module: "junit"
+    }
+
+    ProcessBuilder pb = new ProcessBuilder("nvidia-smi", "-L")
+    def hasGPU = false;
+    try {
+        Process process = pb.start()
+        hasGPU = process.waitFor() == 0
+    } catch (IOException ignore) {
+    }
+
+    if (hasGPU) {
+        runtimeOnly("ai.djl.onnxruntime:onnxruntime-engine") {
+            exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
+        }
+        runtimeOnly "com.microsoft.onnxruntime:onnxruntime_gpu:${onnxruntime_version}"
+    } else {
+        runtimeOnly "ai.djl.onnxruntime:onnxruntime-engine"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 djl_version=0.19.0
+onnxruntime_version=1.11.0
 commons_cli_version=1.5.0
 netty_version=4.1.79.Final
 slf4j_version=1.7.36


### PR DESCRIPTION
This fixes the gradle detection of hardware to enable onnxruntime to run on GPU
that was lost in the move of djl-bench from DJL to DJL Serving.
