### PR TITLE
Upgrade to DJL  0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ brew services stop djl-serving
 For Ubuntu
 
 ```
-curl -O https://publish.djl.ai/djl-serving/djl-serving_0.17.0-1_all.deb
-sudo dpkg -i djl-serving_0.17.0-1_all.deb
+curl -O https://publish.djl.ai/djl-serving/djl-serving_0.18.0-1_all.deb
+sudo dpkg -i djl-serving_0.18.0-1_all.deb
 ```
 
 For Windows
 
 We are considering to create a `chocolatey` package for Windows. For the time being, you can 
-download djl-serving zip file from [here](https://publish.djl.ai/djl-serving/serving-0.17.0.zip).
+download djl-serving zip file from [here](https://publish.djl.ai/djl-serving/serving-0.18.0.zip).
 
 ```
-curl -O https://publish.djl.ai/djl-serving/serving-0.17.0.zip
-unzip serving-0.17.0.zip
+curl -O https://publish.djl.ai/djl-serving/serving-0.18.0.zip
+unzip serving-0.18.0.zip
 # start djl-serving
-serving-0.17.0\bin\serving.bat
+serving-0.18.0\bin\serving.bat
 ```
 
 ### Docker

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -48,25 +48,25 @@ sudo snap alias djlbench djl-bench
 - Or download .deb package from S3
 
 ```
-curl -O https://publish.djl.ai/djl-bench/0.17.0/djl-bench_0.17.0-1_all.deb
-sudo dpkg -i djl-bench_0.17.0-1_all.deb
+curl -O https://publish.djl.ai/djl-bench/0.18.0/djl-bench_0.18.0-1_all.deb
+sudo dpkg -i djl-bench_0.18.0-1_all.deb
 ```
 
 For centOS or Amazon Linux 2
 
-You can download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.17.0/benchmark-0.17.0.zip).
+You can download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.18.0/benchmark-0.18.0.zip).
 
 ```
-curl -O https://publish.djl.ai/djl-bench/0.17.0/benchmark-0.17.0.zip
-unzip benchmark-0.17.0.zip
-rm benchmark-0.17.0.zip
-sudo ln -s $PWD/benchmark-0.17.0/bin/benchmark /usr/bin/djl-bench
+curl -O https://publish.djl.ai/djl-bench/0.18.0/benchmark-0.18.0.zip
+unzip benchmark-0.18.0.zip
+rm benchmark-0.18.0.zip
+sudo ln -s $PWD/benchmark-0.18.0/bin/benchmark /usr/bin/djl-bench
 ```
 
 For Windows
 
 We are considering to create a `chocolatey` package for Windows. For the time being, you can
-download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.17.0/benchmark-0.17.0.zip).
+download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.18.0/benchmark-0.18.0.zip).
 
 Or you can run benchmark using gradle:
 

--- a/benchmark/snapcraft/snapcraft.yaml
+++ b/benchmark/snapcraft/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: djlbench
-version: '0.17.0'
+version: '0.18.0'
 title: DJL Benhmark
 license: Apache-2.0
 summary: A machine learning benchmarking toolkit

--- a/engines/python/README.md
+++ b/engines/python/README.md
@@ -29,13 +29,13 @@ The javadocs output is generated in the `build/doc/javadoc` folder.
 ## Installation
 You can pull the Python engine from the central Maven repository by including the following dependency:
 
-- ai.djl.python:python:0.17.0
+- ai.djl.python:python:0.18.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.python</groupId>
     <artifactId>python</artifactId>
-    <version>0.17.0</version>
+    <version>0.18.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/serving/docker/Dockerfile
+++ b/serving/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN scripts/install_python.sh && \
     djl-serving -i ai.djl.mxnet:mxnet-native-mkl:1.9.0:linux-x86_64 && \
     djl-serving -i ai.djl.pytorch:pytorch-native-cpu:1.11.0:linux-x86_64 && \
     djl-serving -i ai.djl.tensorflow:tensorflow-native-cpu:2.7.0:linux-x86_64 && \
-    djl-serving -i ai.djl.onnxruntime:onnxruntime-engine:0.17.0 && \
+    djl-serving -i ai.djl.onnxruntime:onnxruntime-engine:0.18.0 && \
     djl-serving -i com.microsoft.onnxruntime:onnxruntime:1.11.0 && \
     rm -rf scripts && pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/serving/docker/README.md
+++ b/serving/docker/README.md
@@ -32,7 +32,7 @@ mkdir models
 cd models
 curl -O https://resources.djl.ai/test-models/pytorch/bert_qa_jit.tar.gz
 
-docker run -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.17.0
+docker run -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.18.0
 ```
 
 ### GPU
@@ -52,5 +52,5 @@ mkdir models
 cd models
 
 curl -O https://resources.djl.ai/test-models/pytorch/bert_qa_inf1.tar.gz
-docker run --device /dev/neuron0 -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.17.0-inf1
+docker run --device /dev/neuron0 -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.18.0-inf1
 ```

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -11,7 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 ARG version=11.3.1-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:$version
-ARG djl_version=0.17.0
+ARG djl_version=0.18.0~SNAPSHOT
 ARG torch_version=1.11.0
 ARG deepspeed_version=0.6.5
 ARG transformers_version=4.19.2

--- a/serving/src/test/java/ai/djl/serving/plugins/DependencyManagerTest.java
+++ b/serving/src/test/java/ai/djl/serving/plugins/DependencyManagerTest.java
@@ -23,7 +23,7 @@ public class DependencyManagerTest {
     public void testInstallDependency() throws IOException {
         DependencyManager dm = DependencyManager.getInstance();
         dm.installEngine("OnnxRuntime");
-        dm.installDependency("ai.djl.pytorch:pytorch-jni:1.11.0-0.17.0");
+        dm.installDependency("ai.djl.pytorch:pytorch-jni:1.11.0-0.18.0");
 
         Assert.assertThrows(() -> dm.installDependency("ai.djl.pytorch:pytorch-jni"));
     }

--- a/wlm/README.md
+++ b/wlm/README.md
@@ -56,7 +56,7 @@ You can pull the server from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.serving</groupId>
     <artifactId>wlm</artifactId>
-    <version>0.17.0</version>
+    <version>0.18.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description ##
Update to DJL 0.18.0 - this should be the last change needed before the serving 0.18.0 release.

Currently the Dockerfiles are using the SNAPSHOT djl repo by default - I updated deepspeed to do the same. The github action we're using overrides this default value with the one from gradle.properties, so I think this is ok.

