### PR TITLE
[Integration] make 6 min timeout per model

### DIFF
--- a/serving/docker/scripts/security_patch.sh
+++ b/serving/docker/scripts/security_patch.sh
@@ -5,9 +5,9 @@ IMAGE_NAME=$1
 apt-get update
 
 if [[ "$IMAGE_NAME" == "deepspeed" ]]; then
-  apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0
+  apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0 libdbus-1-3 curl
 elif [[ "$IMAGE_NAME" == "pytorch-cu113" ]]; then
-  apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0 libsepol1
+  apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0 libsepol1 libdbus-1-3 curl
 elif [[ "$IMAGE_NAME" == "cpu" ]]; then
-  apt-get upgrade -y libpcre2-8-0
+  apt-get upgrade -y libpcre2-8-0 libdbus-1-3 curl
 fi

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -40,7 +40,7 @@ while true; do
     echo "DJL serving started"
     break
   fi
-  if [[ "$retry" -ge 8 ]]; then
+  if [[ "$retry" -ge 24 ]]; then
     echo "Max retry exceeded."
     exit 1
   fi


### PR DESCRIPTION
## Description ##

6 min is the default DJL model loading timeout, just make it consistent with test. 2 min seemed to be too tight
