### PR TITLE
Create an ensemble workflow

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -51,7 +51,6 @@ jobs:
           kill %1
       - name: Run Python binary mode tests
         run: |
-          ./gradlew :engines:java:pTML
           cd tests/binary && python prepare.py pt && cd ..
           djl-serving -m test::PyTorch=file://$PWD/binary/model.pt &> output.log &
           sleep 30
@@ -95,6 +94,7 @@ jobs:
       - name: Run Java binary mode tests
         shell: bash
         run: |
+          ./gradlew :engines:java:pTML
           cd tests/binary && python prepare.py pt && cd ../../
           ./gradlew :serving:run --args="-m test::PyTorch=file:$(pwd -W)/tests/binary/model.pt" > output.log &
           sleep 30

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -51,6 +51,7 @@ jobs:
           kill %1
       - name: Run Python binary mode tests
         run: |
+          ./gradlew :engines:java:pTML
           cd tests/binary && python prepare.py pt && cd ..
           djl-serving -m test::PyTorch=file://$PWD/binary/model.pt &> output.log &
           sleep 30

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 # FIXME: Workaround gradle publish issue: https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
-djl_version=0.19.0
+djl_version=0.20.0
 onnxruntime_version=1.12.1
 commons_cli_version=1.5.0
 netty_version=4.1.82.Final

--- a/serving/src/main/java/ai/djl/serving/workflow/WorkflowExpression.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/WorkflowExpression.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.serving.workflow;
 
