### PR TITLE
fix issue in sd handler with data type

### DIFF
--- a/engines/python/setup/djl_python/stable-diffusion.py
+++ b/engines/python/setup/djl_python/stable-diffusion.py
@@ -61,8 +61,7 @@ class StableDiffusionService(object):
             # TODO: Figure out why cuda graph doesn't work for stable diffusion via DS
             "enable_cuda_graph": False,
             "replace_method": "auto",
-            "dtype":
-            torch.float16 if self.data_type == "fp16" else torch.float32,
+            "dtype": self.data_type,
             "mp_size": self.tensor_parallel_degree
         }
 
@@ -76,7 +75,7 @@ class StableDiffusionService(object):
             self.model_id = self.model_dir
 
         kwargs = {}
-        if self.data_type == "fp16":
+        if self.data_type == torch.float16:
             kwargs["torch_dtype"] = torch.float16
             kwargs["revision"] = "fp16"
 


### PR DESCRIPTION
## Description ##

It seems like the type check used for self.data_type to determine kwargs was incorrect, leading to pipeline being initialized as one data type, and ds inference trying to use another data type (always defaults to fp32). This should fix that issue and use the data type the user provides.

Before this change, model would start fine, but during inference there is an issue with invoking a triton op due to mismatched data type. Tested this change on g5 and it should work as expected.
