### PR TITLE
[docker] Upgrade PyTorch to 1.13.1

### DIFF
--- a/serving/docker/Dockerfile
+++ b/serving/docker/Dockerfile
@@ -49,7 +49,7 @@ LABEL com.amazonaws.ml.engines.sagemaker.dlc.framework.djl.cpu="true"
 
 FROM base AS cpu-full
 
-ARG torch_version=1.13.0
+ARG torch_version=1.13.1
 
 COPY scripts scripts/
 RUN scripts/install_python.sh && \

--- a/serving/docker/aarch64.Dockerfile
+++ b/serving/docker/aarch64.Dockerfile
@@ -11,7 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 FROM arm64v8/ubuntu:20.04
 ARG djl_version=0.21.0~SNAPSHOT
-ARG torch_version=1.13.0
+ARG torch_version=1.13.1
 
 EXPOSE 8080
 

--- a/serving/docker/pytorch-cu117.Dockerfile
+++ b/serving/docker/pytorch-cu117.Dockerfile
@@ -14,7 +14,7 @@ ARG version=11.7.1-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:$version as base
 
 ARG djl_version=0.21.0~SNAPSHOT
-ARG torch_version=1.13.0
+ARG torch_version=1.13.1
 
 RUN mkdir -p /opt/djl/conf
 COPY config.properties /opt/djl/conf/


### PR DESCRIPTION
DeepSpeed and inf1 is still on 1.12.1

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
