### PR TITLE
[serving] Change scale worker per device

### DIFF
--- a/benchmark/src/main/java/ai/djl/benchmark/WlmBenchmark.java
+++ b/benchmark/src/main/java/ai/djl/benchmark/WlmBenchmark.java
@@ -19,7 +19,7 @@ import ai.djl.metric.Unit;
 import ai.djl.serving.wlm.Job;
 import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.wlm.WorkLoadManager;
-import ai.djl.serving.wlm.WorkLoadManager.WorkerPool;
+import ai.djl.serving.wlm.WorkerPool;
 import ai.djl.training.listener.MemoryTrainingListener;
 
 import org.slf4j.Logger;
@@ -37,7 +37,6 @@ public class WlmBenchmark extends AbstractBenchmark {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public float[] predict(Arguments arguments, Metrics metrics, int iteration) {
-
         MemoryTrainingListener.collectMemoryInfo(metrics); // Measure memory before loading model
 
         Engine engine = Engine.getEngine(arguments.getEngine());

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.serving;
 
-import ai.djl.Device;
 import ai.djl.engine.Engine;
 import ai.djl.metric.Dimension;
 import ai.djl.metric.Metric;
@@ -356,7 +355,7 @@ public class ModelServer implements AutoCloseable {
             String modelUrl = matcher.group(3);
             String version = null;
             String engineName = null;
-            Device[] devices = {null};
+            String[] devices = {null};
             String modelName;
             if (endpoint != null) {
                 String[] tokens = endpoint.split(":", -1);
@@ -398,14 +397,14 @@ public class ModelServer implements AutoCloseable {
                             wlmc.getMaxBatchDelay(),
                             wlmc.getBatchSize());
             Workflow workflow = new Workflow(modelInfo);
-            Device[] finalDevices = devices;
+            String[] finalDevices = devices;
             CompletableFuture<Void> f =
                     modelManager
                             .registerWorkflow(workflow)
                             .thenAccept(
                                     v -> {
-                                        for (Device device : finalDevices) {
-                                            modelManager.scaleWorkers(workflow, device, 1, -1);
+                                        for (String deviceName : finalDevices) {
+                                            modelManager.initWorkers(workflow, deviceName, 1, -1);
                                         }
                                     })
                             .exceptionally(
@@ -451,7 +450,7 @@ public class ModelServer implements AutoCloseable {
             }
             String endpoint = matcher.group(2);
             String workflowUrlString = matcher.group(3);
-            Device[] devices = {null};
+            String[] devices = {null};
             String workflowName;
             if (endpoint != null) {
                 String[] tokens = endpoint.split(":", -1);
@@ -468,14 +467,14 @@ public class ModelServer implements AutoCloseable {
                     WorkflowDefinition.parse(workflowUrl.toURI(), workflowUrl.openStream())
                             .toWorkflow();
 
-            Device[] finalDevices = devices;
+            String[] finalDevices = devices;
             CompletableFuture<Void> f =
                     modelManager
                             .registerWorkflow(workflow)
                             .thenAccept(
                                     v -> {
-                                        for (Device device : finalDevices) {
-                                            modelManager.scaleWorkers(workflow, device, 1, -1);
+                                        for (String deviceName : finalDevices) {
+                                            modelManager.initWorkers(workflow, deviceName, 1, -1);
                                         }
                                     })
                             .exceptionally(
@@ -595,23 +594,21 @@ public class ModelServer implements AutoCloseable {
         return null;
     }
 
-    private Device[] parseDevices(String devices, Engine engine) {
+    private String[] parseDevices(String devices, Engine engine) {
         if ("*".equals(devices)) {
             int gpuCount = engine.getGpuCount();
             if (gpuCount > 0) {
-                return IntStream.range(0, gpuCount).mapToObj(Device::gpu).toArray(Device[]::new);
+                return IntStream.range(0, gpuCount)
+                        .mapToObj(String::valueOf)
+                        .toArray(String[]::new);
             } else if (NeuronUtils.hasNeuron()) {
                 int neurons = NeuronUtils.getNeuronCores();
-                return IntStream.range(0, neurons)
-                        .mapToObj(i -> Device.of("nc", i))
-                        .toArray(Device[]::new);
+                return IntStream.range(0, neurons).mapToObj(i -> "nc" + i).toArray(String[]::new);
             }
         } else if (!devices.isEmpty()) {
-            return Arrays.stream(devices.split(";"))
-                    .map(n -> Device.fromName(n, engine))
-                    .toArray(Device[]::new);
+            return devices.split(";");
         }
-        return new Device[] {null};
+        return new String[] {null};
     }
 
     private static void printHelp(String msg, Options options) {

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -83,7 +83,7 @@ public class ModelServer implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(ModelServer.class);
     private static final Logger SERVER_METRIC = LoggerFactory.getLogger("server_metric");
-    private static final Pattern MODEL_STORE_PATTERN = Pattern.compile("(\\[?(.+?)]?=)?(.+)");
+    private static final Pattern MODEL_STORE_PATTERN = Pattern.compile("(\\[?([^?]+?)]?=)?(.+)");
 
     private ServerGroups serverGroups;
     private List<ChannelFuture> futures = new ArrayList<>(2);

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -172,7 +172,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                 }
             }
             String engineName = input.getProperty("engine_name", null);
-            String deviceName = input.getProperty("device", "-1");
+            String deviceName = input.getProperty("device", null);
 
             logger.info("Loading model {} from: {}", workflowName, modelUrl);
 

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -12,9 +12,7 @@
  */
 package ai.djl.serving.http;
 
-import ai.djl.Device;
 import ai.djl.ModelException;
-import ai.djl.engine.Engine;
 import ai.djl.metric.Metric;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -176,10 +174,6 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             String engineName = input.getProperty("engine_name", null);
             String deviceName = input.getProperty("device", "-1");
 
-            Engine engine =
-                    engineName != null ? Engine.getEngine(engineName) : Engine.getInstance();
-            Device device = Device.fromName(deviceName, engine);
-
             logger.info("Loading model {} from: {}", workflowName, modelUrl);
 
             WlmConfigManager wlmc = WlmConfigManager.getInstance();
@@ -199,7 +193,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
 
             modelManager
                     .registerWorkflow(wf)
-                    .thenApply(p -> modelManager.scaleWorkers(wf, device, 1, -1))
+                    .thenApply(p -> modelManager.initWorkers(wf, deviceName, 1, -1))
                     .thenAccept(p -> runJob(modelManager, ctx, p, input));
             return;
         }

--- a/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
@@ -20,7 +20,6 @@ import ai.djl.serving.models.Endpoint;
 import ai.djl.serving.models.ModelManager;
 import ai.djl.serving.util.NettyUtils;
 import ai.djl.serving.wlm.ModelInfo;
-import ai.djl.serving.wlm.WorkLoadManager.WorkerPool;
 import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.workflow.BadWorkflowException;
 import ai.djl.serving.workflow.Workflow;
@@ -193,7 +192,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
             ChannelHandlerContext ctx, String workflowName, String version)
             throws ModelNotFoundException {
         ModelManager modelManager = ModelManager.getInstance();
-        DescribeWorkflowResponse resp = modelManager.describeWorkflow(workflowName, version);
+        DescribeWorkflowResponse[] resp = modelManager.describeWorkflow(workflowName, version);
         NettyUtils.sendJsonResponse(ctx, resp);
     }
 
@@ -239,8 +238,8 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                         .thenAccept(
                                 v -> {
                                     for (ModelInfo<Input, Output> m : workflow.getModels()) {
-                                        m.configurePool(maxIdleTime)
-                                                .configureModelBatch(batchSize, maxBatchDelay);
+                                        m.configureModelBatch(
+                                                batchSize, maxBatchDelay, maxIdleTime);
                                         modelManager.initWorkers(
                                                 m, deviceName, minWorkers, maxWorkers);
                                     }
@@ -328,73 +327,56 @@ public class ManagementRequestHandler extends HttpRequestHandler {
             String version)
             throws ModelNotFoundException {
         try {
+            String deviceName = NettyUtils.getParameter(decoder, DEVICE_PARAMETER, null);
+            int maxIdleTime = NettyUtils.getIntParameter(decoder, MAX_IDLE_TIME_PARAMETER, -1);
+            int batchSize = NettyUtils.getIntParameter(decoder, BATCH_SIZE_PARAMETER, -1);
+            int maxBatchDelay = NettyUtils.getIntParameter(decoder, MAX_BATCH_DELAY_PARAMETER, -1);
+            int minWorkers = NettyUtils.getIntParameter(decoder, MIN_WORKER_PARAMETER, -1);
+            int maxWorkers = NettyUtils.getIntParameter(decoder, MAX_WORKER_PARAMETER, -1);
+
             ModelManager modelManager = ModelManager.getInstance();
-            Workflow workflow = modelManager.getWorkflow(workflowName, version, false);
-            if (workflow == null) {
+            Endpoint endpoint = modelManager.getEndpoints().get(workflowName);
+            List<Workflow> workflows = null;
+            if (endpoint != null) {
+                if (version == null) {
+                    // scale all versions
+                    workflows = endpoint.getWorkflows();
+                } else {
+                    Workflow wf = modelManager.getWorkflow(workflowName, version, false);
+                    if (wf != null) {
+                        workflows = Collections.singletonList(wf);
+                    }
+                }
+            }
+            if (workflows == null || workflows.isEmpty()) {
                 throw new ModelNotFoundException("Model or workflow not found: " + workflowName);
             }
 
-            // make sure all models are loaded and ready
-            for (ModelInfo<Input, Output> modelInfo : workflow.getModels()) {
-                if (modelInfo.getStatus() != ModelInfo.Status.READY) {
-                    throw new ServiceUnavailableException(
-                            "Model or workflow is not ready: " + workflowName);
-                }
-            }
-
-            String deviceName = NettyUtils.getParameter(decoder, DEVICE_PARAMETER, null);
-
-            List<String> msgs = new ArrayList<>();
-            for (ModelInfo<Input, Output> modelInfo : workflow.getModels()) {
-                WorkerPool<Input, Output> pool =
-                        modelManager.getWorkLoadManager().getWorkerPoolForModel(modelInfo);
-                int minWorkers =
-                        NettyUtils.getIntParameter(
-                                decoder, MIN_WORKER_PARAMETER, pool.getMinWorkers());
-                int maxWorkers =
-                        NettyUtils.getIntParameter(
-                                decoder, MAX_WORKER_PARAMETER, pool.getMaxWorkers());
-                if (maxWorkers < minWorkers) {
-                    throw new BadRequestException("max_worker cannot be less than min_worker.");
-                }
-
-                int maxIdleTime =
-                        NettyUtils.getIntParameter(
-                                decoder, MAX_IDLE_TIME_PARAMETER, modelInfo.getMaxIdleTime());
-                int batchSize =
-                        NettyUtils.getIntParameter(
-                                decoder, BATCH_SIZE_PARAMETER, modelInfo.getBatchSize());
-                int maxBatchDelay =
-                        NettyUtils.getIntParameter(
-                                decoder, MAX_BATCH_DELAY_PARAMETER, modelInfo.getMaxBatchDelay());
-
-                if (version == null) {
-                    // scale all versions
-                    Endpoint endpoint = modelManager.getEndpoints().get(workflowName);
-                    for (Workflow p : endpoint.getWorkflows()) {
-                        for (ModelInfo<Input, Output> m : p.getModels()) {
-                            m.configurePool(maxIdleTime)
-                                    .configureModelBatch(batchSize, maxBatchDelay);
-                            modelManager.scaleWorkers(m, deviceName, minWorkers, maxWorkers);
-                        }
+            List<String> messages = new ArrayList<>();
+            for (Workflow workflow : workflows) {
+                // make sure all models are loaded and ready
+                for (ModelInfo<Input, Output> modelInfo : workflow.getModels()) {
+                    if (modelInfo.getStatus() != ModelInfo.Status.READY) {
+                        throw new ServiceUnavailableException(
+                                "Model or workflow is not ready: " + workflow.getName());
                     }
-                } else {
-                    modelInfo
-                            .configurePool(maxIdleTime)
-                            .configureModelBatch(batchSize, maxBatchDelay);
-                    modelManager.scaleWorkers(modelInfo, deviceName, minWorkers, maxWorkers);
                 }
 
-                String msg =
-                        "Workflow \""
-                                + workflowName
-                                + "\" worker scaled. New Worker configuration min workers:"
-                                + pool.getMinWorkers()
-                                + " max workers:"
-                                + pool.getMaxWorkers();
-                msgs.add(msg);
+                for (ModelInfo<Input, Output> modelInfo : workflow.getModels()) {
+                    modelInfo.configureModelBatch(batchSize, maxBatchDelay, maxIdleTime);
+                    modelManager.scaleWorkers(modelInfo, deviceName, minWorkers, maxWorkers);
+                    String msg =
+                            "Workflow \""
+                                    + workflow.getName()
+                                    + "\" worker scaled. New Worker configuration min workers:"
+                                    + minWorkers
+                                    + " max workers:"
+                                    + maxWorkers;
+                    messages.add(msg);
+                }
             }
-            String combinedMsg = Strings.join(msgs, '\n');
+
+            String combinedMsg = Strings.join(messages, '\n');
             NettyUtils.sendJsonResponse(ctx, new StatusResponse(combinedMsg));
         } catch (NumberFormatException ex) {
             throw new BadRequestException("parameter is invalid number." + ex.getMessage(), ex);
@@ -402,6 +384,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
     }
 
     private static final class ListPagination {
+
         private int pageToken;
         private int last;
 

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.serving;
 
-import ai.djl.Device;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.serving.util.ConfigManager;
@@ -109,7 +108,7 @@ public class WorkflowTest {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
             for (ModelInfo<Input, Output> model : workflow.getModels()) {
-                wlm.registerModel(model).scaleWorkers(Device.cpu(), 1, 1);
+                wlm.registerModel(model).initWorkers(null, 1, 1);
             }
 
             Output output = workflow.execute(wlm, input).join();

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -108,7 +108,7 @@ public class WorkflowTest {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         try (WorkLoadManager wlm = new WorkLoadManager()) {
             for (ModelInfo<Input, Output> model : workflow.getModels()) {
-                wlm.registerModel(model).initWorkers(null, 1, 1);
+                wlm.registerModel(model).initWorkers(null, -1, 1);
             }
 
             Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -205,25 +204,18 @@ public final class ModelInfo<I, O> implements AutoCloseable {
      * @param batchSize the batchSize to set
      * @param maxBatchDelay maximum time to wait for a free space in worker queue after scaling up
      *     workers before giving up to offer the job to the queue.
-     * @return new configured ModelInfo.
-     */
-    public ModelInfo<I, O> configureModelBatch(int batchSize, int maxBatchDelay) {
-        this.batchSize = batchSize;
-        this.maxBatchDelay = maxBatchDelay;
-        return this;
-    }
-
-    /**
-     * Sets new configuration for the workerPool backing this model and returns a new configured
-     * ModelInfo object. You have to triggerUpdates in the {@code ModelManager} using this new
-     * model.
-     *
      * @param maxIdleTime time a WorkerThread can be idle before scaling down this worker.
-     * @return new configured ModelInfo.
      */
-    public ModelInfo<I, O> configurePool(int maxIdleTime) {
-        this.maxIdleTime = maxIdleTime;
-        return this;
+    public void configureModelBatch(int batchSize, int maxBatchDelay, int maxIdleTime) {
+        if (batchSize > 0) {
+            this.batchSize = batchSize;
+        }
+        if (maxBatchDelay >= 0) {
+            this.maxBatchDelay = maxBatchDelay;
+        }
+        if (maxIdleTime > 0) {
+            this.maxIdleTime = maxIdleTime;
+        }
     }
 
     private Map<Device, ZooModel<I, O>> getModels() {
@@ -298,15 +290,6 @@ public final class ModelInfo<I, O> implements AutoCloseable {
      */
     public Status getStatus() {
         return status == null ? Status.PENDING : status;
-    }
-
-    /**
-     * Returns the model cache directory.
-     *
-     * @return the model cache directory
-     */
-    public Path getModelDir() {
-        return getModels().values().iterator().next().getModelPath();
     }
 
     /**
@@ -424,6 +407,7 @@ public final class ModelInfo<I, O> implements AutoCloseable {
             for (Model m : model.values()) {
                 m.close();
             }
+            model.clear();
         }
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -143,7 +143,6 @@ public final class ModelInfo<I, O> implements AutoCloseable {
      */
     @SuppressWarnings("unchecked")
     public void load(Device device) throws ModelException, IOException {
-        device = withDefaultDevice(device);
         if (getModels().containsKey(device)) {
             return;
         }
@@ -181,7 +180,7 @@ public final class ModelInfo<I, O> implements AutoCloseable {
                 builder.optArgument("batchifier", "stack");
             }
         }
-        logger.info("Loading model {} on {}.", id, device);
+        logger.info("Loading model {} on {}", id, device);
         if ("nc".equals(device.getDeviceType())) {
             String ncs = String.valueOf(device.getDeviceId());
             builder.optOption("env", "NEURON_RT_VISIBLE_CORES=" + ncs);
@@ -241,7 +240,6 @@ public final class ModelInfo<I, O> implements AutoCloseable {
      * @return the loaded {@link ZooModel}
      */
     public ZooModel<I, O> getModel(Device device) {
-        device = withDefaultDevice(device);
         if (getModels().get(device) == null) {
             throw new IllegalStateException("Model \"" + id + "\" has not been loaded yet.");
         }
@@ -422,7 +420,7 @@ public final class ModelInfo<I, O> implements AutoCloseable {
     @Override
     public void close() {
         if (!getModels().isEmpty()) {
-            logger.debug("closing model {}", modelName);
+            logger.info("Unloading model: {}{}", id, version == null ? "" : '/' + version);
             for (Model m : model.values()) {
                 m.close();
             }
@@ -459,16 +457,15 @@ public final class ModelInfo<I, O> implements AutoCloseable {
     /**
      * Returns the default device for this model if device is null.
      *
-     * @param device the device to use if it is not null
+     * @param deviceName the device to use if it is not null
      * @return a non-null device
      */
-    public Device withDefaultDevice(Device device) {
-        if (device != null) {
-            return device;
-        }
-
+    public Device withDefaultDevice(String deviceName) {
         Engine engine = engineName != null ? Engine.getEngine(engineName) : Engine.getInstance();
-        return engine.defaultDevice();
+        if (deviceName == null) {
+            return engine.defaultDevice();
+        }
+        return Device.fromName(deviceName, engine);
     }
 
     /** {@inheritDoc} */

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -12,10 +12,7 @@
  */
 package ai.djl.serving.wlm;
 
-import ai.djl.Device;
-import ai.djl.ModelException;
 import ai.djl.serving.wlm.util.WlmCapacityException;
-import ai.djl.serving.wlm.util.WlmConfigManager;
 import ai.djl.serving.wlm.util.WlmException;
 import ai.djl.serving.wlm.util.WlmShutdownException;
 import ai.djl.serving.wlm.util.WorkerJob;
@@ -23,20 +20,12 @@ import ai.djl.serving.wlm.util.WorkerJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.stream.Collectors;
 
 /**
  * WorkLoadManager is responsible to manage the work load of worker thread. the manage scales
@@ -47,36 +36,14 @@ import java.util.stream.Collectors;
 public class WorkLoadManager implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkLoadManager.class);
-    private ExecutorService threadPool;
 
+    private ExecutorService threadPool;
     private ConcurrentHashMap<ModelInfo<?, ?>, WorkerPool<?, ?>> workerPools;
 
     /** Constructs a {@link WorkLoadManager} instance. */
     public WorkLoadManager() {
         threadPool = Executors.newCachedThreadPool();
         workerPools = new ConcurrentHashMap<>();
-    }
-
-    /**
-     * Returns the workers for the specific model.
-     *
-     * @param <I> the model input class
-     * @param <O> the model output class
-     * @param modelInfo the name of the model we are looking for.
-     * @return the list of workers responsible to handle predictions for this model.
-     */
-    public <I, O> List<WorkerThread<I, O>> getWorkers(ModelInfo<I, O> modelInfo) {
-        List<WorkerThread<I, O>> list;
-        WorkerPool<I, O> pool = getWorkerPoolForModel(modelInfo);
-        if (pool == null) {
-            list = Collections.emptyList();
-        } else {
-            list = pool.getWorkers();
-            if (list == null) {
-                list = Collections.emptyList();
-            }
-        }
-        return list;
     }
 
     /**
@@ -93,7 +60,8 @@ public class WorkLoadManager implements AutoCloseable {
     @SuppressWarnings("unchecked")
     public <I, O> WorkerPool<I, O> registerModel(ModelInfo<I, O> modelInfo) {
         return (WorkerPool<I, O>)
-                workerPools.computeIfAbsent(modelInfo, k -> new WorkerPool<>(modelInfo));
+                workerPools.computeIfAbsent(
+                        modelInfo, k -> new WorkerPool<>(modelInfo, threadPool));
     }
 
     /**
@@ -102,7 +70,7 @@ public class WorkLoadManager implements AutoCloseable {
      * @param model the model to remove
      */
     public void unregisterModel(ModelInfo<?, ?> model) {
-        WorkerPool<?, ?> pool = getWorkerPoolForModel(model);
+        WorkerPool<?, ?> pool = getWorkerPool(model);
         pool.shutdownWorkers();
         workerPools.remove(model);
     }
@@ -125,7 +93,7 @@ public class WorkLoadManager implements AutoCloseable {
             return result;
         }
 
-        WorkerPool<I, O> pool = getWorkerPoolForModel(modelInfo);
+        WorkerPool<I, O> pool = getWorkerPool(modelInfo);
         int maxWorkers = pool.getMaxWorkers();
         if (maxWorkers == 0) {
             result.completeExceptionally(
@@ -150,7 +118,7 @@ public class WorkLoadManager implements AutoCloseable {
                             "Scaling up workers for model {} to {} ",
                             modelInfo,
                             currentWorkers + 1);
-                    pool.addThreads(1);
+                    pool.addThreads();
                 }
             }
         }
@@ -182,17 +150,6 @@ public class WorkLoadManager implements AutoCloseable {
     }
 
     /**
-     * Returns the current number of request in the queue.
-     *
-     * @param modelInfo the model
-     * @return the current number of request in the queue
-     */
-    public int getQueueLength(ModelInfo<?, ?> modelInfo) {
-        WorkerPool<?, ?> pool = getWorkerPoolForModel(modelInfo);
-        return pool.getJobQueue().size();
-    }
-
-    /**
      * Returns the {@link WorkerPool} for a model.
      *
      * @param <I> the model input class
@@ -201,7 +158,7 @@ public class WorkLoadManager implements AutoCloseable {
      * @return the {@link WorkerPool}
      */
     @SuppressWarnings("unchecked")
-    public <I, O> WorkerPool<I, O> getWorkerPoolForModel(ModelInfo<I, O> modelInfo) {
+    public <I, O> WorkerPool<I, O> getWorkerPool(ModelInfo<I, O> modelInfo) {
         return (WorkerPool<I, O>) workerPools.get(modelInfo);
     }
 
@@ -211,288 +168,6 @@ public class WorkLoadManager implements AutoCloseable {
         threadPool.shutdownNow();
         for (WorkerPool<?, ?> wp : workerPools.values()) {
             wp.close();
-        }
-    }
-
-    /**
-     * Manages the work load for a single model.
-     *
-     * @author erik.bamberg@web.de
-     */
-    public final class WorkerPool<I, O> implements AutoCloseable {
-
-        private final ModelInfo<I, O> model;
-        private Map<Device, WorkerPoolDevice> devices;
-        private LinkedBlockingDeque<WorkerJob<I, O>> jobQueue;
-
-        /**
-         * Construct and initial data structure.
-         *
-         * @param model the model this WorkerPool belongs to.
-         */
-        public WorkerPool(ModelInfo<I, O> model) {
-            this.model = model;
-            devices = new ConcurrentHashMap<>();
-            jobQueue = new LinkedBlockingDeque<>(model.getQueueSize());
-        }
-
-        /**
-         * Returns a list of worker thread.
-         *
-         * @return the workers
-         */
-        public List<WorkerThread<I, O>> getWorkers() {
-            return devices.values().stream()
-                    .flatMap(d -> d.workers.stream())
-                    .collect(Collectors.toList());
-        }
-
-        /**
-         * Returns the {@code JobQueue} for this model.
-         *
-         * @return the jobQueue
-         */
-        public LinkedBlockingDeque<WorkerJob<I, O>> getJobQueue() {
-            return jobQueue;
-        }
-
-        /**
-         * Returns the minimum number of workers for a model across all devices.
-         *
-         * @return the minimum number of workers for a model across all devices
-         */
-        public int getMinWorkers() {
-            return devices.values().stream().mapToInt(d -> d.minWorkers).reduce(0, Integer::sum);
-        }
-
-        /**
-         * Returns the maximum number of workers for a model across all devices.
-         *
-         * @return the maximum number of workers for a model across all devices
-         */
-        public int getMaxWorkers() {
-            return devices.values().stream().mapToInt(d -> d.maxWorkers).reduce(0, Integer::sum);
-        }
-
-        /**
-         * Initializes new worker capacities for this model.
-         *
-         * @param deviceName the device for the model, null for default devices
-         * @param minWorkers minimum amount of workers.
-         * @param maxWorkers maximum amount of workers.
-         */
-        public void initWorkers(String deviceName, int minWorkers, int maxWorkers) {
-            Device device = model.withDefaultDevice(deviceName);
-            scaleWorkers(device, minWorkers, maxWorkers);
-        }
-
-        /**
-         * Sets new worker capacities for this model.
-         *
-         * @param deviceName the device for the model, null for all devices
-         * @param minWorkers minimum amount of workers.
-         * @param maxWorkers maximum amount of workers.
-         */
-        public void scaleWorkers(String deviceName, int minWorkers, int maxWorkers) {
-            if (deviceName != null) {
-                Device device = model.withDefaultDevice(deviceName);
-                scaleWorkers(device, minWorkers, maxWorkers);
-                return;
-            }
-
-            // scale for all devices
-            for (Device device : devices.keySet()) {
-                scaleWorkers(device, minWorkers, maxWorkers);
-            }
-        }
-
-        private void scaleWorkers(Device device, int newMinWorkers, int newMaxWorkers) {
-            synchronized (model) {
-                try {
-                    model.load(device);
-                } catch (ModelException | IOException e) {
-                    throw new CompletionException(e);
-                }
-                if (model.getStatus() != ModelInfo.Status.READY) {
-                    logger.warn("Cannot scale workers while model is not READY: {}", model);
-                    return;
-                }
-
-                WlmConfigManager configManager = WlmConfigManager.getInstance();
-                newMaxWorkers = configManager.getDefaultMaxWorkers(model, device, newMaxWorkers);
-                newMinWorkers =
-                        configManager.getDefaultMinWorkers(
-                                model, device, newMinWorkers, newMaxWorkers);
-
-                WorkerPoolDevice wpd = new WorkerPoolDevice(device, newMinWorkers, newMaxWorkers);
-                devices.put(device, wpd);
-
-                cleanup();
-
-                List<WorkerThread<I, O>> threads = getWorkers();
-                List<WorkerThread<I, O>> fixedPoolThread =
-                        threads.stream()
-                                .filter(WorkerThread::isFixPoolThread)
-                                .collect(Collectors.toList());
-
-                int numberOfCurrentFixedWorkers = fixedPoolThread.size();
-
-                if (numberOfCurrentFixedWorkers < newMinWorkers) {
-                    // scale up the fixed pool
-                    wpd.addThreads(newMinWorkers - numberOfCurrentFixedWorkers, true);
-                } else {
-                    // scale down the fixed pool
-                    fixedPoolThread
-                            .subList(newMinWorkers, numberOfCurrentFixedWorkers)
-                            .forEach(
-                                    t -> {
-                                        t.shutdown(WorkerState.WORKER_SCALED_DOWN);
-                                    });
-                }
-                log();
-            }
-        }
-
-        /** Shutdown all works. */
-        public void shutdownWorkers() {
-            synchronized (model) {
-                List<WorkerThread<I, O>> threads = getWorkers();
-                for (WorkerThread<I, O> thread : threads) {
-                    thread.shutdown(WorkerState.WORKER_SCALED_DOWN);
-                }
-                threads.clear();
-            }
-        }
-
-        /**
-         * Returns the {@link WorkerPoolDevice} for a particular {@link Device}.
-         *
-         * @param device the device for a worker pool
-         * @return the {@link WorkerPoolDevice} or null if device is not used
-         */
-        public WorkerPoolDevice forDevice(Device device) {
-            return devices.get(device);
-        }
-
-        /**
-         * Logs the current state of this {@code WorkerPool} when level "Debug" is enabled.
-         *
-         * <p>Logs all thread-ids in the pool.
-         */
-        public void log() {
-            if (logger.isDebugEnabled()) {
-                StringBuffer buf = new StringBuffer();
-                getWorkers()
-                        .forEach(
-                                w -> {
-                                    buf.append(w.getWorkerId());
-                                    if (w.isFixPoolThread()) {
-                                        buf.append("-fixedPool\n");
-                                    } else {
-                                        buf.append("-tmpPool\n");
-                                    }
-                                });
-                logger.debug("worker pool for model {}:\n {}", model, buf);
-            }
-        }
-
-        /** removes all stopped workers and workers in state error from the pool. */
-        public void cleanup() {
-            for (WorkerPoolDevice wpd : devices.values()) {
-                wpd.workers.removeIf(
-                        t ->
-                                t.getState() == WorkerState.WORKER_STOPPED
-                                        || t.getState() == WorkerState.WORKER_ERROR);
-            }
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {
-            model.close();
-            for (WorkerPoolDevice wpd : devices.values()) {
-                for (WorkerThread<I, O> worker : wpd.workers) {
-                    worker.shutdown(WorkerState.WORKER_STOPPED);
-                }
-            }
-            for (WorkerJob<I, O> wj : jobQueue) {
-                wj.getFuture().cancel(true);
-            }
-        }
-
-        /**
-         * Adds temporary threads across existing devices.
-         *
-         * <p>Only supports temporary threads because permanent threads are managed per-device, so
-         * it doesn't need a multi-device version.
-         *
-         * @param count number of threads to add
-         */
-        private void addThreads(int count) {
-            // Add threads to devices which has most room to grow
-            List<WorkerPoolDevice> sorted = new ArrayList<>(devices.values());
-            sorted.sort(Comparator.comparingInt(p -> p.getMaxWorkers() - p.getMinWorkers()));
-
-            for (WorkerPoolDevice wpd : devices.values()) {
-                int toAdd = Math.min(count, wpd.getMaxWorkers() - wpd.workers.size());
-                wpd.addThreads(toAdd, false);
-                count -= toAdd;
-                if (count == 0) {
-                    return;
-                }
-            }
-        }
-
-        /**
-         * The {@link WorkerPoolDevice} manages the {@link WorkerPool} for a particular {@link
-         * Device}.
-         */
-        public final class WorkerPoolDevice {
-
-            private Device device;
-            private int minWorkers;
-            private int maxWorkers;
-            private List<WorkerThread<I, O>> workers;
-
-            private WorkerPoolDevice(Device device, int minWorkers, int maxWorkers) {
-                this.device = device;
-                this.minWorkers = minWorkers;
-                this.maxWorkers = maxWorkers;
-                workers = new CopyOnWriteArrayList<>();
-            }
-
-            /**
-             * Returns the min number of workers for the model and device.
-             *
-             * @return the min number of workers for the model and device
-             */
-            public int getMinWorkers() {
-                return minWorkers;
-            }
-
-            /**
-             * Returns the max number of workers for the model and device.
-             *
-             * @return the max number of workers for the model and device
-             */
-            public int getMaxWorkers() {
-                return maxWorkers;
-            }
-
-            private void addThreads(int count, boolean permanent) {
-                for (int i = 0; i < count; ++i) {
-                    WorkerThread<I, O> thread =
-                            WorkerThread.builder(model.getInputClass(), model.getOutputClass())
-                                    .setModel(model)
-                                    .setDevice(device)
-                                    .setJobQueue(jobQueue)
-                                    .optFixPoolThread(permanent)
-                                    .build();
-
-                    workers.add(thread);
-                    threadPool.submit(thread);
-                }
-            }
         }
     }
 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.Device;
+import ai.djl.Model;
+import ai.djl.serving.wlm.util.WlmConfigManager;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+
+/** The {@link WorkerGroup} manages the {@link WorkerPool} for a particular {@link Device}. */
+public class WorkerGroup<I, O> {
+
+    private WorkerPool<I, O> workerPool;
+    private Device device;
+    private int minWorkers;
+    int maxWorkers;
+    List<WorkerThread<I, O>> workers;
+
+    WorkerGroup(WorkerPool<I, O> workerPool, Device device) {
+        this.workerPool = workerPool;
+        this.device = device;
+        workers = new CopyOnWriteArrayList<>();
+        WlmConfigManager config = WlmConfigManager.getInstance();
+        Model model = workerPool.getModel().getModel(device);
+        minWorkers = config.getDefaultMinWorkers(model);
+        maxWorkers = config.getDefaultMaxWorkers(model);
+        minWorkers = Math.min(minWorkers, maxWorkers);
+    }
+
+    /**
+     * Returns the device of the worker group.
+     *
+     * @return the device of the worker group
+     */
+    public Device getDevice() {
+        return device;
+    }
+
+    /**
+     * Returns a list of workers.
+     *
+     * @return a list of workers
+     */
+    public List<WorkerThread<I, O>> getWorkers() {
+        return workers;
+    }
+
+    /**
+     * Returns the min number of workers for the model and device.
+     *
+     * @return the min number of workers for the model and device
+     */
+    public int getMinWorkers() {
+        return minWorkers;
+    }
+
+    /**
+     * Returns the max number of workers for the model and device.
+     *
+     * @return the max number of workers for the model and device
+     */
+    public int getMaxWorkers() {
+        return maxWorkers;
+    }
+
+    /**
+     * Configures minimum and maximum number of workers.
+     *
+     * @param minWorkers the minimum number of workers
+     * @param maxWorkers the maximum number of workers
+     */
+    public void configureWorkers(int minWorkers, int maxWorkers) {
+        if (minWorkers >= 0) {
+            this.minWorkers = minWorkers;
+        }
+        if (maxWorkers >= 0) {
+            this.maxWorkers = maxWorkers;
+        }
+    }
+
+    void addThreads(int count, boolean permanent) {
+        ModelInfo<I, O> model = workerPool.getModel();
+        ExecutorService threadPool = workerPool.getThreadPool();
+        for (int i = 0; i < count; ++i) {
+            WorkerThread<I, O> thread =
+                    WorkerThread.builder(model)
+                            .setDevice(device)
+                            .setJobQueue(workerPool.getJobQueue())
+                            .optFixPoolThread(permanent)
+                            .build();
+
+            workers.add(thread);
+            threadPool.submit(thread);
+        }
+    }
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.Device;
+import ai.djl.ModelException;
+import ai.djl.serving.wlm.util.WorkerJob;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Collectors;
+
+/**
+ * Manages the work load for a single model.
+ *
+ * @author erik.bamberg@web.de
+ */
+public class WorkerPool<I, O> implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkerPool.class);
+
+    private final ModelInfo<I, O> model;
+    private ExecutorService threadPool;
+    private Map<Device, WorkerGroup<I, O>> workerGroups;
+    private LinkedBlockingDeque<WorkerJob<I, O>> jobQueue;
+
+    /**
+     * Construct and initial data structure.
+     *
+     * @param model the model this WorkerPool belongs to
+     * @param threadPool the thread pool executor
+     */
+    WorkerPool(ModelInfo<I, O> model, ExecutorService threadPool) {
+        this.model = model;
+        this.threadPool = threadPool;
+        workerGroups = new ConcurrentHashMap<>();
+        jobQueue = new LinkedBlockingDeque<>(model.getQueueSize());
+    }
+
+    ModelInfo<I, O> getModel() {
+        return model;
+    }
+
+    ExecutorService getThreadPool() {
+        return threadPool;
+    }
+
+    /**
+     * Returns a map of {@code WorkerGroup}.
+     *
+     * @return a map of {@code WorkerGroup}
+     */
+    public Map<Device, WorkerGroup<I, O>> getWorkerGroups() {
+        return workerGroups;
+    }
+
+    /**
+     * Returns a list of worker thread.
+     *
+     * @return the workers
+     */
+    public List<WorkerThread<I, O>> getWorkers() {
+        return workerGroups.values().stream()
+                .flatMap(g -> g.workers.stream())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the {@code JobQueue} for this model.
+     *
+     * @return the jobQueue
+     */
+    public LinkedBlockingDeque<WorkerJob<I, O>> getJobQueue() {
+        return jobQueue;
+    }
+
+    /**
+     * Returns the maximum number of workers for a model across all devices.
+     *
+     * @return the maximum number of workers for a model across all devices
+     */
+    public int getMaxWorkers() {
+        return workerGroups.values().stream().mapToInt(g -> g.maxWorkers).reduce(0, Integer::sum);
+    }
+
+    /**
+     * Returns if the worker groups is fully scaled.
+     *
+     * @return true if the worker groups is fully scaled
+     */
+    public boolean isFullyScaled() {
+        for (WorkerGroup<I, O> group : workerGroups.values()) {
+            if (group.getMinWorkers() > group.getWorkers().size()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Initializes new worker capacities for this model.
+     *
+     * @param deviceName the device for the model, null for default devices
+     * @param minWorkers minimum amount of workers.
+     * @param maxWorkers maximum amount of workers.
+     */
+    public void initWorkers(String deviceName, int minWorkers, int maxWorkers) {
+        Device device = model.withDefaultDevice(deviceName);
+        logger.info("initWorkers for {} ({}): {}, {}", model, device, minWorkers, maxWorkers);
+        synchronized (model) {
+            try {
+                model.load(device);
+            } catch (ModelException | IOException e) {
+                throw new CompletionException(e);
+            }
+            if (model.getStatus() != ModelInfo.Status.READY) {
+                logger.warn("Cannot scale workers while model is not READY: {}", model);
+            }
+        }
+        cleanup();
+
+        WorkerGroup<I, O> group =
+                workerGroups.computeIfAbsent(device, d -> new WorkerGroup<>(this, d));
+        group.configureWorkers(minWorkers, maxWorkers);
+        doScaleWorker(group);
+        log();
+    }
+
+    /**
+     * Sets new worker capacities for this model.
+     *
+     * @param deviceName the device for the model, null for all loaded devices
+     * @param minWorkers minimum amount of workers.
+     * @param maxWorkers maximum amount of workers.
+     */
+    public void scaleWorkers(String deviceName, int minWorkers, int maxWorkers) {
+        if (deviceName != null) {
+            // if the model has not been loaded on device, this will load the model
+            initWorkers(deviceName, minWorkers, maxWorkers);
+            return;
+        }
+
+        cleanup();
+
+        // scale for all devices
+        for (WorkerGroup<I, O> group : workerGroups.values()) {
+            group.configureWorkers(minWorkers, maxWorkers);
+            doScaleWorker(group);
+        }
+        log();
+    }
+
+    private void doScaleWorker(WorkerGroup<I, O> group) {
+        int minWorkers = group.getMinWorkers();
+        List<WorkerThread<I, O>> fixedPoolThreads = new ArrayList<>();
+        for (WorkerThread<I, O> threads : group.getWorkers()) {
+            if (threads.isFixPoolThread()) {
+                fixedPoolThreads.add(threads);
+            }
+        }
+        int activeThreads = fixedPoolThreads.size();
+        if (activeThreads < minWorkers) {
+            // scale up the fixed pool
+            group.addThreads(minWorkers - activeThreads, true);
+        } else {
+            // scale down the fixed pool
+            fixedPoolThreads
+                    .subList(minWorkers, activeThreads)
+                    .forEach(t -> t.shutdown(WorkerState.WORKER_SCALED_DOWN));
+        }
+    }
+
+    /** Shutdown all works. */
+    public void shutdownWorkers() {
+        synchronized (model) {
+            List<WorkerThread<I, O>> threads = getWorkers();
+            for (WorkerThread<I, O> thread : threads) {
+                thread.shutdown(WorkerState.WORKER_SCALED_DOWN);
+            }
+            threads.clear();
+        }
+    }
+
+    /** removes all stopped workers and workers in state error from the pool. */
+    public void cleanup() {
+        for (WorkerGroup<I, O> group : workerGroups.values()) {
+            group.workers.removeIf(
+                    t ->
+                            t.getState() == WorkerState.WORKER_STOPPED
+                                    || t.getState() == WorkerState.WORKER_ERROR);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() {
+        model.close();
+        for (WorkerGroup<I, O> group : workerGroups.values()) {
+            for (WorkerThread<I, O> worker : group.workers) {
+                worker.shutdown(WorkerState.WORKER_STOPPED);
+            }
+        }
+        for (WorkerJob<I, O> wj : jobQueue) {
+            wj.getFuture().cancel(true);
+        }
+    }
+
+    /**
+     * Adds temporary threads across existing devices.
+     *
+     * <p>Only supports temporary threads because permanent threads are managed per-device, so it
+     * doesn't need a multi-device version.
+     */
+    void addThreads() {
+        // Add threads to devices which has most room to grow
+        List<WorkerGroup<I, O>> sorted = new ArrayList<>(workerGroups.values());
+        if (sorted.isEmpty()) {
+            logger.warn("No worker pool available.");
+            return;
+        }
+        sorted.sort(Comparator.comparingInt(p -> p.getMaxWorkers() - p.getMinWorkers()));
+
+        WorkerGroup<I, O> group = sorted.get(sorted.size() - 1);
+        if (group.getMaxWorkers() > group.workers.size()) {
+            group.addThreads(1, false);
+        }
+    }
+
+    /**
+     * Logs the current state of this {@code WorkerPool} when level "Debug" is enabled.
+     *
+     * <p>Logs all thread-ids in the pool.
+     */
+    private void log() {
+        if (logger.isDebugEnabled()) {
+            StringBuffer buf = new StringBuffer();
+            getWorkers()
+                    .forEach(
+                            w -> {
+                                buf.append(w.getWorkerId());
+                                if (w.isFixPoolThread()) {
+                                    buf.append("-fixedPool\n");
+                                } else {
+                                    buf.append("-tmpPool\n");
+                                }
+                            });
+            logger.debug("worker pool for model {}:\n {}", model, buf);
+        }
+    }
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -128,6 +128,9 @@ public final class WlmConfigManager {
      */
     public int getDefaultMinWorkers(
             ModelInfo<?, ?> modelInfo, Device device, int minWorkers, int maxWorkers) {
+        if (minWorkers == 0) {
+            return 0;
+        }
         Model model = modelInfo.getModel(device);
         minWorkers = getWorkersProperty(model, device, "minWorkers", minWorkers);
         return Math.min(minWorkers, maxWorkers);
@@ -142,10 +145,12 @@ public final class WlmConfigManager {
      * @return the default number of workers for a new registered model
      */
     public int getDefaultMaxWorkers(ModelInfo<?, ?> modelInfo, Device device, int target) {
-        Model model = modelInfo.getModel(device);
         if (target == 0) {
             return 0; // explicitly shutdown
-        } else if (target == -1) {
+        }
+
+        Model model = modelInfo.getModel(device);
+        if (target == -1) {
             // auto detection
             if (isDebug()) {
                 return 1;

--- a/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
@@ -14,7 +14,6 @@ package ai.djl.serving.wlm;
 
 import static org.testng.Assert.assertEquals;
 
-import ai.djl.Device;
 import ai.djl.modality.Classifications;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -39,7 +38,7 @@ public class WorkLoadManagerTest {
                             .optModelUrls(modelUrl)
                             .build();
             try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria)) {
-                wlm.registerModel(modelInfo).scaleWorkers(Device.cpu(), 1, 2);
+                wlm.registerModel(modelInfo).initWorkers(null, 1, 2);
                 Input input = new Input();
                 URL url = new URL("https://resources.djl.ai/images/0.png");
                 try (InputStream is = url.openStream()) {


### PR DESCRIPTION
1. If engine name is not specified, currently use MXNet to detect default device. We should differ to scale worker time, so we can use correct engine to find default device.
2. When unregister to model, if model is loaded on non-default device, we always load the model on default device and then unregister. This causing confusion.
3. Scale worker API is broken for workflow, new behavior will scale per device, if device is not provided, scale for all loaded devices.
4. Scale worker API now allow you to scale worker for a new device which model was not loaded on.
5. Auto scaling now is per device configuration (GPU and CPU has different default maxWorkers)
6. Fixes describeWorkflow API, it shows Unhealthy due to mis-calcuated minWorkers
7. DescribeWorkerflow API will show WorkGroup information