### PR TITLE
Reorganize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,92 +76,8 @@ docker run -itd -p 8080:8080 deepjavalibrary/djl-serving
 
 ## Usage
 
-### Sample Usage
-
-Use the following command to start model server locally:
-
-```sh
-djl-serving
-```
-
-The model server will be listening on port 8080. You can also load a model for serving on start up:
-
-```sh
-djl-serving -m "https://resources.djl.ai/demo/mxnet/resnet18_v1.zip"
-```
-
-Open another terminal, and type the following command to test the inference REST API:
-
-```sh
-curl -O https://resources.djl.ai/images/kitten.jpg
-curl -X POST http://localhost:8080/predictions/resnet18_v1 -T kitten.jpg
-
-or:
-
-curl -X POST http://localhost:8080/predictions/resnet18_v1 -F "data=@kitten.jpg"
-
-[
-  {
-    "className": "n02123045 tabby, tabby cat",
-    "probability": 0.4838452935218811
-  },
-  {
-    "className": "n02123159 tiger cat",
-    "probability": 0.20599420368671417
-  },
-  {
-    "className": "n02124075 Egyptian cat",
-    "probability": 0.18810515105724335
-  },
-  {
-    "className": "n02123394 Persian cat",
-    "probability": 0.06411745399236679
-  },
-  {
-    "className": "n02127052 lynx, catamount",
-    "probability": 0.010215568356215954
-  }
-]
-```
-
-### Examples for loading models
-
-```shell
-# Load models from the DJL model zoo on startup
-djl-serving -m "djl://ai.djl.pytorch/resnet"
-
-# Load version v1 of a PyTorch model on GPU(0) from the local file system
-djl-serving -m "resnet:v1:PyTorch:0=file:$HOME/models/pytorch/resnet18/"
-
-# Load a TensorFlow model from TFHub
-djl-serving -m "resnet=https://tfhub.dev/tensorflow/resnet_50/classification/1"
-```
-
-### Examples for customizing data processing
-
-```shell
-# Use the default data processing for a well-known application
-djl-serving -m "file:/resnet?application=CV/image_classification"
-
-# Specify a custom data processing with a Translator
-djl-serving -m "file:/resnet?translatorFactory=MyFactory"
-
-## Pass parameters for data processing
-djl-serving -m "djl://ai.djl.pytorch/resnet?applySoftmax=false"
-```
-
-### Using DJL Extensions
-
-```shell
-# Load a model from an AWS S3 Bucket
-djl-serving -m "s3://djl-ai/demo/resnet/resnet18.zip"
-
-# Load a model from HDFS
-djl-serving -m "hdfs://localhost:50070/models/pytorch/resnet18/"
-
-# Use a HuggingFace tokenizer
-djl-serving -m "file:/resnet?transaltorFactory=ai.djl.huggingface.BertQATranslator"
-```
+DJL Serving can be started from the command line.
+To see examples, see the [starting page](serving/docs/starting.md).
 
 ### More examples
 
@@ -197,14 +113,7 @@ Please see [DJL Serving Configuration](serving/docs/configuration.md) for how to
 
 ## Architecture
 
