### PR TITLE
copy gemm config computation binaries to sys directory

### DIFF
--- a/serving/docker/fastertransformer.Dockerfile
+++ b/serving/docker/fastertransformer.Dockerfile
@@ -65,6 +65,8 @@ RUN git clone https://github.com/NVIDIA/FasterTransformer.git -b ${ft_version} \
     && make -j${nproc} install \
     && rm -rf lib/*TritonBackend.so \
     && cp lib/*.so /usr/local/backends/fastertransformer/ \
+    && mkdir /usr/local/backends/fastertransformer/bin \
+    && cp -r bin/*_gemm /usr/local/backends/fastertransformer/bin/ \
     && cd ../../ && rm -rf FasterTransformer
 
 # TODO: Add DLC patching

--- a/serving/docker/fastertransformer.Dockerfile
+++ b/serving/docker/fastertransformer.Dockerfile
@@ -65,7 +65,7 @@ RUN git clone https://github.com/NVIDIA/FasterTransformer.git -b ${ft_version} \
     && make -j${nproc} install \
     && rm -rf lib/*TritonBackend.so \
     && cp lib/*.so /usr/local/backends/fastertransformer/ \
-    && mkdir /usr/local/backends/fastertransformer/bin \
+    && mkdir -p /usr/local/backends/fastertransformer/bin \
     && cp -r bin/*_gemm /usr/local/backends/fastertransformer/bin/ \
     && cd ../../ && rm -rf FasterTransformer
 


### PR DESCRIPTION
## Description ##

Copy gemm config binaries generated during build to system directory.

FasterTransformer suggests to run these binaries like for e.g
`./bin/t5_gemm 8 4 32 512 8 64 2048 512 8 64 2048 32128 0 2 1` to
generate the best GEMM configuration for a given model config and record the configuration into the gemm_config.in file. This change packages these binaries in the container to give users option to run these optimization.

Without running this, FT throws a warning: `[WARNING] gemm_config.in is not found; using default GEMM algo`
