### PR TITLE
update deepspeed version

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -13,7 +13,7 @@ ARG version=11.3.1-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:$version
 ARG djl_version=0.19.0~SNAPSHOT
 ARG torch_version=1.11.0
-ARG deepspeed_version=0.6.5
+ARG deepspeed_version=0.6.7
 ARG transformers_version=4.19.2
 
 EXPOSE 8080


### PR DESCRIPTION
## Description ##

Upgrade DeepSpeed version to its latest.

This solves GPT-J-6B model inference issues