-DJL serving is built on top of [Deep Java Library](https://djl.ai). You can visit the
-[DJL github repository](https://github.com/deepjavalibrary/djl) to learn more.
-
-It is also possible to leverage only the worker thread pool using the separate [WorkLoadManager](wlm) module.
-The separate WorkLoadManager can be used to take advantage of DJL serving's model batching
-and threading and integrate it into a custom Java service.
-
-![Architecture Diagram](https://resources.djl.ai/images/djl-serving/architecture.png)
+Details about how DJL Serving is implemented can be found in the [architecture docs](serving/docs/architecture.md).
 
 # Plugin management
 

--- a/serving/docs/architecture.md
+++ b/serving/docs/architecture.md
@@ -1,0 +1,18 @@
+# DJL Serving Architecture
+
+DJL serving is built on top of [Deep Java Library](https://djl.ai). You can visit the
+[DJL github repository](https://github.com/deepjavalibrary/djl) to learn more.
+
+DJL Serving uses a [Netty](https://netty.io/) frontend on top of backend worker thread pools.
+The frontend uses a single Netty setup with multiple [HttpRequestHandler](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/HttpRequestHandler.html)s.
+Different request handlers will provide support for the [inference API](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/InferenceRequestHandler.html), [Management API](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/ManagementRequestHandler.html), or other APIs available from various plugins.
+
+The backend is based around the [WorkLoadManager](../../wlm/README.md) module.
+The WLM takes care of multiple worker threads for each model along with the batching and request routing to them.
+It is also available separately and can be utilized through the WLM module (`ai.djl.serving:wlm`).
+
+Within each worker thread inside the WLM, there is a DJL Predictor.
+Depending on what Engine the Predictor is, it can run various models such as those from PyTorch, Tensorflow, XGBoost, or any of the other engines supported by DJL.
+Notably, there is also a [Python Engine](../../engines/python/README.md) which can be used to run models, preprocessing, and postprocessing defined in a python script.
+
+![Architecture Diagram](https://resources.djl.ai/images/djl-serving/architecture.png)

--- a/serving/docs/starting.md
+++ b/serving/docs/starting.md
@@ -1,0 +1,86 @@
+# Starting DJL Serving
+
+Use the following command to start model server locally:
+
+```sh
+djl-serving
+```
+
+The model server will be listening on port 8080. You can also load a model for serving on start up:
+
+```sh
+djl-serving -m "https://resources.djl.ai/demo/mxnet/resnet18_v1.zip"
+```
+
+Open another terminal, and type the following command to test the inference REST API:
+
+```sh
+curl -O https://resources.djl.ai/images/kitten.jpg
+curl -X POST http://localhost:8080/predictions/resnet18_v1 -T kitten.jpg
+
+or:
+
+curl -X POST http://localhost:8080/predictions/resnet18_v1 -F "data=@kitten.jpg"
+
+[
+  {
+    "className": "n02123045 tabby, tabby cat",
+    "probability": 0.4838452935218811
+  },
+  {
+    "className": "n02123159 tiger cat",
+    "probability": 0.20599420368671417
+  },
+  {
+    "className": "n02124075 Egyptian cat",
+    "probability": 0.18810515105724335
+  },
+  {
+    "className": "n02123394 Persian cat",
+    "probability": 0.06411745399236679
+  },
+  {
+    "className": "n02127052 lynx, catamount",
+    "probability": 0.010215568356215954
+  }
+]
+```
+
+### Examples for loading models
+
+```shell
+# Load models from the DJL model zoo on startup
+djl-serving -m "djl://ai.djl.pytorch/resnet"
+
+# Load version v1 of a PyTorch model on GPU(0) from the local file system
+djl-serving -m "resnet:v1:PyTorch:0=file:$HOME/models/pytorch/resnet18/"
+
+# Load a TensorFlow model from TFHub
+djl-serving -m "resnet=https://tfhub.dev/tensorflow/resnet_50/classification/1"
+```
+
+### Examples for customizing data processing
+
+```shell
+# Use the default data processing for a well-known application
+djl-serving -m "file:/resnet?application=CV/image_classification"
+
+# Specify a custom data processing with a Translator
+djl-serving -m "file:/resnet?translatorFactory=MyFactory"
+
+## Pass parameters for data processing
+djl-serving -m "djl://ai.djl.pytorch/resnet?applySoftmax=false"
+```
+
+### Using DJL Extensions
+
+```shell
+# Load a model from an AWS S3 Bucket
+djl-serving -m "s3://djl-ai/demo/resnet/resnet18.zip"
+
+# Load a model from HDFS
+djl-serving -m "hdfs://localhost:50070/models/pytorch/resnet18/"
+
+# Use a HuggingFace tokenizer
+djl-serving -m "file:/resnet?transaltorFactory=ai.djl.huggingface.BertQATranslator"
+```


### PR DESCRIPTION
Reorganizes the docs to separate the starting and architecture pages. This gives them more room to grow and can be cleaner from the new docs section.

Related to https://github.com/deepjavalibrary/djl/pull/2100