### PR TITLE
[wlm] Removes AutoClosable for ModelServer, Endpoint and Workflow

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -79,7 +79,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** The main entry point for model server. */
-public class ModelServer implements AutoCloseable {
+public class ModelServer {
 
     private static final Logger logger = LoggerFactory.getLogger(ModelServer.class);
     private static final Logger SERVER_METRIC = LoggerFactory.getLogger("server_metric");
@@ -616,11 +616,5 @@ public class ModelServer implements AutoCloseable {
         formatter.setLeftPadding(1);
         formatter.setWidth(120);
         formatter.printHelp(msg, options);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void close() {
-        stop();
     }
 }

--- a/serving/src/main/java/ai/djl/serving/models/Endpoint.java
+++ b/serving/src/main/java/ai/djl/serving/models/Endpoint.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /** A class that represents a webservice endpoint. */
-public class Endpoint implements AutoCloseable {
+public class Endpoint {
 
     private List<Workflow> workflows;
     private Map<String, Integer> map;
@@ -130,11 +130,10 @@ public class Endpoint implements AutoCloseable {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
+    /** Closes the {@code Endpoint}. */
     public void close() {
         for (Workflow workflow : workflows) {
-            workflow.close();
+            workflow.stop();
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -128,7 +128,7 @@ public final class ModelManager {
             // unregister all versions
             for (Workflow workflow : endpoint.getWorkflows()) {
                 candidateModelsToUnregister.addAll(workflow.getModels());
-                workflow.close();
+                workflow.stop();
             }
             startupWorkflows.remove(workflowName);
             endpoint.getWorkflows().clear();
@@ -140,7 +140,7 @@ public final class ModelManager {
                 return false;
             }
             candidateModelsToUnregister.addAll(workflow.getModels());
-            workflow.close();
+            workflow.stop();
             startupWorkflows.remove(workflowName);
         }
         if (endpoint.getWorkflows().isEmpty()) {

--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /** A flow of executing {@link ai.djl.Model}s and custom functions. */
-public class Workflow implements AutoCloseable {
+public class Workflow {
 
     private static final Logger logger = LoggerFactory.getLogger(Workflow.class);
 
@@ -167,9 +167,8 @@ public class Workflow implements AutoCloseable {
         return name;
     }
 
-    /** {@inheritDoc} * */
-    @Override
-    public void close() {
+    /** Stops the workflow and unloads all the models in the workflow. */
+    public void stop() {
         for (ModelInfo<Input, Output> m : getModels()) {
             m.close();
         }

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -166,7 +166,8 @@ public class ModelServerTest {
     public void testModelStore()
             throws IOException, ServerStartupException, GeneralSecurityException, ParseException,
                     InterruptedException {
-        try (ModelServer server = initTestServer("src/test/resources/config.properties")) {
+        ModelServer server = initTestServer("src/test/resources/config.properties");
+        try {
             Path modelStore = Paths.get("build/models");
             Path modelDir = modelStore.resolve("test_model");
             Files.createDirectories(modelDir);
@@ -241,6 +242,8 @@ public class ModelServerTest {
 
             url = server.mapModelUrl(mar);
             assertEquals(url, "torchServe::Python:*=" + mar.toUri().toURL());
+        } finally {
+            server.stop();
         }
     }
 
@@ -258,8 +261,8 @@ public class ModelServerTest {
             throws InterruptedException, HttpPostRequestEncoder.ErrorDataEncoderException,
                     IOException, ParseException, GeneralSecurityException,
                     ReflectiveOperationException, ServerStartupException {
-
-        try (ModelServer server = initTestServer("src/test/resources/config.properties")) {
+        ModelServer server = initTestServer("src/test/resources/config.properties");
+        try {
             assertTrue(server.isRunning());
             Channel channel = initTestChannel();
 
@@ -310,6 +313,8 @@ public class ModelServerTest {
             testServiceUnavailable();
 
             ConfigManagerTest.testSsl();
+        } finally {
+            server.stop();
         }
     }
 
@@ -317,7 +322,8 @@ public class ModelServerTest {
     public void testWorkflows()
             throws ServerStartupException, GeneralSecurityException, ParseException, IOException,
                     InterruptedException, ReflectiveOperationException {
-        try (ModelServer server = initTestServer("src/test/resources/workflow.config.properties")) {
+        ModelServer server = initTestServer("src/test/resources/workflow.config.properties");
+        try {
             assertTrue(server.isRunning());
             Channel channel = initTestChannel();
 
@@ -327,6 +333,8 @@ public class ModelServerTest {
             channel.close().sync();
 
             ConfigManagerTest.testSsl();
+        } finally {
+            server.stop();
         }
     }
 

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -106,14 +106,15 @@ public class WorkflowTest {
     private Input runWorkflow(Path workflowFile, Input input)
             throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
-        try (WorkLoadManager wlm = new WorkLoadManager()) {
-            for (ModelInfo<Input, Output> model : workflow.getModels()) {
-                wlm.registerModel(model).initWorkers(null, -1, 1);
-            }
-
-            Output output = workflow.execute(wlm, input).join();
-            Assert.assertNotNull(output.getData());
-            return output;
+        WorkLoadManager wlm = new WorkLoadManager();
+        for (ModelInfo<Input, Output> model : workflow.getModels()) {
+            wlm.registerModel(model).initWorkers(null, -1, 1);
         }
+
+        Output output = workflow.execute(wlm, input).join();
+        workflow.stop();
+        wlm.close();
+        Assert.assertNotNull(output.getData());
+        return output;
     }
 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** A class represent a loaded model and it's metadata. */
-public final class ModelInfo<I, O> implements AutoCloseable {
+public final class ModelInfo<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(ModelInfo.class);
 
@@ -399,8 +399,7 @@ public final class ModelInfo<I, O> implements AutoCloseable {
         return queueSize;
     }
 
-    /** {@inheritDoc} */
-    @Override
+    /** Close all loaded models. */
     public void close() {
         if (!getModels().isEmpty()) {
             logger.info("Unloading model: {}{}", id, version == null ? "" : '/' + version);

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -33,7 +33,7 @@ import java.util.concurrent.LinkedBlockingDeque;
  *
  * @author erik.bamberg@web.de
  */
-public class WorkLoadManager implements AutoCloseable {
+public class WorkLoadManager {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkLoadManager.class);
 
@@ -162,12 +162,12 @@ public class WorkLoadManager implements AutoCloseable {
         return (WorkerPool<I, O>) workerPools.get(modelInfo);
     }
 
-    /** {@inheritDoc} */
-    @Override
+    /** Close all models related to the {@code WorkloadManager}. */
     public void close() {
         threadPool.shutdownNow();
         for (WorkerPool<?, ?> wp : workerPools.values()) {
-            wp.close();
+            wp.shutdown();
         }
+        workerPools.clear();
     }
 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  *
  * @author erik.bamberg@web.de
  */
-public class WorkerPool<I, O> implements AutoCloseable {
+public class WorkerPool<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkerPool.class);
 
@@ -211,15 +211,15 @@ public class WorkerPool<I, O> implements AutoCloseable {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void close() {
+    /** Shuts down all the worker threads in the work pool. */
+    public void shutdown() {
         model.close();
         for (WorkerGroup<I, O> group : workerGroups.values()) {
             for (WorkerThread<I, O> worker : group.workers) {
                 worker.shutdown(WorkerState.WORKER_STOPPED);
             }
         }
+        workerGroups.clear();
         for (WorkerJob<I, O> wj : jobQueue) {
             wj.getFuture().cancel(true);
         }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -33,14 +33,13 @@ public class ModelInfoTest {
 
     @Test
     public void testQueueSizeIsSet() {
-        try (ModelInfo<?, ?> modelInfo =
+        ModelInfo<?, ?> modelInfo =
                 new ModelInfo<>(
-                        "", null, null, "MXNet", Input.class, Output.class, 4711, 1, 300, 1)) {
-            Assert.assertEquals(4711, modelInfo.getQueueSize());
-            Assert.assertEquals(1, modelInfo.getMaxIdleTime());
-            Assert.assertEquals(300, modelInfo.getMaxBatchDelay());
-            Assert.assertEquals(1, modelInfo.getBatchSize());
-        }
+                        "", null, null, "MXNet", Input.class, Output.class, 4711, 1, 300, 1);
+        Assert.assertEquals(4711, modelInfo.getQueueSize());
+        Assert.assertEquals(1, modelInfo.getMaxIdleTime());
+        Assert.assertEquals(300, modelInfo.getMaxBatchDelay());
+        Assert.assertEquals(1, modelInfo.getBatchSize());
     }
 
     @Test
@@ -51,18 +50,16 @@ public class ModelInfoTest {
                         .setTypes(Input.class, Output.class)
                         .optModelUrls(modelUrl)
                         .build();
-        try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria)) {
-            modelInfo.load(Device.cpu());
-            try (ZooModel<Input, Output> model = modelInfo.getModel(Device.cpu())) {
-                try (Predictor<Input, Output> predictor = model.newPredictor()) {
-                    Input input = new Input();
-                    URL url = new URL("https://resources.djl.ai/images/0.png");
-                    try (InputStream is = url.openStream()) {
-                        input.add(Utils.toByteArray(is));
-                    }
-                    predictor.predict(input);
-                }
+        ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria);
+        modelInfo.load(Device.cpu());
+        try (ZooModel<Input, Output> model = modelInfo.getModel(Device.cpu());
+                Predictor<Input, Output> predictor = model.newPredictor()) {
+            Input input = new Input();
+            URL url = new URL("https://resources.djl.ai/images/0.png");
+            try (InputStream is = url.openStream()) {
+                input.add(Utils.toByteArray(is));
             }
+            predictor.predict(input);
         }
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
@@ -30,25 +30,25 @@ public class WorkLoadManagerTest {
 
     @Test
     public void testFromCriteria() throws IOException {
-        try (WorkLoadManager wlm = new WorkLoadManager()) {
-            String modelUrl = "djl://ai.djl.zoo/mlp/0.0.3/mlp";
-            Criteria<Input, Output> criteria =
-                    Criteria.builder()
-                            .setTypes(Input.class, Output.class)
-                            .optModelUrls(modelUrl)
-                            .build();
-            try (ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria)) {
-                wlm.registerModel(modelInfo).initWorkers(null, 1, 2);
-                Input input = new Input();
-                URL url = new URL("https://resources.djl.ai/images/0.png");
-                try (InputStream is = url.openStream()) {
-                    input.add(Utils.toByteArray(is));
-                }
-                Output output = wlm.runJob(new Job<>(modelInfo, input)).join();
-
-                Classifications classification = (Classifications) output.get(0);
-                assertEquals(classification.best().getClassName(), "0");
-            }
+        WorkLoadManager wlm = new WorkLoadManager();
+        String modelUrl = "djl://ai.djl.zoo/mlp/0.0.3/mlp";
+        Criteria<Input, Output> criteria =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optModelUrls(modelUrl)
+                        .build();
+        ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", criteria);
+        wlm.registerModel(modelInfo).initWorkers(null, 1, 2);
+        Input input = new Input();
+        URL url = new URL("https://resources.djl.ai/images/0.png");
+        try (InputStream is = url.openStream()) {
+            input.add(Utils.toByteArray(is));
         }
+        Output output = wlm.runJob(new Job<>(modelInfo, input)).join();
+
+        Classifications classification = (Classifications) output.get(0);
+        assertEquals(classification.best().getClassName(), "0");
+        modelInfo.close();
+        wlm.close();
     }
 }


### PR DESCRIPTION
1. We are only using try-with-resource in our unit test code
2. AutoClosable suppose to be closed with try-catch on every reference, but it is not fessible in most cases
3. The close() function is very hard to find usage in IDE
4. IDE gave a lot of warning due to the class is not used with try-with-resource style

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
