### PR TITLE
Fix fp32 issues with DS fork wheel for stable diffusion, fix llm tests

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests
+        run: pip3 install requests pillow
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh deepspeed ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -177,6 +177,15 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
           python3 llm/client.py stable-diffusion stable-diffusion-v1-4
+          docker rm -f $(docker ps -aq)
+      - name: Test stable-diffusion-v1-5
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py stable-diffusion stable-diffusion-v1-5
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          serve
+          python3 llm/client.py stable-diffusion stable-diffusion-v1-5
           docker rm -f $(docker ps -aq)
       - name: Test bloom-7b
         working-directory: tests/integration

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -69,6 +69,11 @@ sd_handler_list = {
         "option.tensor_parallel_degree": 2,
         "option.dtype": "fp16"
     },
+    "stable-diffusion-v1-5": {
+        "option.s3url": "s3://djl-llm/stable-diffusion-v1-5/",
+        "option.tensor_parallel_degree": 4,
+        "option.dtype": "fp32"
+    },
 }
 
 


### PR DESCRIPTION
## Description ##

1. Fix issues with fp32 dtype for stable diffusion via deepspeed. There are 2 things that get fixed:
    - If dtype is not specified (i.e. None) when passed to ds init inference and `replace_with_kernel_inject=True` and `replace_method='auto'`, then ds will invoke fp16 layers and fused kernels. If fp32 is specified with the same configurations otherwise, there will be an error due to not having fused kernels/layers to replace with (fp32 kernels for stable-diffusion layers are not implemented in ds 0.7.5)
    - In our fork with bf16, due to some logic changes about replacing layers, there is an error in the case dtype=None rather than silently failing and using fp16 like the original deepspeed behavior
    - Stable diffusion kernels for fp32, as well as some ops not being set for layer replacement seem to be partially fixed in 0.7.6, and actively being worked on for 0.7.7
2. Fixes the issues with llm integration tests
  - workflow run with the changes introduced in this PR https://github.com/deepjavalibrary/djl-serving/actions/runs/3671873469/jobs/6207526726
  - adds check to make sure image can be decoded by client (validate image)
