### PR TITLE
Inf2 container with transformers-neuronx LLM support

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ cpu, cpu-full, deepspeed, transformers, pytorch-inf1, pytorch-cu117, paddle-cu112 ]
+        arch: [ cpu, cpu-full, deepspeed, transformers, pytorch-inf1, pytorch-inf2, pytorch-cu117, paddle-cu112 ]
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker

--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -7,15 +7,15 @@ on:
         description: 'The released version of DJL'
         required: false
         default: ''
-#  schedule:
-#    - cron: '0 15 * * *'
+  schedule:
+    - cron: '0 15 * * *'
 
 
 jobs:
   create-runners:
     runs-on: [self-hosted, scheduler]
     steps:
-      - name: Create new Inf2.2xl instance
+      - name: Create new Inf2.24xl instance
         id: create_inf2
         run: |
           cd /home/ubuntu/djl_benchmark_script/scripts

--- a/serving/docker/docker-compose.yml
+++ b/serving/docker/docker-compose.yml
@@ -49,3 +49,8 @@ services:
       context: .
       dockerfile: paddle-cu112.Dockerfile
     image: "deepjavalibrary/djl-serving:${RELEASE_VERSION}paddle-cu112${NIGHTLY}"
+  pytorch-inf2:
+    build:
+      context: .
+      dockerfile: pytorch-inf2.Dockerfile
+    image: "deepjavalibrary/djl-serving:${RELEASE_VERSION}pytorch-inf2${NIGHTLY}"

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -1,0 +1,50 @@
+# -*- mode: dockerfile -*-
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+FROM ubuntu:20.04
+ARG djl_version=0.21.0~SNAPSHOT
+ARG python_version=3.8
+ARG torch_neuronx_version=1.13.0.1.4.0
+EXPOSE 8080
+
+# Sets up Path for Neuron tools
+ENV PATH="/opt/aws/neuron/bin:${PATH}"
+
+COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh
+WORKDIR /opt/djl
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV OMP_NUM_THREADS=1
+ENV MODEL_SERVER_HOME=/opt/djl
+ENV JAVA_OPTS="-Xmx1g -Xms1g -Xss2m -XX:-UseContainerSupport -XX:+ExitOnOutOfMemoryError"
+
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
+CMD ["serve"]
+
+COPY scripts scripts/
+RUN mkdir -p /opt/djl/conf && \
+    mkdir -p /opt/djl/deps
+COPY config.properties /opt/djl/conf/
+RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
+    echo "${djl_version} inf2" > /opt/djl/bin/telemetry && \
+    scripts/install_python.sh ${python_version} && \
+    scripts/install_djl_serving.sh $djl_version && \
+    scripts/install_inferentia2.sh $torch_neuronx_version && \
+    pip install git+https://github.com/aws-neuron/transformers-neuronx.git && \
+    scripts/patch_oss_dlc.sh python && \
+    useradd -m -d /home/djl djl && \
+    chown -R djl:djl /opt/djl && \
+    rm -rf scripts && pip3 cache purge && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+LABEL maintainer="djl-dev@amazon.com"
+LABEL dlc_major_version="1"
+LABEL com.amazonaws.ml.engines.sagemaker.dlc.framework.djl.inf2="true"

--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+TORCH_NEURONX_VERSION=$1
+
+set -ex
+
+apt-get update -y && apt-get install -y --no-install-recommends \
+  curl \
+  git \
+  gnupg2
+
+# Configure Linux for Neuron repository updates
+. /etc/os-release
+echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc/apt/sources.list.d/neuron.list
+curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
+
+apt-get update -y && apt-get install -y linux-headers-$(uname -r) && apt-get install -y aws-neuronx-dkms=2.* \
+    aws-neuronx-collectives=2.* \
+    aws-neuronx-runtime-lib=2.* \
+    aws-neuronx-tools=2.*
+
+export PATH=/opt/aws/neuron/bin:$PATH
+
+python3 -m pip install numpy awscli
+python3 -m pip install neuronx-cc==2.* torch_neuronx==${TORCH_NEURONX_VERSION} --extra-index-url=https://pip.repos.neuron.amazonaws.com

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -21,7 +21,7 @@ if [[ "$platform" == *"cu117"* ]]; then # if the platform has cuda capabilities
 elif [[ "$platform" == *"deepspeed"* ]]; then # Runs multi-gpu
   runtime="nvidia"
   shm="2gb"
-elif [[ "$platform" == *"inf1"* ]]; then # if the platform is inferentia
+elif [[ "$platform" == *"inf1"* || "$platform" == *"inf2"* ]]; then # if the platform is inferentia
   host_device="/dev/neuron0"
 fi
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -126,6 +126,15 @@ ft_model_list = {
     }
 }
 
+transformers_neuronx_handler_list = {
+    "gpt2": {
+        "option.tensor_parallel_degree": 2,
+        "option.batch_size": 4,
+        "option.dtype": "f32",
+        "option.n_positions": 128,
+    },
+}
+
 
 def write_properties(properties):
     model_path = "models/test"
@@ -202,13 +211,26 @@ def build_ft_raw_model(model):
     shutil.copyfile("llm/fastertransformer-model.py", "models/test/model.py")
 
 
