### PR TITLE
[python] flush logging output before process end

### DIFF
--- a/engines/python/setup/djl_python_engine.py
+++ b/engines/python/setup/djl_python_engine.py
@@ -153,6 +153,9 @@ def main():
         logging.exception("Python engine process died")
     finally:
         logging.info(f"{pid} - Python process finished")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        logging.shutdown()
         if sock_type == 'unix':
             if os.path.exists(sock_name):
                 os.remove(sock_name)


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
