### PR TITLE
install git by default for all python releases

### DIFF
--- a/serving/docker/scripts/install_aitemplate.sh
+++ b/serving/docker/scripts/install_aitemplate.sh
@@ -9,4 +9,3 @@ python setup.py bdist_wheel
 pip install dist/*.whl --force-reinstall
 cd ../../
 rm -rf AITemplate
-apt-get remove -y git

--- a/serving/docker/scripts/install_python.sh
+++ b/serving/docker/scripts/install_python.sh
@@ -7,7 +7,7 @@ set -ex
 apt-get update
 
 if [ -z "$PYTHON_VERSION" ]; then
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip git
 else
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl software-properties-common
   add-apt-repository -y ppa:deadsnakes/ppa


### PR DESCRIPTION
## Description ##

This will help the installation of git-based python dependencies:

```
git+https://github.com/facebookincubator/AITemplate
git+https://github.com/huggingface/transformers
```
