### PR TITLE
[serving] Removes 0.21.0 workaround.

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/DsNDManager.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/DsNDManager.java
@@ -16,11 +16,7 @@ import ai.djl.Device;
 import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDManager;
 
-/**
- * {@code DsNDManager} is the Python engine implementation of {@link NDManager}.
- *
- * <p>TODO: remove this class in 0.21.0
- */
+/** {@code DsNDManager} is the Python engine implementation of {@link NDManager}. */
 public class DsNDManager extends PyNDManager {
 
     DsNDManager(Engine engine, NDManager parent, Device device) {

--- a/engines/python/src/main/java/ai/djl/python/engine/PyNDManager.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyNDManager.java
@@ -89,7 +89,6 @@ public class PyNDManager extends BaseNDManager {
     /** {@inheritDoc} */
     @Override
     public Engine getEngine() {
-        // FIXME: return engine in 0.21.0, and make this method final
         return Engine.getEngine("Python");
     }
 

--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -311,10 +311,6 @@ public class PyEngineTest {
             NDArray array = list.singletonOrThrow();
             Assert.assertEquals(array.getShape(), new Shape(1, 3, 224, 224));
 
-            // workaround bug: https://github.com/deepjavalibrary/djl/pull/2436
-            // TODO: Remove in 0.22.0
-            list = new NDList(manager.create(array.toFloatArray(), new Shape(1, 3, 224, 224)));
-
             list = predictor.predict(list);
             Assert.assertEquals(list.get(0).getShape(), new Shape(1, 1000));
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
