### PR TITLE
[inf2] Adding gptj to transformers handler

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -89,6 +89,17 @@ jobs:
           python3 llm/client.py transformers_neuronx opt-1.3b
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
+      - name: Test transformers-neuronx gpt-j-6b with handler
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py transformers_neuronx gpt-j-6b
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-6 \
+          serve
+          curl http://127.0.0.1:8080/models
+          python3 llm/client.py transformers_neuronx gpt-j-6b
+          docker rm -f $(docker ps -aq)
+          sudo rm -rf models
       - name: On fail step
         if: ${{ failure() }}
         working-directory: tests/integration

--- a/engines/python/setup/djl_python/transformer-neuronx.py
+++ b/engines/python/setup/djl_python/transformer-neuronx.py
@@ -17,6 +17,7 @@ import logging
 
 from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer
 from transformers_neuronx import dtypes
+from transformers_neuronx.gptj.model import GPTJForSampling
 from transformers_neuronx.gpt2.model import GPT2ForSampling
 from transformers_neuronx.module import save_pretrained_split
 from transformers_neuronx.opt.model import OPTForSampling
@@ -64,7 +65,7 @@ class TransformerNeuronXService(object):
             f.writelines("opt-converted")
         return load_path
 
-    def convert_gpt2(self, amp):
+    def convert_gpt(self, amp, gpt_type="gpt2"):
         logging.warning(
             "Model conversion is a slow process to do in runtime, please consider convert it"
             " Ahead-of-Time next time")
@@ -85,7 +86,7 @@ class TransformerNeuronXService(object):
         logging.info(f"Saving to INF2 model to {load_path} ...")
         self.model.save_pretrained(load_path, max_shard_size="100GB")
         with open(os.path.join(load_path, "verify"), "w") as f:
-            f.writelines("gpt2-converted")
+            f.writelines("{}-converted".format(gpt_type))
         return load_path
 
     def load_opt(self, amp, unroll, n_positions):
@@ -104,8 +105,21 @@ class TransformerNeuronXService(object):
     def load_gpt2(self, amp, unroll, n_positions):
         load_path = self.model_id_or_path
         if not os.path.exists(os.path.join(load_path, "verify")):
