### PR TITLE
Add better logging and error handling for s5cmd process execution

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -317,11 +317,14 @@ public class PyModel extends BaseModel {
                 logger.info("s5cmd is not installed, using aws cli");
                 commands = new String[] {"aws", "s3", "sync", url, downloadDir};
             }
-            Process exec = Runtime.getRuntime().exec(commands);
+            Process exec = new ProcessBuilder(commands).redirectErrorStream(true).start();
             try (InputStream is = exec.getInputStream()) {
                 logger.debug(Utils.toString(is));
             }
-            exec.waitFor();
+            int exitCode = exec.waitFor();
+            if (0 != exitCode) {
+                throw new IOException("s5cmd failed. View the debug logs for details");
+            }
             logger.info("Download completed! Files saved to {}", downloadDir);
         } catch (IOException | InterruptedException e) {
             throw new EngineException("Model failed to download from s3", e);


### PR DESCRIPTION
## Description ##

Minor improvements to s5cmd process execution. Unfortunately, s5cmd does not return non-zero exit codes for every failure (like no credentials found). Alternatively we could process stdout and stderr separately, and if stderr is nonempty we assume ERROR and throw an exception. 

For now, all output will be logged and when s5cmd returns non-zero exit code we'll fail.
