### PR TITLE
Add security patching for fastertransformers image

### DIFF
--- a/serving/docker/fastertransformer.Dockerfile
+++ b/serving/docker/fastertransformer.Dockerfile
@@ -73,13 +73,13 @@ RUN git clone https://github.com/NVIDIA/FasterTransformer.git -b ${ft_version} \
     && cp -r bin/*_gemm /usr/local/backends/fastertransformer/bin/ \
     && cd ../../ && rm -rf FasterTransformer
 
-# TODO: Add DLC patching
 RUN apt-get update && \
     scripts/install_djl_serving.sh $djl_version && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     echo "${djl_version} fastertransformer" > /opt/djl/bin/telemetry && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \
+    scripts/security_patch.sh fastertransformer && \
     useradd -m -d /home/djl djl && \
     chown -R djl:djl /opt/djl && \
     rm -rf scripts && \

--- a/serving/docker/scripts/security_patch.sh
+++ b/serving/docker/scripts/security_patch.sh
@@ -4,9 +4,9 @@ IMAGE_NAME=$1
 
 apt-get update
 
-if [[ "$IMAGE_NAME" == "deepspeed" ]]; then
-  apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0 libdbus-1-3 curl
-elif [[ "$IMAGE_NAME" == "pytorch-cu117" ]]; then
+if [[ "$IMAGE_NAME" == "deepspeed" ]] || \
+   [[ "$IMAGE_NAME" == "pytorch-cu117" ]] || \
+   [[ "$IMAGE_NAME" == "fastertransformer" ]]; then
   apt-get upgrade -y dpkg e2fsprogs libdpkg-perl libpcre2-8-0 libpcre3 openssl libsqlite3-0 libsepol1 libdbus-1-3 curl
 elif [[ "$IMAGE_NAME" == "cpu" ]] ||  [[ "$IMAGE_NAME" == "pytorch-inf1" ]]; then
   apt-get upgrade -y libpcre2-8-0 libdbus-1-3 curl


### PR DESCRIPTION
## Description ##
Adds security patching to fastertransformer image - we need this in master as well as dlc branch so 2 prs are raised

It seems like we're doing the same set of patches for all of fastertransformer, deepspeed, pytorch-cu117 so i combined them into a single block (this makes sense to me since they all derive from the same base image, and we're patching the os libs- maybe we update the security patching to operate based on the base image?)

Same PR is raised for the dlc branch https://github.com/deepjavalibrary/djl-serving/pull/510
