### PR TITLE
[serving] Print better stacktrace if channel is closed

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -95,7 +95,7 @@ class Connection {
     CompletableFuture<Output> send(Input input) throws InterruptedException {
         CompletableFuture<Output> f = new CompletableFuture<>();
         requestHandler.setResponseFuture(f);
-        if (!channel.writeAndFlush(input).sync().isSuccess()) {
+        if (!channel.isActive() || !channel.writeAndFlush(input).sync().isSuccess()) {
             throw new IllegalStateException("Failed to send data to python.");
         }
         return f;

--- a/serving/src/main/java/ai/djl/serving/util/NettyUtils.java
+++ b/serving/src/main/java/ai/djl/serving/util/NettyUtils.java
@@ -339,11 +339,19 @@ public final class NettyUtils {
         HttpUtil.setContentLength(resp, resp.content().readableBytes());
         if (!keepAlive || code >= 400) {
             headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
-            ChannelFuture f = channel.writeAndFlush(resp);
-            f.addListener(ChannelFutureListener.CLOSE);
+            if (channel.isActive()) {
+                ChannelFuture f = channel.writeAndFlush(resp);
+                f.addListener(ChannelFutureListener.CLOSE);
+            } else {
+                logger.warn("Channel is closed by peer.");
+            }
         } else {
             headers.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-            channel.writeAndFlush(resp);
+            if (channel.isActive()) {
+                channel.writeAndFlush(resp);
+            } else {
+                logger.warn("Channel is closed by peer.");
+            }
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
