### PR TITLE
Create CacheWorkflowFunction

### DIFF
--- a/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
@@ -65,6 +65,9 @@ public class WorkflowDefinition {
     @SerializedName("functions")
     Map<String, String> funcs;
 
+    @SerializedName("configs")
+    Map<String, Map<String, Object>> configs;
+
     int queueSize;
     int maxIdleSeconds;
     int maxBatchDelayMillis;
@@ -174,7 +177,7 @@ public class WorkflowDefinition {
             }
         }
 
-        return new Workflow(name, version, models, expressions, loadedFunctions);
+        return new Workflow(name, version, models, expressions, configs, loadedFunctions);
     }
 
     private int firstValid(int... inputs) {

--- a/serving/src/main/java/ai/djl/serving/workflow/function/cache/CacheEngine.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/cache/CacheEngine.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function.cache;
+
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/** A cache that can be used as part of the {@link CacheWorkflowFunction}. */
+public interface CacheEngine {
+
+    /**
+     * Puts an item in the cache.
+     *
+     * @param hash the item hash
+     * @param data the data to store
+     */
+    void put(int hash, Item data);
+
+    /**
+     * Returns an item from the cache.
+     *
+     * @param hash the item hash
+     * @return the item
+     */
+    CompletableFuture<Optional<Item>> get(int hash);
+
+    /**
+     * Removes an item from the cache.
+     *
+     * @param hash the item hash
+     */
+    void clear(int hash);
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/cache/CacheWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/cache/CacheWorkflowFunction.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function.cache;
+
+import ai.djl.serving.workflow.Workflow.WorkflowArgument;
+import ai.djl.serving.workflow.Workflow.WorkflowExecutor;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+import ai.djl.serving.workflow.function.WorkflowFunction;
+import ai.djl.translate.ArgumentsUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link WorkflowFunction} "cache" that caches the results of the computation.
+ *
+ * <p>It should be called with three arguments such as ["cache", "modelName", "configName"].
+ *
+ * <p>The following config options are available:
+ *
+ * <ul>
+ *   <li>cache - the type of cache. Available options are "memory".
+ *   <li>capacity - the number of elements to cache. Only used by some cache engines including
+ *       "memory".
+ *   <li>usageTimeout - number of minutes between creating a cache element and it being removed.
+ * </ul>
+ */
+public class CacheWorkflowFunction extends WorkflowFunction {
+
+    public static final String NAME = "cache";
+
+    static final Logger logger = LoggerFactory.getLogger(CacheWorkflowFunction.class);
+
+    private Map<String, CacheEngine> caches;
+
+    /** Constructs a {@link CacheWorkflowFunction}. */
+    public CacheWorkflowFunction() {
+        caches = new ConcurrentHashMap<>();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CompletableFuture<Item> run(WorkflowExecutor executor, List<WorkflowArgument> args) {
+        if (args.size() != 3) {
+            throw new IllegalArgumentException(
+                    "The cache should have three args: model, input, settings but found "
+                            + args.size());
+        }
+
+        String modelName = args.get(0).getItem().getString();
+        WorkflowFunction model = executor.getExecutable(modelName);
+        WorkflowArgument input = args.get(1);
+        Map<String, Object> config = executor.getConfig(args.get(2));
+
+        CacheEngine cache = getOrCreateCacheEngine(modelName, config);
+
+        return input.evaluate()
+                .thenComposeAsync(
+                        processedInput -> {
+                            int hash =
+                                    Arrays.hashCode(
+                                            processedInput.getInput().getData().getAsBytes());
+
+                            // Try using cache
+                            return cache.get(hash)
+                                    .thenComposeAsync(
+                                            lookup -> {
+                                                if (lookup.isPresent()) {
+                                                    return CompletableFuture.completedFuture(
+                                                            lookup.get());
+                                                }
+
+                                                // Compute value through model
+                                                CompletableFuture<Item> output =
+                                                        model.run(
+                                                                        executor,
+                                                                        Collections.singletonList(
+                                                                                input))
+                                                                .whenComplete(
+                                                                        (item, e) ->
+                                                                                cache.put(
+                                                                                        hash,
+                                                                                        item));
+
+                                                // Clear if using usageTimeout
+                                                if (config.containsKey("usageTimeout")) {
+                                                    int usageTimeout =
+                                                            ArgumentsUtil.intValue(
+                                                                    config, "usageTimeout");
+                                                    output.whenCompleteAsync(
+                                                            (res, e) -> cache.clear(hash),
+                                                            CompletableFuture.delayedExecutor(
+                                                                    usageTimeout,
+                                                                    TimeUnit.MINUTES));
+                                                }
+                                                return output;
+                                            });
+                        });
+    }
+
+    private CacheEngine getOrCreateCacheEngine(String modelName, Map<String, Object> config) {
+        if (caches.containsKey(modelName)) {
+            return caches.get(modelName);
+        }
+
+        CacheEngine engine = constructCacheEngine(config);
+        caches.put(modelName, engine);
+        return engine;
+    }
+
+    private CacheEngine constructCacheEngine(Map<String, Object> config) {
+        String cacheType = ArgumentsUtil.stringValue(config, "cache");
+        switch (cacheType) {
+            case "memory":
+                int capacity = ArgumentsUtil.intValue(config, "capacity");
+                if (capacity == 0) {
+                    capacity = 128;
+                    logger.info(
+                            "The MemoryCacheEngine was not provided a capacity and is using the"
+                                    + " default value: "
+                                    + capacity);
+                }
+                return new MemoryCacheEngine(capacity);
+            default:
+                throw new IllegalArgumentException(
+                        "Workflow provided invalid or missing cache type: " + cacheType);
+        }
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/cache/MemoryCacheEngine.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/cache/MemoryCacheEngine.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function.cache;
+
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/** A simple {@link CacheEngine} that uses working memory. */
+public class MemoryCacheEngine implements CacheEngine {
+
+    Map<Integer, Item> cache;
+
+    /**
+     * Constructs a new {@link MemoryCacheEngine}.
+     *
+     * @param capacity the number of elements to cache
+     */
+    public MemoryCacheEngine(int capacity) {
+        // Simple LRU cache based on https://stackoverflow.com/a/224886/3483497
+        cache =
+                new LinkedHashMap<>(capacity + 1, .75f, true) {
+                    /** {@inheritDoc} */
+                    @Override
+                    public boolean removeEldestEntry(Entry<Integer, Item> eldest) {
+                        return size() > capacity;
+                    }
+                };
+        cache = Collections.synchronizedMap(cache);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void put(int hash, Item data) {
+        cache.put(hash, data);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CompletableFuture<Optional<Item>> get(int hash) {
+        return CompletableFuture.completedFuture(Optional.ofNullable(cache.get(hash)));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clear(int hash) {
+        cache.remove(hash);
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/cache/package-info.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/cache/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/**
+ * Contains the {@link ai.djl.serving.workflow.function.cache.CacheWorkflowFunction} and various
+ * cache components.
+ */
+package ai.djl.serving.workflow.function.cache;

--- a/serving/src/test/resources/workflows/cache.json
+++ b/serving/src/test/resources/workflows/cache.json
@@ -1,0 +1,15 @@
+{
+  "name": "CacheWorkflow",
+  "version": "0.1",
+  "models": {
+    "m": "https://resources.djl.ai/test-models/mlp.tar.gz"
+  },
+  "configs": {
+    "cacheConfig": {
+      "cache": "memory"
+    }
+  },
+  "workflow": {
+    "out": ["cache", "m", "in", "cacheConfig"]
+  }
+}


### PR DESCRIPTION
This creates a simple CacheWorkflowFunction that will cache the results of models (or other WorkflowFunctions).

It will be used as a precursor to a streaming equivalent.