### PR TITLE
Fix issue with cpu image tag for docker release image

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -36,6 +36,7 @@ jobs:
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(cat ../../gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          export BASE_RELEASE_VERSION="${DJL_VERSION}"
           export RELEASE_VERSION="${DJL_VERSION}-"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} ${{ matrix.arch }}
           docker compose push ${{ matrix.arch }}
@@ -90,6 +91,7 @@ jobs:
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(cat ../../gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          export BASE_RELEASE_VERSION="${DJL_VERSION}"
           export RELEASE_VERSION="${DJL_VERSION}-"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} aarch64
           docker compose push aarch64

--- a/serving/docker/docker-compose.yml
+++ b/serving/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       target: base
       dockerfile: Dockerfile
-    image: "deepjavalibrary/djl-serving:${RELEASE_VERSION:-cpu}${NIGHTLY}"
+    image: "deepjavalibrary/djl-serving:${BASE_RELEASE_VERSION:-cpu}${NIGHTLY}"
   cpu-full:
     build:
       context: .


### PR DESCRIPTION
## Description ##

When running the docker nightly publish action for 'release', there's currently a bug where the base image gets tagged as 'vX.X.X-' rather than 'vX.X.X'. This is causing failures in the 'Retag image for release' step. 

I think we want the base image for a given version to not have the trailing hyphen ('-'), so I've updated the image name as such.

This change should fix that issue

## Example of Failure Case ##
I tried running the Build and push docker nightly action for release to publish the 0.18.0* images to dockerhub.

For release, we set RELEASE_VERSION like `export RELEASE_VERSION="${DJL_VERSION}-"`. In this case it would be `0.18.0-`. 

When we build the cpu image for release, the resulting tag would be `0.18.0-` instead of `0.18.0` based on the logic for naming the image in the compose file `deepjavalibrary/djl-serving:${RELEASE_VERSION:-cpu}${NIGHTLY}`. Here's the output from the workflow showing the incorrect tag https://github.com/deepjavalibrary/djl-serving/runs/7311968989?check_suite_focus=true#step:5:625. `#13 naming to docker.io/***/djl-serving:0.18.0- done`

The step for retagging the image then fails with the following error https://github.com/deepjavalibrary/djl-serving/runs/7311968989?check_suite_focus=true#step:6:7. `Error response from daemon: No such image: ***/djl-serving:0.18.0`

We could update the retagging step to expect the trailing hyphen. That would fix the error. But I think we want the tag to not have the trailing hyphen, hence these changes.
