### PR TITLE
Fix issue with passing dtype in huggingface handler. Refactor dtype_f…

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -111,14 +111,13 @@ def get_torch_dtype_from_str(dtype: str):
         return torch.float32
     if dtype == "fp16":
         return torch.float16
-    elif dtype == "bf16":
+    if dtype == "bf16":
         return torch.bfloat16
-    elif dtype == "int8":
+    if dtype == "int8":
         return torch.int8
-    elif dtype is None:
+    if dtype is None:
         return None
-    else:
-        raise ValueError(f"Invalid data type: {dtype}")
+    raise ValueError(f"Invalid data type: {dtype}")
 
 
 class DeepSpeedService(object):

--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -40,6 +40,22 @@ ARCHITECTURES_2_TASK = {
 }
 
 
+def get_torch_dtype_from_str(dtype: str):
+    if dtype == "auto":
+        return dtype
+    if dtype == "fp32":
+        return torch.float32
+    if dtype == "fp16":
+        return torch.float16
+    if dtype == "bf16":
+        return torch.bfloat16
+    if dtype == "int8":
+        return torch.int8
+    if dtype is None:
+        return None
+    raise ValueError(f"Invalid data type: {dtype}")
+
+
 class HuggingFaceService(object):
 
     def __init__(self):
@@ -72,7 +88,7 @@ class HuggingFaceService(object):
             kwargs["low_cpu_mem_usage"] = properties.get("low_cpu_mem_usage")
 
         if "dtype" in properties:
-            kwargs["torch_dtype"] = properties.get("dtype")
+            kwargs["torch_dtype"] = get_torch_dtype_from_str(properties.get("dtype"))
         if task:
             self.hf_pipeline = self.get_pipeline(task=task,
                                                  model_id=model_id,

--- a/engines/python/setup/djl_python/stable-diffusion.py
+++ b/engines/python/setup/djl_python/stable-diffusion.py
@@ -26,10 +26,9 @@ def get_torch_dtype_from_str(dtype: str):
         return torch.float32
     if dtype == "fp16":
         return torch.float16
-    elif dtype is None:
+    if dtype is None:
         return None
-    else:
-        raise ValueError(f"Invalid data type: {dtype}")
+    raise ValueError(f"Invalid data type: {dtype}")
 
 
 class StableDiffusionService(object):

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -32,7 +32,8 @@ hf_handler_list = {
         "option.s3url": "s3://djl-llm/gpt-j-6b/",
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 2,
-        "option.device_map": "auto"
+        "option.device_map": "auto",
+        "option.dtype": "fp16"
     },
     "bloom-7b1": {
         "option.s3url": "s3://djl-llm/bloom-7b1/",


### PR DESCRIPTION
## Description ##

If user provides `option.dtype`, we are passing the string to the `pipeline` and `AutoModel.from_pretrained` methods. This causes an error ```ValueError: `torch_dtype` can be either a `torch.dtype` or `auto`, but received fp16```. 

This fixes the issue with dtype in huggingface handler, and refactors the methods in all handlers that convert str to torch.dtype.

A test is modified to verify this behavior works as expected.


