### PR TITLE
[ci] Upgrades testng version to 7.7.0 to fix CVE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ slf4j_version=1.7.36
 log4j_slf4j_version=2.19.0
 snakeyaml_version=1.33
 disruptor_version=3.4.4
-testng_version=7.6.1
+testng_version=7.7.0


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