+import ai.djl.modality.Input;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -44,7 +46,7 @@ public class WorkflowExpression {
     /**
      * Returns the executable name (the first argument).
      *
-     * @return the executable name or null if it is an expression
+     * @return the executable name or throws an exception if it is not an executable name
      */
     public String getExecutableName() {
         return args.get(0).getString();
@@ -75,6 +77,8 @@ public class WorkflowExpression {
     public static class Item {
         private String string;
         private WorkflowExpression expression;
+        private Input input;
+        private ItemType itemType;
 
         /**
          * Constructs an {@link Item} containing a string.
@@ -83,6 +87,7 @@ public class WorkflowExpression {
          */
         public Item(String string) {
             this.string = string;
+            itemType = ItemType.STRING;
         }
 
         /**
@@ -92,24 +97,85 @@ public class WorkflowExpression {
          */
         public Item(WorkflowExpression expression) {
             this.expression = expression;
+            itemType = ItemType.EXPRESSION;
         }
 
         /**
-         * Returns the string value or null if it does not contain a string.
+         * Constructs an {@link Item} containing an {@link Input}.
          *
-         * @return the string value or null if it does not contain a string.
+         * @param input the input
+         */
+        public Item(Input input) {
+            this.input = input;
+            itemType = ItemType.INPUT;
+        }
+
+        /**
+         * Returns the string value or throws an exception if it does not contain a string.
+         *
+         * @return the string value or throws an exception if it does not contain a string
          */
         public String getString() {
+            if (itemType != ItemType.STRING) {
+                throw new IllegalArgumentException(
+                        "Expected a string workflow item, but found " + itemType);
+            }
             return string;
         }
 
         /**
-         * Returns the expression value or null if it does not contain an expression.
+         * Returns the expression value or throws an exception if it does not contain an expression.
          *
-         * @return the expression value or null if it does not contain an expression
+         * @return the expression value or throws an exception if it does not contain an expression
          */
         public WorkflowExpression getExpression() {
+            if (itemType != ItemType.EXPRESSION) {
+                throw new IllegalArgumentException(
+                        "Expected an expression workflow item, but found " + itemType);
+            }
             return expression;
+        }
+
+        /**
+         * Returns the input value or throws an exception if it does not contain an input.
+         *
+         * @return the input value or throws an exception if it does not contain an input
+         */
+        public Input getInput() {
+            if (itemType != ItemType.INPUT) {
+                throw new IllegalArgumentException(
+                        "Expected an input workflow item, but found " + itemType);
+            }
+            return input;
+        }
+
+        /**
+         * Returns the type of item.
+         *
+         * @return the type of item
+         */
+        public ItemType getItemType() {
+            return itemType;
+        }
+
+        /**
+         * Returns the expression value as a list.
+         *
+         * @return the expression value as a list.
+         */
+        public List<Item> getList() {
+            if (itemType != ItemType.EXPRESSION) {
+                throw new IllegalArgumentException(
+                        "Expected an expression/list workflow item, but found " + itemType);
+            }
+            return expression.getArgs();
+        }
+
+        /** The type of contents stored in the item. */
+        public enum ItemType {
+            STRING,
+            EXPRESSION,
+            INPUT
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/workflow/function/EnsembleMerge.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/EnsembleMerge.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function;
+
+import ai.djl.modality.Output;
+import ai.djl.ndarray.BytesSupplier;
+import ai.djl.serving.workflow.Workflow.WorkflowArgument;
+import ai.djl.serving.workflow.Workflow.WorkflowExecutor;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+import ai.djl.translate.Ensembleable;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Workflow function "ensemble" accepts a list of {@link Ensembleable} outputs and merges them using
+ * {@link Ensembleable#ensemble(List)}.
+ */
+public class EnsembleMerge extends WorkflowFunction {
+
+    public static final String NAME = "ensemble";
+
+    /** {@inheritDoc} */
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public CompletableFuture<Item> run(WorkflowExecutor executor, List<WorkflowArgument> args) {
+        if (args.size() != 1) {
+            throw new IllegalArgumentException(
+                    "Expected one arguments, the list of items to ensemble");
+        }
+
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    List<Ensembleable> outputs =
+                            args.get(0).evaluate().join().getList().stream()
+                                    .map(i -> (Ensembleable<?>) i.getInput().get(0))
+                                    .collect(Collectors.toList());
+
+                    Ensembleable<?> ensembled = Ensembleable.ensemble(outputs);
+                    Output output = new Output();
+                    output.add((BytesSupplier) ensembled);
+                    return new Item(output);
+                });
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/FunctionsApply.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/FunctionsApply.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function;
+
+import ai.djl.serving.workflow.Workflow.WorkflowArgument;
+import ai.djl.serving.workflow.Workflow.WorkflowExecutor;
+import ai.djl.serving.workflow.WorkflowExpression;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Workflow function "functionsApply" accepts a list of functions and an input and applies each
+ * function to the input.
+ *
+ * <p>It returns a list of the results of applying each function to the input.
+ */
+public class FunctionsApply extends WorkflowFunction {
+
+    public static final String NAME = "functionsApply";
+
+    /** {@inheritDoc} */
+    @Override
+    @SuppressWarnings("unchecked")
+    public CompletableFuture<Item> run(WorkflowExecutor executor, List<WorkflowArgument> args) {
+        if (args.size() != 2) {
+            throw new IllegalArgumentException(
+                    "Expected two arguments: the list of functions to run and the input, but found "
+                            + args.size());
+        }
+        List<Item> fns = args.get(0).getItem().getList();
+        Item input = args.get(1).getItem();
+
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    // Get classifications
+                    CompletableFuture<Item>[] futures =
+                            fns.stream()
+                                    .map(
+                                            fn ->
+                                                    executor.executeExpression(
+                                                            new WorkflowExpression(fn, input)))
+                                    .toArray(CompletableFuture[]::new);
+                    CompletableFuture.allOf(futures);
+                    List<Item> outputs =
+                            Arrays.stream(futures).map(m -> m.join()).collect(Collectors.toList());
+
+                    return new Item(new WorkflowExpression(outputs));
+                });
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/IdentityWF.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/IdentityWF.java
@@ -12,18 +12,20 @@
  */
 package ai.djl.serving.workflow.function;
 
-import ai.djl.modality.Input;
 import ai.djl.serving.workflow.Workflow;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-/** An identity function which passes back it's input. */
+/** Workflow function "id" accepts a single argument and returns the result of evaluating it. */
 public class IdentityWF extends WorkflowFunction {
+
+    public static final String NAME = "id";
 
     /** {@inheritDoc} */
     @Override
-    public CompletableFuture<Input> run(
+    public CompletableFuture<Item> run(
             Workflow.WorkflowExecutor executor, List<Workflow.WorkflowArgument> args) {
         if (args.size() != 1) {
             throw new IllegalArgumentException("Expected one argument to id");

--- a/serving/src/main/java/ai/djl/serving/workflow/function/ModelWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/ModelWorkflowFunction.java
@@ -17,6 +17,7 @@ import ai.djl.modality.Output;
 import ai.djl.serving.wlm.Job;
 import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.workflow.Workflow;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +39,7 @@ public class ModelWorkflowFunction extends WorkflowFunction {
     /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
-    public CompletableFuture<Input> run(
+    public CompletableFuture<Item> run(
             Workflow.WorkflowExecutor executor, List<Workflow.WorkflowArgument> args) {
         if (args.size() != 1) {
             throw new IllegalArgumentException(
@@ -52,7 +53,7 @@ public class ModelWorkflowFunction extends WorkflowFunction {
                 .thenComposeAsync(
                         processedArgs ->
                                 executor.getWlm()
-                                        .runJob(new Job<>(model, processedArgs.get(0)))
-                                        .thenApply(o -> o));
+                                        .runJob(new Job<>(model, processedArgs.get(0).getInput()))
+                                        .thenApply(Item::new));
     }
 }

--- a/serving/src/main/java/ai/djl/serving/workflow/function/WorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/WorkflowFunction.java
@@ -12,8 +12,8 @@
  */
 package ai.djl.serving.workflow.function;
 
-import ai.djl.modality.Input;
 import ai.djl.serving.workflow.Workflow;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public abstract class WorkflowFunction {
      * @param args the list of function arguments
      * @return a future containing the input
      */
-    public abstract CompletableFuture<Input> run(
+    public abstract CompletableFuture<Item> run(
             Workflow.WorkflowExecutor executor, List<Workflow.WorkflowArgument> args);
 
     /**
@@ -44,8 +44,8 @@ public abstract class WorkflowFunction {
      * @return a future with the list of evaluated arguments
      */
     @SuppressWarnings("unchecked")
-    protected CompletableFuture<List<Input>> evaluateArgs(List<Workflow.WorkflowArgument> args) {
-        CompletableFuture<Input>[] processedArgs =
+    protected CompletableFuture<List<Item>> evaluateArgs(List<Workflow.WorkflowArgument> args) {
+        CompletableFuture<Item>[] processedArgs =
                 args.stream()
                         .map(Workflow.WorkflowArgument::evaluate)
                         .toArray(CompletableFuture[]::new);

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -103,6 +103,12 @@ public class WorkflowTest {
         Assert.assertEquals(m.getBatchSize(), 3);
     }
 
+    @Test
+    public void testEnsemble() throws IOException, BadWorkflowException {
+        Path workflowFile = Paths.get("src/test/resources/workflows/ensemble.json");
+        runWorkflow(workflowFile, zeroInput);
+    }
+
     private Input runWorkflow(Path workflowFile, Input input)
             throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();

--- a/serving/src/test/resources/workflows/ensemble.json
+++ b/serving/src/test/resources/workflows/ensemble.json
@@ -1,0 +1,10 @@
+{
+  "models": {
+    "m1": "https://resources.djl.ai/test-models/mlp.tar.gz",
+    "m2": "https://resources.djl.ai/test-models/mlp.tar.gz",
+    "m3": "https://resources.djl.ai/test-models/mlp.tar.gz"
+  },
+  "workflow": {
+    "out": ["ensemble", ["functionsApply",["m1", "m2", "m3"], "in"]]
+  }
+}


### PR DESCRIPTION
This creates a test for an ensemble workflow. As part of it, it also modifies the workflow expression evaluation to return an Item instead of an Input. This is primarily so that a list can be returned. It is useful for more logical or control flow functions like map, filter, functionsApply, etc.

It also creates two new built-ins: ensemble and functionsApply.

Lastly, the dependency on Ensembleable means that the current version of DJL Serving must depend on DJL 0.20.0 (including as snapshot).