### PR TITLE
bump to latest djl snapshot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 # FIXME: Workaround gradle publish issue: https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
-djl_version=0.18.0
+djl_version=0.19.0
 commons_cli_version=1.5.0
 netty_version=4.1.79.Final
 slf4j_version=1.7.36

--- a/serving/docker/Dockerfile
+++ b/serving/docker/Dockerfile
@@ -10,7 +10,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 FROM ubuntu:20.04 AS base
-ARG djl_version=0.18.0~SNAPSHOT
+ARG djl_version=0.19.0~SNAPSHOT
 
 COPY scripts scripts/
 RUN mkdir -p /opt/djl/conf

--- a/serving/docker/aarch64.Dockerfile
+++ b/serving/docker/aarch64.Dockerfile
@@ -10,7 +10,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 FROM arm64v8/ubuntu:20.04
-ARG djl_version=0.18.0~SNAPSHOT
+ARG djl_version=0.19.0~SNAPSHOT
 
 EXPOSE 8080
 

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -11,7 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 ARG version=11.3.1-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:$version
-ARG djl_version=0.18.0~SNAPSHOT
+ARG djl_version=0.19.0~SNAPSHOT
 ARG torch_version=1.11.0
 ARG deepspeed_version=0.6.5
 ARG transformers_version=4.19.2

--- a/serving/docker/pytorch-cu113.Dockerfile
+++ b/serving/docker/pytorch-cu113.Dockerfile
@@ -11,7 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 ARG version=11.3.1-cudnn8-runtime-ubuntu20.04
 FROM nvidia/cuda:$version
-ARG djl_version=0.18.0~SNAPSHOT
+ARG djl_version=0.19.0~SNAPSHOT
 ARG torch_version=1.11.0
 
 RUN mkdir -p /opt/djl/conf

--- a/serving/docker/pytorch-inf1.Dockerfile
+++ b/serving/docker/pytorch-inf1.Dockerfile
@@ -10,7 +10,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 FROM ubuntu:20.04
-ARG djl_version=0.18.0~SNAPSHOT
+ARG djl_version=0.19.0~SNAPSHOT
 ARG torch_version=1.11.0
 EXPOSE 8080
 


### PR DESCRIPTION
## Description ##

bump djl version so nightly image builds use latest snapshot. 

It's expected that some of the checks fail due to not having the 0.19.0-SNAPSHOT serving artifacts in maven. We need to run the "serving publish" action from djl after this has been merged, and then run the actions in this repo to verify. 

Alternatively I could push this change to a different branch, modify the workflow in djl on a separate branch to checkout the corresponding serving branch and run the action that way to validate before merging this to master.
