### PR TITLE
[docker] Update PyTorch/TensorFlow version

### DIFF
--- a/serving/docker/Dockerfile
+++ b/serving/docker/Dockerfile
@@ -37,7 +37,8 @@ ENV TF_CPP_MIN_LOG_LEVEL=1
 ENV JAVA_OPTS="-Xmx1g -Xms1g -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError"
 ENV MODEL_SERVER_HOME=/opt/djl
 
-RUN useradd -m -d /home/djl djl
+RUN useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl
 
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
@@ -48,7 +49,7 @@ LABEL com.amazonaws.ml.engines.sagemaker.dlc.framework.djl.cpu="true"
 
 FROM base AS cpu-full
 
-ARG torch_version=1.12.1
+ARG torch_version=1.13.0
 
 COPY scripts scripts/
 RUN scripts/install_python.sh && \
@@ -56,8 +57,10 @@ RUN scripts/install_python.sh && \
     echo "${djl_version} cpufull" > /opt/djl/bin/telemetry && \
     djl-serving -i ai.djl.mxnet:mxnet-native-mkl:1.9.1:linux-x86_64 && \
     djl-serving -i ai.djl.pytorch:pytorch-native-cpu:$torch_version:linux-x86_64 && \
-    djl-serving -i ai.djl.tensorflow:tensorflow-native-cpu:2.7.0:linux-x86_64 && \
+    djl-serving -i ai.djl.tensorflow:tensorflow-native-cpu:2.7.4:linux-x86_64 && \
     scripts/patch_oss_dlc.sh python && \
+    rm -rf /opt/djl/logs && \
+    chown -R djl:djl /opt/djl && \
     rm -rf scripts && pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* \
 

--- a/serving/docker/aarch64.Dockerfile
+++ b/serving/docker/aarch64.Dockerfile
@@ -11,7 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 FROM arm64v8/ubuntu:20.04
 ARG djl_version=0.20.0~SNAPSHOT
-ARG torch_version=1.12.1
+ARG torch_version=1.13.0
 
 EXPOSE 8080
 
@@ -23,8 +23,6 @@ ENV OMP_NUM_THREADS=1
 ENV JAVA_OPTS="-Xmx1g -Xms1g -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError -Dai.djl.default_engine=PyTorch"
 ENV MODEL_SERVER_HOME=/opt/djl
 
-RUN useradd -m -d /home/djl djl
-
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
 
@@ -33,7 +31,7 @@ RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/djl/deps
 COPY config.properties /opt/djl/conf/
 
-RUN scripts/install_djl_serving.sh $djl_version && \
+RUN scripts/install_djl_serving.sh $djl_version $torch_version && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     echo "${djl_version} aarch" > /opt/djl/bin/telemetry && \
     scripts/install_djl_serving.sh $djl_version $torch_version && \
@@ -42,6 +40,9 @@ RUN scripts/install_djl_serving.sh $djl_version && \
     rm -f /usr/local/djl-serving-*/lib/mxnet-* && \
     rm -f /usr/local/djl-serving-*/lib/tensorflow-* && \
     rm -f /usr/local/djl-serving-*/lib/tensorrt-* && \
+    rm -rf /opt/djl/logs && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
     rm -rf scripts && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -29,8 +29,6 @@ ENV MODEL_SERVER_HOME=/opt/djl
 ENV MODEL_LOADING_TIMEOUT=1200
 ENV PREDICT_TIMEOUT=240
 
-RUN useradd -m -d /home/djl djl
-
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
 
@@ -53,6 +51,8 @@ RUN apt-get update && \
     pip3 install diffusers[torch]==${diffusers_version} && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh deepspeed && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
     rm -rf scripts && \
     pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/serving/docker/paddle-cu112.Dockerfile
+++ b/serving/docker/paddle-cu112.Dockerfile
@@ -22,6 +22,8 @@ RUN scripts/install_djl_serving.sh $djl_version && \
     echo "${djl_version} paddlegpu" > /opt/djl/bin/telemetry && \
     scripts/security_patch.sh pytorch-cu117 && \
     scripts/patch_oss_dlc.sh python && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
     rm -rf scripts
 
@@ -35,8 +37,6 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV OMP_NUM_THREADS=1
 ENV JAVA_OPTS="-Xmx1g -Xms1g -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError"
 ENV MODEL_SERVER_HOME=/opt/djl
-
-RUN useradd -m -d /home/djl djl
 
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]

--- a/serving/docker/pytorch-cu117.Dockerfile
+++ b/serving/docker/pytorch-cu117.Dockerfile
@@ -30,8 +30,6 @@ ENV PYTORCH_VERSION=${torch_version}
 ENV PYTORCH_FLAVOR=cu117-precxx11
 ENV JAVA_OPTS="-Xmx1g -Xms1g -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError -Dai.djl.default_engine=PyTorch"
 
-RUN useradd -m -d /home/djl djl
-
 COPY scripts scripts/
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh && \
     scripts/install_djl_serving.sh $djl_version && \
@@ -43,8 +41,11 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh && \
     pip3 install numpy && pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu117 && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh pytorch-cu117 && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
     rm -rf scripts && pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
 
 EXPOSE 8080
 

--- a/serving/docker/pytorch-inf1.Dockerfile
+++ b/serving/docker/pytorch-inf1.Dockerfile
@@ -31,8 +31,6 @@ ENV PYTORCH_PRECXX11=true
 ENV PYTORCH_VERSION=1.12.1
 ENV JAVA_OPTS="-Xmx1g -Xms1g -Xss2m -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError -Dai.djl.default_engine=PyTorch"
 
-RUN useradd -m -d /home/djl djl
-
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
 
@@ -47,6 +45,8 @@ RUN scripts/install_djl_serving.sh $djl_version && \
     scripts/install_inferentia.sh && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh pytorch-inf1 && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
     rm -rf scripts && pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/serving/docker/scripts/install_djl_serving.sh
+++ b/serving/docker/scripts/install_djl_serving.sh
@@ -23,9 +23,7 @@ if [ -z "$PYTORCH_JNI" ]; then
   cp -r /usr/local/djl-serving-*/plugins /opt/djl/plugins
 else
   if [[ ! "$DJL_VERSION" == *SNAPSHOT ]]; then
-    # TODO: remove hack in 0.20.0
-    mkdir -p /root/.djl.ai/pytorch/${PYTORCH_JNI}-cpu-precxx11-linux-x86_64/
-    mkdir -p /root/.djl.ai/pytorch/${PYTORCH_JNI}-cu116-precxx11-linux-x86_64/
     djl-serving -i ai.djl.pytorch:pytorch-jni:${PYTORCH_JNI}-${DJL_VERSION}
+    rm -rf /opt/djl/logs
   fi
 fi


### PR DESCRIPTION
1. Upgrades PyTorch to 1.13.0
2. Upgrades TensorFlow to 2.7.4
3. Removes dandling logs in docker
4. Removes 0.19.0 workaround
5. Fixes /opt/djl folder permission

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
