### PR TITLE
Add tests for stable-diffusion-2-1-base model

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -179,14 +179,14 @@ jobs:
         working-directory: tests/integration
         run: |
           docker pull deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG
-      - name: Test stable-diffusion-v1-4
+      - name: Test stable-diffusion-2-1-base
         working-directory: tests/integration
         run: |
           rm -rf models
-          python3 llm/prepare.py stable-diffusion stable-diffusion-v1-4
+          python3 llm/prepare.py stable-diffusion stable-diffusion-2-1-base
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
-          python3 llm/client.py stable-diffusion stable-diffusion-v1-4
+          python3 llm/client.py stable-diffusion stable-diffusion-2-1-base
           docker rm -f $(docker ps -aq)
       - name: Test stable-diffusion-v1-5
         working-directory: tests/integration

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -96,17 +96,17 @@ ft_raw_model_spec = {
 }
 
 sd_model_spec = {
-    "stable-diffusion-v1-4": {
+    "stable-diffusion-v1-5": {
         "max_memory_per_gpu": 8.0,
         "size": [256, 512],
-        "steps": [1, 2],
-        "worker": 2
+        "num_inference_steps": [50, 100]
     },
-    "stable-diffusion-v1-5": {
-        "max_memory_per_gpu": 16.0,
+    "stable-diffusion-2-1-base": {
+        "max_memory_per_gpu": 8.0,
         "size": [256, 512],
-        "steps": [1, 2]
-    },
+        "num_inference_steps": [50, 100],
+        "workers": 2
+    }
 }
 
 
@@ -223,9 +223,9 @@ def test_sd_handler(model, model_spec):
     from PIL import Image
     from io import BytesIO
     for size in spec["size"]:
-        for step in spec["steps"]:
+        for step in spec["num_inference_steps"]:
             req = {"prompt": "A bird and cat flying through space"}
-            params = {"height": size, "width": size, "steps": step}
+            params = {"height": size, "width": size, "num_inference_steps": step}
             req["parameters"] = params
             logging.info(f"req: {req}")
             res = send_json(req)

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -65,16 +65,16 @@ ds_handler_list = {
 }
 
 sd_handler_list = {
-    "stable-diffusion-v1-4": {
-        "option.s3url": "s3://djl-llm/stable-diffusion-v1-4/",
-        "option.tensor_parallel_degree": 2,
-        "option.dtype": "fp16"
-    },
     "stable-diffusion-v1-5": {
         "option.s3url": "s3://djl-llm/stable-diffusion-v1-5/",
         "option.tensor_parallel_degree": 4,
-        "option.dtype": "fp32"
+        "option.dtype": "fp16"
     },
+    "stable-diffusion-2-1-base": {
+        "option.s3url": "s3://djl-llm/stable-diffusion-2-1-base/",
+        "option.tensor_parallel_degree": 2,
+        "option.dtype": "fp16"
+    }
 }
 
 ft_model_list = {


### PR DESCRIPTION
## Description ##

stable-diffusion-2-1-base tests. Replaces the test for stable-diffusion-1-4 which is covered pretty much by the stable-diffusion-1-5. 

test files have been updated as well to reflect the new diffusers api changes (steps -> num_inference_steps)
