### PR TITLE
Deepspeed AOT Partition in DLC

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -281,7 +281,7 @@ _service = DeepSpeedService()
 
 
 def partition(inputs: Input):
-    _service.initialize(inputs.properties)
+    _service.initialize(inputs.get_properties())
 
 
 def handle(inputs: Input) -> Optional[Output]:

--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -149,6 +149,8 @@ class DeepSpeedService(object):
             "auto",
             "max_tokens":
             self.max_tokens,
+            "save_mp_checkpoint_path":
+            properties.get("save_mp_checkpoint_path")
         }
         if "checkpoint" in properties:
             ds_config["checkpoint"] = os.path.join(
@@ -276,6 +278,10 @@ class DeepSpeedService(object):
 
 
 _service = DeepSpeedService()
+
+
+def partition(inputs: Input):
+    _service.initialize(inputs.properties)
 
 
 def handle(inputs: Input) -> Optional[Output]:

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -34,8 +34,10 @@ CMD ["serve"]
 
 COPY scripts scripts/
 RUN mkdir -p /opt/djl/conf && \
-    mkdir -p /opt/djl/deps
+    mkdir -p /opt/djl/deps && \
+    mkdir -p /opt/djl/partition
 COPY config.properties /opt/djl/conf/config.properties
+COPY partition /opt/djl/partition
 
 RUN apt-get update && \
     scripts/install_djl_serving.sh $djl_version && \

--- a/serving/docker/dockerd-entrypoint.sh
+++ b/serving/docker/dockerd-entrypoint.sh
@@ -11,7 +11,7 @@ if [[ "$1" = "serve" ]]; then
     done
 elif [[ "$1" = "partition" ]]; then
     shift 1
-    /usr/bin/python3 partition/partition.py "$@"
+    /usr/bin/python3 /opt/djl/partition/partition.py "$@"
 else
     eval "$@"
 fi

--- a/serving/docker/dockerd-entrypoint.sh
+++ b/serving/docker/dockerd-entrypoint.sh
@@ -9,6 +9,9 @@ if [[ "$1" = "serve" ]]; then
         /usr/bin/djl-serving "$@"
         code=$?
     done
+elif [[ "$1" = "partition" ]]; then
+    shift 1
+    /usr/bin/python3 partition/partition.py "$@"
 else
     eval "$@"
 fi

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    #extract_python_jar()
+    extract_python_jar()
 
     properties_manager = PropertiesManager(args.model_dir)
     service = PartitionService(properties_manager)

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import subprocess
+import logging
+import sys
+import configparser
+import os
+import json
+import argparse
+import zipfile
+import glob
+
+from pathlib import Path
+
+MASTER_ADDR = "127.0.0.1"
+MASTER_PORT = 29761
+
+PYTHON_CACHE_DIR = '/tmp/djlserving/cache'
+
+FILES_TO_EXTRACT = ['djl_python/',
+                    'djl_python/deepspeed.py',
+                    'djl_python/inputs.py',
+                    'djl_python/outputs.py',
+                    'djl_python/pair_list.py',
+                    'djl_python/np_util.py',
+                    'djl_python/service_loader.py']
+
+
+def get_python_executable():
+    python_executable = os.environ.get("PYTHON_EXECUTABLE")
+    if python_executable is None:
+        python_executable = "python3"
+
+    return python_executable
+
+
+class PartitionService(object):
+
+    def __init__(self, model_dir):
+        self.properties = {}
+        self.load_properties(model_dir)
+        self.install_requirements_file()
+        self.download_model()
+
+    def load_properties(self, properties_dir):
+        properties_file = os.path.join(properties_dir, 'serving.properties')
+        with open(properties_file, 'r') as f:
+            for line in f:
+                # ignoring line starting with #
+                if line.startswith("#"):
+                    continue
+                key, value = line.strip().split('=', 1)
+                if key.startswith("option"):
+                    self.properties[key[7:]] = value
+                else:
+                    self.properties[key] = value
+
+    def download_model(self):
+        if "s3url" not in self.properties:
+            return
+        download_dir = os.environ.get("SERVING_DOWNLOAD_DIR", '/tmp/download/model/')
+
+        s3url = self.properties["s3url"]
+        commands = []
+        if Path("/opt/djl/bin/s5cmd").is_file():
+            if not s3url.endswith("*"):
+                if s3url.endswith("/"):
+                    s3url = s3url + '*'
+                else:
+                    s3url = s3url + '/*'
+
+            commands = ["/opt/djl/bin/s5cmd", "--retry-count", "1", "sync", s3url, download_dir]
+        else:
+            commands = ["aws", "s3", "sync", s3url, download_dir]
+
+        subprocess.run(commands)
+        self.properties['model_id'] = download_dir
+
+    def generate_properties_file(self):
+        properties_dir = self.properties.get('save_mp_checkpoint_path')
+
+        checkpoint_json = os.path.join(properties_dir, 'ds_inference_config.json')
+        if not os.path.exists(checkpoint_json):
+            raise Exception('Partition was not successful')
+
+        configs = {
+            'engine': self.properties.get('engine'),
+            'option.model_dir': properties_dir,
+            'option.checkpoint': 'ds_inference_config.json',
+        }
+
+        EXCLUDE_PROPERTIES = ['engine',
+                              'model_id',
+                              'checkpoint',
+                              's3url',
+                              'save_mp_checkpoint_path',
+                              'model_dir']
+
+        for key, value in self.properties.items():
+            if key not in EXCLUDE_PROPERTIES:
+                configs[f'option.{key}'] = value
+
+        properties_file = os.path.join(properties_dir, 'serving.properties')
+        with open(properties_file, "w") as f:
+            for key, value in configs.items():
+                f.write(f"{key}={value}\n")
+
+    def install_requirements_file(self):
+        model_dir = self.properties.get("model_dir")
+        file = os.path.join(model_dir, 'requirements.txt')
+        if os.path.isfile(file):
+            command = [get_python_executable(), "-m", "pip", "-q", "install", "-r", str(file)]
+            try:
+                result = subprocess.run(command)
+                if result.returncode == 0:
+                    logging.info("pip install requirements succeed!")
+                else:
+                    logging.info(f"requirements installation failed! With error: {result}")
+            except Exception as e:
+                logging.exception(f"Could not install requirements.txt {str(e)}")
+
+    def get_environmental_vars(self):
+        python_path = os.environ.get("PYTHONPATH")
+        python_path = f"{python_path},{PYTHON_CACHE_DIR}" if python_path else PYTHON_CACHE_DIR
+        python_path += self.properties['model_dir']
+
+    def run_partition(self):
+        commands = [
+            "mpirun",
+            "-N",
+            self.properties.get("tensor_parallel_degree", 1),
+            "--allow-run-as-root",
+            "--mca",
+            "btl_vader_single_copy_mechanism",
+            "none",
+            "--tag-output",
+            "-x",
+            "FI_PROVIDER=efa",
+            "-x",
+            "RDMAV_FORK_SAFE=1",
+            "-x",
+            "FI_EFA_USE_DEVICE_RDMA=1",
+            "-x",
+            "LD_LIBRARY_PATH",
+            "-x",
+            f"MASTER_ADDR={MASTER_ADDR}",
+            "-x",
+            f"MASTER_PORT={MASTER_PORT}",
+            "-x",
+            "PYTHONPATH",
+            get_python_executable(),
+            "run_partition.py",
+            "--properties",
+            str(json.dumps(self.properties))
+        ]
+
+        result = subprocess.run(commands,
+                                env=self.get_environmental_vars())
+        logging.info(result)
+        if result.returncode == 0:
+            logging.info(f"Partitioning done.")
+            self.generate_properties_file()
+        else:
+            logging.exception("Partitioning was not successful.")
+
+
+def extract_python_jar():
+    os.makedirs(PYTHON_CACHE_DIR, exist_ok=True)
+    jarfiles = glob.glob('/usr/local/djl-serving-*/lib/python-*.jar')
+
+    with zipfile.ZipFile(jarfiles[0], 'r') as zip:
+        # Extracting only required files into a specific location.
+        for file in FILES_TO_EXTRACT:
+            zip.extract(file,  path=PYTHON_CACHE_DIR)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(stream=sys.stdout,
+                        format="%(message)s",
+                        level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--model-dir',
+                        type=str,
+                        help='path of the model directory containing model/properties file')
+
+    args = parser.parse_args()
+
+    extract_python_jar()
+
+    service = PartitionService(args.model_dir)
+    service.run_partition()

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -13,7 +13,6 @@
 import subprocess
 import logging
 import sys
-import configparser
 import os
 import json
 import argparse
@@ -21,19 +20,18 @@ import zipfile
 import glob
 
 from pathlib import Path
+from properties_manager import PropertiesManager
 
 MASTER_ADDR = "127.0.0.1"
 MASTER_PORT = 29761
 
 PYTHON_CACHE_DIR = '/tmp/djlserving/cache'
 
-FILES_TO_EXTRACT = ['djl_python/',
-                    'djl_python/deepspeed.py',
-                    'djl_python/inputs.py',
-                    'djl_python/outputs.py',
-                    'djl_python/pair_list.py',
-                    'djl_python/np_util.py',
-                    'djl_python/service_loader.py']
+FILES_TO_EXTRACT = [
+    'djl_python/', 'djl_python/deepspeed.py', 'djl_python/inputs.py',
+    'djl_python/outputs.py', 'djl_python/pair_list.py',
+    'djl_python/np_util.py', 'djl_python/service_loader.py'
+]
 
 
 def get_python_executable():
@@ -45,30 +43,17 @@ def get_python_executable():
 
 
 class PartitionService(object):
-
-    def __init__(self, model_dir):
-        self.properties = {}
-        self.load_properties(model_dir)
+    def __init__(self, props_manager):
+        self.properties_manager = props_manager
+        self.properties = props_manager.properties()
         self.install_requirements_file()
         self.download_model()
-
-    def load_properties(self, properties_dir):
-        properties_file = os.path.join(properties_dir, 'serving.properties')
-        with open(properties_file, 'r') as f:
-            for line in f:
-                # ignoring line starting with #
-                if line.startswith("#"):
-                    continue
-                key, value = line.strip().split('=', 1)
-                if key.startswith("option"):
-                    self.properties[key[7:]] = value
-                else:
-                    self.properties[key] = value
 
     def download_model(self):
         if "s3url" not in self.properties:
             return
-        download_dir = os.environ.get("SERVING_DOWNLOAD_DIR", '/tmp/download/model/')
+        download_dir = os.environ.get("SERVING_DOWNLOAD_DIR",
+                                      '/tmp/download/model/')
 
         s3url = self.properties["s3url"]
         commands = []
@@ -79,55 +64,43 @@ class PartitionService(object):
                 else:
                     s3url = s3url + '/*'
 
-            commands = ["/opt/djl/bin/s5cmd", "--retry-count", "1", "sync", s3url, download_dir]
+            commands = [
+                "/opt/djl/bin/s5cmd",
+                "--retry-count",
+                "1",
+                "sync",
+                s3url,
+                download_dir
+            ]
         else:
-            commands = ["aws", "s3", "sync", s3url, download_dir]
+            commands = ["aws",
+                        "s3",
+                        "sync",
+                        s3url,
+                        download_dir]
 
         subprocess.run(commands)
         self.properties['model_id'] = download_dir
-
-    def generate_properties_file(self):
-        properties_dir = self.properties.get('save_mp_checkpoint_path')
-
-        checkpoint_json = os.path.join(properties_dir, 'ds_inference_config.json')
-        if not os.path.exists(checkpoint_json):
-            raise Exception('Partition was not successful')
-
-        configs = {
-            'engine': self.properties.get('engine'),
-            'option.model_dir': properties_dir,
-            'option.checkpoint': 'ds_inference_config.json',
-        }
-
-        EXCLUDE_PROPERTIES = ['engine',
-                              'model_id',
-                              'checkpoint',
-                              's3url',
-                              'save_mp_checkpoint_path',
-                              'model_dir']
-
-        for key, value in self.properties.items():
-            if key not in EXCLUDE_PROPERTIES:
-                configs[f'option.{key}'] = value
-
-        properties_file = os.path.join(properties_dir, 'serving.properties')
-        with open(properties_file, "w") as f:
-            for key, value in configs.items():
-                f.write(f"{key}={value}\n")
 
     def install_requirements_file(self):
         model_dir = self.properties.get("model_dir")
         file = os.path.join(model_dir, 'requirements.txt')
         if os.path.isfile(file):
-            command = [get_python_executable(), "-m", "pip", "-q", "install", "-r", str(file)]
+            command = [
+                get_python_executable(), "-m", "pip", "-q", "install", "-r",
+                str(file)
+            ]
             try:
                 result = subprocess.run(command)
                 if result.returncode == 0:
                     logging.info("pip install requirements succeed!")
                 else:
-                    logging.info(f"requirements installation failed! With error: {result}")
+                    logging.info(
+                        f"requirements installation failed! With error: {result}"
+                    )
             except Exception as e:
-                logging.exception(f"Could not install requirements.txt {str(e)}")
+                logging.exception(
+                    f"Could not install requirements.txt {str(e)}")
 
     def get_environmental_vars(self):
         python_path = os.environ.get("PYTHONPATH")
@@ -136,42 +109,24 @@ class PartitionService(object):
 
     def run_partition(self):
         commands = [
-            "mpirun",
-            "-N",
+            "mpirun", "-N",
             self.properties.get("tensor_parallel_degree", 1),
-            "--allow-run-as-root",
-            "--mca",
-            "btl_vader_single_copy_mechanism",
-            "none",
-            "--tag-output",
-            "-x",
-            "FI_PROVIDER=efa",
-            "-x",
-            "RDMAV_FORK_SAFE=1",
-            "-x",
-            "FI_EFA_USE_DEVICE_RDMA=1",
-            "-x",
-            "LD_LIBRARY_PATH",
-            "-x",
-            f"MASTER_ADDR={MASTER_ADDR}",
-            "-x",
-            f"MASTER_PORT={MASTER_PORT}",
-            "-x",
-            "PYTHONPATH",
-            get_python_executable(),
-            "run_partition.py",
-            "--properties",
+            "--allow-run-as-root", "--mca", "btl_vader_single_copy_mechanism",
+            "none", "--tag-output", "-x", "FI_PROVIDER=efa", "-x",
+            "RDMAV_FORK_SAFE=1", "-x", "FI_EFA_USE_DEVICE_RDMA=1", "-x",
+            "LD_LIBRARY_PATH", "-x", f"MASTER_ADDR={MASTER_ADDR}", "-x",
+            f"MASTER_PORT={MASTER_PORT}", "-x", "PYTHONPATH",
+            get_python_executable(), "run_partition.py", "--properties",
             str(json.dumps(self.properties))
         ]
 
-        result = subprocess.run(commands,
-                                env=self.get_environmental_vars())
+        result = subprocess.run(commands, env=self.get_environmental_vars())
         logging.info(result)
         if result.returncode == 0:
             logging.info(f"Partitioning done.")
-            self.generate_properties_file()
+            self.properties_manager.generate_properties_file()
         else:
-            logging.exception("Partitioning was not successful.")
+            raise Exception("Partitioning was not successful.")
 
 
 def extract_python_jar():
@@ -181,7 +136,7 @@ def extract_python_jar():
     with zipfile.ZipFile(jarfiles[0], 'r') as zip:
         # Extracting only required files into a specific location.
         for file in FILES_TO_EXTRACT:
-            zip.extract(file,  path=PYTHON_CACHE_DIR)
+            zip.extract(file, path=PYTHON_CACHE_DIR)
 
 
 if __name__ == "__main__":
@@ -191,13 +146,15 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--model-dir',
-                        type=str,
-                        help='path of the model directory containing model/properties file')
+    parser.add_argument(
+        '--model-dir',
+        type=str,
+        help='path of the model directory containing model/properties file')
 
     args = parser.parse_args()
 
     extract_python_jar()
 