-            load_path = self.convert_gpt2(amp)
+            load_path = self.convert_gpt(amp, gpt_type="gpt2")
         self.model = GPT2ForSampling.from_pretrained(
+            load_path,
+            batch_size=self.batch_size,
+            amp=amp,
+            tp_degree=self.tensor_parallel_degree,
+            n_positions=n_positions,
+            unroll=unroll)
+        self.model.to_neuron()
+
+    def load_gptj(self, amp, unroll, n_positions):
+        load_path = self.model_id_or_path
+        if not os.path.exists(os.path.join(load_path, "verify")):
+            load_path = self.convert_gpt(amp, gpt_type="gptj")
+        self.model = GPTJForSampling.from_pretrained(
             load_path,
             batch_size=self.batch_size,
             amp=amp,
@@ -137,6 +151,8 @@ class TransformerNeuronXService(object):
             self.load_opt(amp, unroll, n_positions)
         elif "gpt2" == model_config.model_type:
             self.load_gpt2(amp, unroll, n_positions)
+        elif "gptj" == model_config.model_type:
+            self.load_gptj(amp, unroll, n_positions)
         self.initialized = True
 
     def infer(self, inputs):

--- a/engines/python/setup/djl_python/transformer-neuronx.py
+++ b/engines/python/setup/djl_python/transformer-neuronx.py
@@ -86,7 +86,7 @@ class TransformerNeuronXService(object):
         logging.info(f"Saving to INF2 model to {load_path} ...")
         self.model.save_pretrained(load_path, max_shard_size="100GB")
         with open(os.path.join(load_path, "verify"), "w") as f:
-            f.writelines("{}-converted".format(gpt_type))
+            f.writelines(f"{gpt_type}-converted")
         return load_path
 
     def load_opt(self, amp, unroll, n_positions):

--- a/engines/python/setup/djl_python/transformer-neuronx.py
+++ b/engines/python/setup/djl_python/transformer-neuronx.py
@@ -27,7 +27,7 @@ model = None
 
 DTYPE_MAPPER = {"fp32": "f32", "fp16": "f16"}
 
-SUPPORTED_MODEL_TYPES = {"opt", "gpt2"}
+SUPPORTED_MODEL_TYPES = {"opt", "gpt2", "gptj"}
 
 
 class TransformerNeuronXService(object):

--- a/engines/python/setup/djl_python/transformers-neuronx.py
+++ b/engines/python/setup/djl_python/transformers-neuronx.py
@@ -30,7 +30,7 @@ DTYPE_MAPPER = {"fp32": "f32", "fp16": "f16"}
 SUPPORTED_MODEL_TYPES = {"opt", "gpt2", "gptj"}
 
 
-class TransformerNeuronXService(object):
+class TransformersNeuronXService(object):
 
     def __init__(self) -> None:
         self.initialized = False
@@ -183,7 +183,7 @@ class TransformerNeuronXService(object):
         return outputs
 
 
-_service = TransformerNeuronXService()
+_service = TransformersNeuronXService()
 
 
 def handle(inputs: Input):

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -46,6 +46,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     scripts/install_djl_serving.sh $djl_version && \
     scripts/install_inferentia2.sh $torch_neuronx_version && \
     pip install git+https://github.com/aws-neuron/transformers-neuronx.git && \
+    scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \
     useradd -m -d /home/djl djl && \
     chown -R djl:djl /opt/djl && \

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -133,6 +133,11 @@ transformers_neuronx_model_spec = {
         "worker": 3,
         "seq_length": [128, 256],
         "batch_size": [4]
+    },
+    "gpt-j-6b": {
+        "worker": 1,
+        "seq_length": [128, 256, 512],
+        "batch_size": [4]
     }
 }
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -144,7 +144,15 @@ transformers_neuronx_handler_list = {
         "option.n_positions": 256,
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600
-    }
+    },
+    "gpt-j-6b": {
+        "option.s3url": "s3://djl-llm/gpt-j-6b/",
+        "option.batch_size": 4,
+        "option.tensor_parallel_degree": 8,
+        "option.n_positions": 512,
+        "option.dtype": "fp32",
+        "option.model_loading_timeout": 720
+    },
 }
 
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -262,7 +262,7 @@ def build_transformers_neuronx_handler_model(model):
         )
     options = transformers_neuronx_handler_list[model]
     options["engine"] = "Python"
-    options["option.entryPoint"] = "djl_python.transformer-neuronx"
+    options["option.entryPoint"] = "djl_python.transformers-neuronx"
     write_properties(options)
 
 


### PR DESCRIPTION
## Description ##

Adding `gptj` to transformers handler

- If this change is a backward incompatible change, why must this change be made? *N/A*
- Interesting edge cases to note here *N/A*


### Testing
```
$ docker pull deepjavalibrary/djl-serving:pytorch-inf2-nightly
$ mkdir models
$ tee models/serving.properties > /dev/null <<EOF
option.s3url=s3://djl-llm/gpt-j-6b/
option.batch_size=4
option.tensor_parallel_degree=8
option.n_positions=512
option.dtype=fp32
option.model_loading_timeout=720
engine=Python
option.entryPoint=djl_python.transformer-neuronx
EOF
$ docker run -it --rm --network=host -v `pwd`/models:/opt/ml/model -v /home/ubuntu/djl-serving/tests/integration/logs:/opt/djl/logs -v /home/ubuntu/.aws:/home/djl/.aws -e TEST_TELEMETRY_COLLECTION=true -e MODEL_LOADING_TIMEOUT=7200 -e PREDICT_TIMEOUT=360 -u djl --device /dev/neuron0 --device /dev/neuron1 --device /dev/neuron2 --device /dev/neuron3 --device /dev/neuron4 --device /dev/neuron5 deepjavalibrary/djl-serving:pytorch-inf2-nightly /bin/bash
> export AWS_ACCESS_KEY_ID=****
> export AWS_SECRET_ACCESS_KEY=****
> export AWS_SESSION_TOKEN=****
> djl-serving -m /opt/ml/models

$ curl -X POST "http://127.0.0.1:8080/predictions/test"      -H 'Content-Type: application/json'      -d '{"seq_length":128, "text":["Hello, I'\''m a language model,","Welcome to Amazon Elastic Compute Cloud,"]}'
```