### PR TITLE
[serving] Sets default ONNXRuntime OMP threads to 1

### DIFF
--- a/benchmark/src/main/java/ai/djl/benchmark/Benchmark.java
+++ b/benchmark/src/main/java/ai/djl/benchmark/Benchmark.java
@@ -107,6 +107,12 @@ public final class Benchmark extends AbstractBenchmark {
             if (System.getProperty("ai.djl.pytorch.num_threads") == null) {
                 System.setProperty("ai.djl.pytorch.num_threads", "1");
             }
+            if (System.getProperty("ai.djl.onnxruntime.num_interop_threads") == null) {
+                System.setProperty("ai.djl.pytorch.num_interop_threads", "1");
+            }
+            if (System.getProperty("ai.djl.onnxruntime.num_threads") == null) {
+                System.setProperty("ai.djl.onnxruntime.num_threads", "1");
+            }
         }
         if (System.getProperty("ai.djl.tflite.disable_alternative") == null) {
             System.setProperty("ai.djl.tflite.disable_alternative", "true");

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -136,6 +136,12 @@ public final class ConfigManager {
                 && Utils.getenv("OMP_NUM_THREADS") == null) {
             System.setProperty("ai.djl.pytorch.num_threads", "1");
         }
+        if (System.getProperty("ai.djl.onnxruntime.num_interop_threads") == null) {
+            System.setProperty("ai.djl.pytorch.num_interop_threads", "1");
+        }
+        if (System.getProperty("ai.djl.onnxruntime.num_threads") == null) {
+            System.setProperty("ai.djl.onnxruntime.num_threads", "1");
+        }
         if (System.getProperty("log4j2.contextSelector") == null) {
             // turn on async logging by default
             System.setProperty(


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
