### PR TITLE
Update python handlers for deepspeed 0.8.0

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -120,13 +120,9 @@ class HuggingFaceService(object):
 
             input_map = decode(inputs, content_type)
             data = input_map.pop("inputs", input_map)
-            parameters = input_map.pop("parameters", None)
+            parameters = input_map.pop("parameters", {})
 
-            # pass inputs with all kwargs in data
-            if parameters is not None:
-                prediction = self.hf_pipeline(data, **parameters)
-            else:
-                prediction = self.hf_pipeline(data)
+            prediction = self.hf_pipeline(data, **parameters)
 
             outputs = Output()
             encode(outputs, prediction, accept)

--- a/engines/python/setup/djl_python/stable-diffusion.py
+++ b/engines/python/setup/djl_python/stable-diffusion.py
@@ -102,7 +102,7 @@ class StableDiffusionService(object):
             if content_type == "application/json":
                 request = inputs.get_as_json()
                 prompt = request.pop("prompt")
-                params = request.pop("parameters")
+                params = request.pop("parameters", {})
                 result = self.pipeline(prompt, **params)
             else:
                 prompt = inputs.get_as_string()

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -14,8 +14,7 @@ FROM nvidia/cuda:$version
 ARG djl_version=0.21.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG accelerate_version=0.16.0
-# This needs to be added once available in s3
-ARG deepspeed_wheel=""
+ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.8.0-py2.py3-none-any.whl"
 ARG transformers_version=4.26.0
 ARG diffusers_version=0.12.0
 
@@ -46,7 +45,7 @@ RUN apt-get update && \
     scripts/install_s5cmd.sh x64 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu117 && \
-    pip3 install deepspeed==${deepspeed_version} &&  \
+    pip3 install deepspeed==${deepspeed_wheel} &&  \
     pip3 install transformers==${transformers_version} && \
     pip3 install triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
     pip3 install diffusers[torch]==${diffusers_version} && \

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -9,14 +9,14 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-ARG version=11.6.1-cudnn8-devel-ubuntu20.04
+ARG version=11.7.1-cudnn8-devel-ubuntu22.04
 FROM nvidia/cuda:$version
 ARG djl_version=0.21.0~SNAPSHOT
-ARG torch_version=1.12.1
-ARG accelerate_version=0.13.2
-ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.7.5%2Bbf16-py2.py3-none-any.whl"
-ARG transformers_version=4.23.1
-ARG diffusers_version=0.7.2
+ARG torch_version=1.13.1
+ARG accelerate_version=0.16.0
+ARG deepspeed_version=0.8.0
+ARG transformers_version=4.26.0
+ARG diffusers_version=0.12.0
 
 EXPOSE 8080
 
@@ -45,7 +45,7 @@ RUN apt-get update && \
     scripts/install_s5cmd.sh x64 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu116 && \
-    pip3 install ${deepspeed_wheel} &&  \
+    pip3 install deepspeed==${deepspeed_version} &&  \
     pip3 install transformers==${transformers_version} && \
     pip3 install triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
     pip3 install diffusers[torch]==${diffusers_version} && \

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -9,7 +9,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-ARG version=11.7.1-cudnn8-devel-ubuntu22.04
+ARG version=11.7.1-cudnn8-devel-ubuntu20.04
 FROM nvidia/cuda:$version
 ARG djl_version=0.21.0~SNAPSHOT
 ARG torch_version=1.13.1
@@ -44,7 +44,7 @@ RUN apt-get update && \
     scripts/install_python.sh && \
     scripts/install_s5cmd.sh x64 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
-    pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu116 && \
+    pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu117 && \
     pip3 install deepspeed==${deepspeed_version} &&  \
     pip3 install transformers==${transformers_version} && \
     pip3 install triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -14,7 +14,8 @@ FROM nvidia/cuda:$version
 ARG djl_version=0.21.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG accelerate_version=0.16.0
-ARG deepspeed_version=0.8.0
+# This needs to be added once available in s3
+ARG deepspeed_wheel=""
 ARG transformers_version=4.26.0
 ARG diffusers_version=0.12.0
 


### PR DESCRIPTION
## Description ##

Updating the deepspeed handlers for 0.8.0. Minimal changes are required to support the current functionality.

So far I have tested gptj-6b with fp16, fp32, bf16 with no issues.

In 0.8.0, Deepspeed has changed how the replacement of layers works. Only 1 of replace_method and injection_policy will be honored. Auto replacement seems to be working as expected now (previously it was broken for some model classes like opt), so we defer to that.

Remaining work pending wheel updates:
- int8 integration and corresponding testing
- Model loading from partitioned checkpoints
- Adding support for new ds configs related to quantization

Remaining enhancements:
- Support user provided injection policy
- Dynamic batching support (applies to all python handlers)