-    service = PartitionService(args.model_dir)
+    properties_manager = PropertiesManager(args.model_dir)
+    service = PartitionService(properties_manager)
     service.run_partition()

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -31,6 +31,7 @@ PYTHON_CACHE_DIR = '/tmp/djlserving/cache'
 
 FILES_TO_EXTRACT = [
     'djl_python/',
+    'djl_python/__init__.py',
     'djl_python/deepspeed.py',
     'djl_python/inputs.py',
     'djl_python/outputs.py',
@@ -186,7 +187,9 @@ class PartitionService(object):
             f"MASTER_PORT={MASTER_PORT}",
             "-x",
             "PYTHONPATH",
-            get_python_executable(), "run_partition.py", "--properties",
+            get_python_executable(),
+            "/opt/djl/partition/run_partition.py",
+            "--properties",
             str(json.dumps(self.properties))
         ]
         self.set_environmental_vars()

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -11,6 +11,7 @@
 # the specific language governing permissions and limitations under the License.
 import os
 import glob
+import torch
 
 # Properties to exclude while generating serving.properties
 EXCLUDE_PROPERTIES = ['model_id',
@@ -24,15 +25,18 @@ PARTITION_SUPPORTED_ENGINES = ['DeepSpeed']
 
 class PropertiesManager(object):
 
-    def __init__(self, model_dir):
-        self.properties = []
-        self.load_properties(model_dir)
-        self.validate_model()
+    def __init__(self, properties_dir):
+        self.properties = {}
+        self.properties_dir = properties_dir
+
+        self.load_properties()
+
+        self.set_and_validate_model_dir()
         self.validate_engine()
         self.validate_tp_degree()
 
-    def load_properties(self, properties_dir):
-        properties_file = os.path.join(properties_dir, 'serving.properties')
+    def load_properties(self):
+        properties_file = os.path.join(self.properties_dir, 'serving.properties')
         if os.path.exists(properties_file):
             with open(properties_file, 'r') as f:
                 for line in f:
@@ -45,7 +49,23 @@ class PropertiesManager(object):
                     else:
                         self.properties[key] = value
         else:
-            raise Exception("serving.properties file does not exist in the path provided.")
+            raise FileNotFoundError("serving.properties file does not exist in the path provided.")
+
+    def set_and_validate_model_dir(self):
+        if 'model_dir' in self.properties:
+            model_files = glob.glob(os.path.join(self.properties['model_dir'], '*.bin'))
+            if not model_files:
+                raise FileNotFoundError('No .bin files found in the given option.model_dir')
+        elif 'model_id' in self.properties:
+            self.properties['model_dir'] = self.properties_dir
+        elif 's3url' not in self.properties:
+            model_files = glob.glob(os.path.join(self.properties_dir, '*.bin'))
+            if model_files:
+                self.properties['model_dir'] = self.properties_dir
+            else:
+                raise KeyError('Please specify the option.model_dir or option.model_id or option.s3_url'
+                                'include model '
+                                'files in the model-dir argument.')
 
     def generate_properties_file(self):
         checkpoint_path = self.properties.get('save_mp_checkpoint_path')
@@ -70,19 +90,16 @@ class PropertiesManager(object):
 
     def validate_engine(self):
         if 'engine' not in self.properties:
-            raise Exception('Please specify engine in serving.properties')
+            raise KeyError('Please specify engine in serving.properties')
         elif self.properties['engine'] not in PARTITION_SUPPORTED_ENGINES:
-            raise Exception(f'{self.properties["engine"]} engine is not supported for ahead of time partitioning.')
+            raise NotImplementedError(f'{self.properties["engine"]} '
+                                      f'engine is not supported for ahead of time partitioning.')
 
     def validate_tp_degree(self):
         if 'tensor_parallel_degree' not in self.properties:
-            raise Exception('Please specify tensor_parallel_degree in serving.properties')
-        # TODO: get the GPU device and validate.
+            raise ValueError('Please specify tensor_parallel_degree in serving.properties')
 
-    def validate_model(self):
-        if 'model_id' in self.properties:
-            return
-        if 'model_dir' in self.properties:
-            model_files = glob.glob(os.path.join(self.properties, '*.bin'))
-            if not model_files:
-                raise Exception('No .bin files found in the model directory.')
+        num_gpus = torch.cuda.device_count()
+        tensor_parallel_degree = self.properties['tensor_parallel_degree']
+        if num_gpus < int(tensor_parallel_degree):
+            raise ValueError(f'GPU devices are not enough to run {tensor_parallel_degree} partitions.')

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -53,13 +53,18 @@ class PropertiesManager(object):
             raise FileNotFoundError("serving.properties file does not exist in the path provided.")
 
     def set_and_validate_model_dir(self):
+        if 'model_id' in self.properties and 's3url' in self.properties:
+            raise KeyError('Both model_id and s3url cannot be in serving.properties')
+
         if 'model_dir' in self.properties:
             model_files = glob.glob(os.path.join(self.properties['model_dir'], '*.bin'))
             if not model_files:
                 raise FileNotFoundError('No .bin files found in the given option.model_dir')
         elif 'model_id' in self.properties:
             self.properties['model_dir'] = self.properties_dir
-        elif 's3url' not in self.properties:
+        elif 's3url' in self.properties:
+            self.properties['model_dir'] = self.properties_dir
+        else:
             model_files = glob.glob(os.path.join(self.properties_dir, '*.bin'))
             if model_files:
                 self.properties['model_dir'] = self.properties_dir

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import os
+import glob
+
+# Properties to exclude while generating serving.properties
+EXCLUDE_PROPERTIES = ['model_id',
+                      'checkpoint',
+                      's3url',
+                      'save_mp_checkpoint_path',
+                      'model_dir']
+
+PARTITION_SUPPORTED_ENGINES = ['DeepSpeed']
+
+
+class PropertiesManager(object):
+
+    def __init__(self, model_dir):
+        self.properties = []
+        self.load_properties(model_dir)
+        self.validate_model()
+        self.validate_engine()
+        self.validate_tp_degree()
+
+    def load_properties(self, properties_dir):
+        properties_file = os.path.join(properties_dir, 'serving.properties')
+        if os.path.exists(properties_file):
+            with open(properties_file, 'r') as f:
+                for line in f:
+                    # ignoring line starting with #
+                    if line.startswith("#"):
+                        continue
+                    key, value = line.strip().split('=', 1)
+                    if key.startswith("option"):
+                        self.properties[key[7:]] = value
+                    else:
+                        self.properties[key] = value
+        else:
+            raise Exception("serving.properties file does not exist in the path provided.")
+
+    def generate_properties_file(self):
+        checkpoint_path = self.properties.get('save_mp_checkpoint_path')
+
+        checkpoint_json = os.path.join(checkpoint_path, 'ds_inference_config.json')
+        if not os.path.exists(checkpoint_json):
+            raise Exception('Partition was not successful')
+
+        configs = {
+            'option.model_dir': checkpoint_path,
+            'option.checkpoint': 'ds_inference_config.json',
+        }
+
+        for key, value in self.properties.items():
+            if key not in EXCLUDE_PROPERTIES:
+                configs[f'option.{key}'] = value
+
+        properties_file = os.path.join(checkpoint_path, 'serving.properties')
+        with open(properties_file, "w") as f:
+            for key, value in configs.items():
+                f.write(f"{key}={value}\n")
+
+    def validate_engine(self):
+        if 'engine' not in self.properties:
+            raise Exception('Please specify engine in serving.properties')
+        elif self.properties['engine'] not in PARTITION_SUPPORTED_ENGINES:
+            raise Exception(f'{self.properties["engine"]} engine is not supported for ahead of time partitioning.')
+
+    def validate_tp_degree(self):
+        if 'tensor_parallel_degree' not in self.properties:
+            raise Exception('Please specify tensor_parallel_degree in serving.properties')
+        # TODO: get the GPU device and validate.
+
+    def validate_model(self):
+        if 'model_id' in self.properties:
+            return
+        if 'model_dir' in self.properties:
+            model_files = glob.glob(os.path.join(self.properties, '*.bin'))
+            if not model_files:
+                raise Exception('No .bin files found in the model directory.')

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -34,6 +34,7 @@ class PropertiesManager(object):
         self.set_and_validate_model_dir()
         self.validate_engine()
         self.validate_tp_degree()
+        self.set_and_validate_entry_point()
 
     def load_properties(self):
         properties_file = os.path.join(self.properties_dir, 'serving.properties')
@@ -103,3 +104,13 @@ class PropertiesManager(object):
         tensor_parallel_degree = self.properties['tensor_parallel_degree']
         if num_gpus < int(tensor_parallel_degree):
             raise ValueError(f'GPU devices are not enough to run {tensor_parallel_degree} partitions.')
+
+    def set_and_validate_entry_point(self):
+        if "entryPoint" not in self.properties:
+            entry_point = os.environ.get("DJL_ENTRY_POINT")
+            if entry_point is None:
+                entry_point_file = glob.glob(os.path.join(self.properties_dir, 'model.py'))
+                if entry_point_file:
+                    self.properties['entryPoint'] = 'model.py'
+                else:
+                    raise FileNotFoundError(f"model.py not found in model path {self.properties_dir}")

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -45,10 +45,7 @@ class PropertiesManager(object):
                     if line.startswith("#"):
                         continue
                     key, value = line.strip().split('=', 1)
-                    if key.startswith("option"):
-                        self.properties[key[7:]] = value
-                    else:
-                        self.properties[key] = value
+                    self.properties[key.split(".", 1)[-1]] = value
         else:
             raise FileNotFoundError("serving.properties file does not exist in the path provided.")
 

--- a/serving/docker/partition/run_partition.py
+++ b/serving/docker/partition/run_partition.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import logging
+import sys
+import json
+import argparse
+
+
+PYTHON_CACHE_DIR = '/tmp/djlserving/cache'
+
+sys.path.append(PYTHON_CACHE_DIR)
+
+from djl_python.inputs import Input
+from djl_python.service_loader import load_model_service
+
+PARTITION_HANDLER = "partition"
+
+def invoke_partition(properties):
+    inputs = Input()
+    handler = properties.get("partition_handler", PARTITION_HANDLER)
+    inputs.properties = properties
+
+    try:
+        model_service = load_model_service(properties['model_dir'],
+                                           properties['entryPoint'],
+                                           None)
+        model_service.invoke_handler(handler, inputs)
+        logging.info("Partitioning is successful")
+    except Exception as e:
+        logging.exception(f"Partitioning failed {str(e)}")
+        raise Exception("Partitioning failed.")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout,
+                        format="%(message)s",
+                        level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--properties',
+                        type=str,
+                        help='properties')
+
+    args = parser.parse_args()
+    properties = json.loads(args.properties)
+
+    invoke_partition(properties)

