### PR TITLE
[ci] fix npmInstall in case nodejs is not installed

### DIFF
--- a/plugins/management-console/build.gradle
+++ b/plugins/management-console/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 }
 
 node {
+    download = true
     nodeProjectDir = file("${project.projectDir}/webapp")
 }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
