### PR TITLE
fix typo in Pymodel mpi log

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -160,7 +160,7 @@ public class PyModel extends BaseModel {
                 }
                 pyEnv.setTensorParallelDegree(partitions);
             }
-            logger.info("Loading model in MPI model with TP: {}.", partitions);
+            logger.info("Loading model in MPI mode with TP: {}.", partitions);
 
             int mpiWorkers = pyEnv.getMpiWorkers();
             if (mpiWorkers <= 0) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