--- a/serving/docker/partition/run_partition.py
+++ b/serving/docker/partition/run_partition.py
@@ -25,6 +25,7 @@ from djl_python.service_loader import load_model_service
 
 PARTITION_HANDLER = "partition"
 
+
 def invoke_partition(properties):
     inputs = Input()
     handler = properties.get("partition_handler", PARTITION_HANDLER)

--- a/tests/integration/llm/deepspeed-model.py
+++ b/tests/integration/llm/deepspeed-model.py
@@ -78,6 +78,9 @@ def pipeline_inference(model, tokenizer, batch_size, length):
     return [item[0]['generated_text'] for item in outputs]
 
 
+def partition(inputs: Input):
+    load_model(inputs.get_properties())
+
 def handle(inputs: Input):
     global model, tokenizer
     if not model:


### PR DESCRIPTION
ToDo

- [x] Script to call the entryPoint for partition in mpi mode
- [x] Reads the properties, 
- [x] Downloads the model from S3
- [x] Loading model from local and then partition
- [x] Generates serving.properties after partitioning is successful
- [x] Include PYTHONPATH environment variable
- [x] option.partition_handle - configure the partitioning
- [x] Option to include DOWNLOAD_DIR env variable for s3_url download 
- [x] Option to include requirements.txt 
- [x] Include PYTHON_CACHE_DIR in environment variable 
- [x] Copy config.json, tokenizer_config.json and vocab.json into the partitioned folder file
- [x] Error handling if something failed, show the appropriate messages  
- [x] Error message, to show AOT is supported only by Deepspeed as of now.

Testing yet to do

- [x] Test all the models of the deepspeed wheel 
- [x] Test custom partition script with s3 url downloaded. 
