### PR TITLE
feat: update deepspeed version to hosted deepspeed wheel

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -14,7 +14,7 @@ FROM nvidia/cuda:$version
 ARG djl_version=0.20.0~SNAPSHOT
 ARG torch_version=1.12.1
 ARG accelerate_version=0.13.2
-ARG deepspeed_version=0.7.5
+ARG deepspeed_wheel="https://djl-misc.s3.amazonaws.com/deepspeed/deepspeed-0.7.5%2Bbf16-py2.py3-none-any.whl"
 ARG transformers_version=4.23.1
 
 EXPOSE 8080
@@ -44,7 +44,8 @@ RUN apt-get update && \
     scripts/install_s5cmd.sh x64 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu116 && \
-    pip3 install deepspeed==${deepspeed_version} transformers==${transformers_version} && \
+    pip3 install ${deepspeed_wheel} &&  \
+    pip3 install transformers==${transformers_version} && \
     pip3 install triton==1.0.0 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh deepspeed && \


### PR DESCRIPTION
## Description ##

Updating the dockerfile to point to the deepspeed wheel hosted on s3.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