+def build_transformers_neuronx_model(model):
+    if model not in transformers_neuronx_handler_list.keys():
+        raise ValueError(
+            f"{model} is not one of the supporting handler {list(transformers_neuronx_handler_list.keys())}"
+        )
+    options = transformers_neuronx_handler_list[model]
+    options["engine"] = "Python"
+    write_properties(options)
+    shutil.copyfile("llm/transformers-neuronx-gpt2-model.py",
+                    "models/test/model.py")
+
+
 supported_handler = {
     'deepspeed': build_ds_handler_model,
     'huggingface': build_hf_handler_model,
     "deepspeed_raw": build_ds_raw_model,
     'stable-diffusion': build_sd_handler_model,
     'fastertransformer_raw': build_ft_raw_model,
-    'deepspeed_aot': build_ds_aot_model
+    'deepspeed_aot': build_ds_aot_model,
+    'transformers_neuronx': build_transformers_neuronx_model,
 }
 
 if __name__ == '__main__':

--- a/tests/integration/llm/transformers-neuronx-gpt2-model.py
+++ b/tests/integration/llm/transformers-neuronx-gpt2-model.py
@@ -1,0 +1,66 @@
+import torch
+import tempfile
+import os
+
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+from transformers_neuronx import dtypes
+from transformers_neuronx.gpt2.model import GPT2ForSampling
+from djl_python import Input, Output
+
+model = None
+
+
+def load_model(properties):
+    batch_size = int(properties.get("batch_size", 4))
+    tp_degree = int(properties.get("tensor_parallel_degree", 2))
+    amp = properties.get("dtype", "f32")
+    n_positions = int(properties.get("n_positions", 128))
+    unroll = properties.get("unroll", None)
+    model_id = "gpt2"
+    load_path = os.path.join(tempfile.gettempdir(), model_id)
+    model = AutoModelForCausalLM.from_pretrained(model_id,
+                                                 low_cpu_mem_usage=True)
+    dtype = dtypes.to_torch_dtype(amp)
+    for block in model.transformer.h:
+        block.attn.to(dtype)
+        block.mlp.to(dtype)
+    model.lm_head.to(dtype)
+    model.save_pretrained(load_path, max_shard_size="100GB")
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = GPT2ForSampling.from_pretrained(load_path,
+                                            batch_size=batch_size,
+                                            amp=amp,
+                                            tp_degree=tp_degree,
+                                            n_positions=n_positions,
+                                            unroll=unroll)
+    model.to_neuron()
+    return model, tokenizer, batch_size
+
+
+def infer(seq_length, prompt):
+    with torch.inference_mode():
+        encoded_text = tokenizer.encode(prompt)
+        input_ids = torch.as_tensor([encoded_text])
+        input_ids = torch.cat([input_ids for _ in range(batch_size)], dim=0)
+        generated_sequence = model.sample(input_ids,
+                                          sequence_length=seq_length)
+        outputs = [tokenizer.decode(gen_seq) for gen_seq in generated_sequence]
+    return outputs
+
+
+def handle(inputs: Input):
+    global model, tokenizer, batch_size
+    if not model:
+        model, tokenizer, batch_size = load_model(inputs.get_properties())
+
+    if inputs.is_empty():
+        # Model server makes an empty call to warmup the model on startup
+        return None
+
+    data = inputs.get_as_json()
+    seq_length = data["seq_length"]
+    prompt = data["text"]
+    outputs = infer(seq_length, prompt)
+    result = {"outputs": outputs}
+    return Output().add_as_json(result)


### PR DESCRIPTION
## Description ##

Adding inf2 container with support for LLMs available as part of [transformers-neuronx](https://github.com/aws-neuron/transformers-neuronx#currently-supported-models) module

- If this change is a backward incompatible change, why must this change be made? *N/A*
- Interesting edge cases to note here *N/A*


### Tasks
- [X] Configure base environment of the container (end2end run with Inf2 example)
- [X] Build the docker file and add it to publish pipeline and install DJLServing
- [X] Make DJLServing work with Inf2 (a code sample with test cases) `model.py` and `serving.config`
- [ ] If needed any glue code or library that could improve UX
- [x] Integration tests from GitHub repo with the inf2 chip.

### Manual test
```
# Install Docker and Docker compose
git clone https://github.com/maaquib/djl-serving/
cd djl-serving && git checkout inf2 && cd serving/docker
docker compose build pytorch-inf2
cd ../../tests/integration
python3 llm/prepare.py transformers_neuronx gpt2
./launch_container.sh deepjavalibrary/djl-serving:pytorch-inf2 `pwd`/models inf2 serve
python3 llm/client.py transformers_neuronx gpt2
```

```
docker pull deepjavalibrary/djl-serving:pytorch-inf2-nightly
git clone https://github.com/maaquib/djl-serving/
cd djl-serving && git checkout inf2 && cd tests/integration
python3 llm/prepare.py transformers_neuronx gpt2
./launch_container.sh deepjavalibrary/djl-serving:pytorch-inf2-nightly `pwd`/models inf2 serve
python3 llm/client.py transformers_neuronx gpt2
```
