### PR TITLE
[serving] deprecate s3Url and replace it with model_id

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -109,8 +109,8 @@ class DeepSpeedService(object):
         self.initialized = True
 
     def _parse_properties(self, properties):
-        # If option.s3url is used, the directory is stored in model_id
-        # If option.s3url is not used but model_id is present, we download from hub
+        # model_id can point to huggingface model_id or local directory.
+        # If option.model_id points to a s3 bucket, we download it and set model_id to the download directory.
         # Otherwise we assume model artifacts are in the model_dir
         self.model_id_or_path = properties.get("model_id") or properties.get(
             "model_dir")

--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -63,8 +63,8 @@ class HuggingFaceService(object):
         self.initialized = False
 
     def initialize(self, properties: dict):
-        # If option.s3url is used, the directory is stored in model_id
-        # If option.s3url is not used but model_id is present, we download from hub
+        # model_id can point to huggingface model_id or local directory.
+        # If option.model_id points to a s3 bucket, we download it and set model_id to the download directory.
         # Otherwise we assume model artifacts are in the model_dir
         model_id_or_path = properties.get("model_id") or properties.get(
             "model_dir")

--- a/engines/python/setup/djl_python/stable-diffusion.py
+++ b/engines/python/setup/djl_python/stable-diffusion.py
@@ -46,8 +46,8 @@ class StableDiffusionService(object):
         self.save_image_dir = None
 
     def initialize(self, properties: dict):
-        # If option.s3url is used, the directory is stored in model_id
-        # If option.s3url is not used but model_id is present, we download from hub
+        # model_id can point to huggingface model_id or local directory.
+        # If option.model_id points to a s3 bucket, we download it and set model_id to the download directory.
         # Otherwise we assume model artifacts are in the model_dir
         self.model_id_or_path = properties.get("model_id") or properties.get(
             "model_dir")

--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -168,15 +168,20 @@ public class PyModel extends BaseModel {
         }
         pyEnv.setEntryPoint(entryPoint);
 
-        String s3Url = pyEnv.getInitParameters().get("s3url");
+        Map<String, String> initParameters = pyEnv.getInitParameters();
+        String s3Url = initParameters.get("s3url");
+        String modelId = pyEnv.getInitParameters().get("model_id");
         if (s3Url != null) {
-            if (pyEnv.getInitParameters().containsKey("model_id")) {
+            // s3url is deprecated, use model_id instead
+            if (modelId != null) {
                 throw new IllegalArgumentException("model_id and s3url could not both set!");
             }
-
-            logger.info("S3 url found, start downloading from {}", s3Url);
+            modelId = s3Url;
+        }
+        if (modelId != null && modelId.startsWith("s3://")) {
+            logger.info("S3 url found, start downloading from {}", modelId);
             String downloadDir = getDownloadDir().toString();
-            downloadS3(s3Url, downloadDir);
+            downloadS3(modelId, downloadDir);
             // point model_id to download directory
             pyEnv.addParameter("model_id", downloadDir);
         }

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -40,13 +40,14 @@ class PartitionService(object):
         self.download_model_from_s3()
 
     def download_model_from_s3(self):
-        if "s3url" not in self.properties:
+        model_id = self.properties.get("model_id")
+        if not model_id or not model_id.startswith("s3://"):
             return
 
         download_dir = os.environ.get("SERVING_DOWNLOAD_DIR",
                                       '/tmp/download/model/')
 
-        s3url = self.properties["s3url"]
+        s3url = model_id
         if Path("/opt/djl/bin/s5cmd").is_file():
             if not s3url.endswith("*"):
                 if s3url.endswith("/"):

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -71,16 +71,18 @@ class PropertiesManager(object):
         elif 'model_id' in self.properties:
             self.properties['model_dir'] = self.properties_dir
         elif 's3url' in self.properties:
+            # backward compatible only, should be replaced with model_id
             self.properties['model_dir'] = self.properties_dir
+            self.properties['model_id'] = self.properties['s3url']
+            self.properties.pop('s3url')
         else:
             model_files = glob.glob(os.path.join(self.properties_dir, '*.bin'))
             if model_files:
                 self.properties['model_dir'] = self.properties_dir
             else:
                 raise KeyError(
-                    'Please specify the option.model_dir or option.model_id or option.s3_url or '
-                    'include model '
-                    'files in the model-dir argument.')
+                    'Please specify the option.model_dir or option.model_id or include model files in the model-dir.'
+                )
 
     def generate_properties_file(self):
         checkpoint_path = self.properties.get('save_mp_checkpoint_path')

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -7,6 +7,7 @@ parser.add_argument('handler', help='the handler used in the model')
 parser.add_argument('model', help='model that works with certain handler')
 
 ds_aot_list = {
+    # Keep option.s3url to test backward compatible case
     "opt-6.7b": {
         "option.s3url": "s3://djl-llm/opt-6b7/",
         "option.tensor_parallel_degree": 4,
@@ -14,7 +15,7 @@ ds_aot_list = {
         "option.dtype": "float16"
     },
     "gpt-neox-20b": {
-        "option.s3url": "s3://djl-llm/gpt-neox-20b/",
+        "option.model_id": "s3://djl-llm/gpt-neox-20b/",
         "option.tensor_parallel_degree": 4,
         "option.task": "text-generation",
         "option.dtype": "float16"
@@ -23,16 +24,16 @@ ds_aot_list = {
 
 ds_model_list = {
     "gpt-j-6b": {
-        "option.s3url": "s3://djl-llm/gpt-j-6b/",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
         "option.tensor_parallel_degree": 4
     },
     "bloom-7b1": {
-        "option.s3url": "s3://djl-llm/bloom-7b1/",
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
         "option.tensor_parallel_degree": 4,
         "option.dtype": "float16"
     },
     "opt-30b": {
-        "option.s3url": "s3://djl-llm/opt-30b/",
+        "option.model_id": "s3://djl-llm/opt-30b/",
         "option.tensor_parallel_degree": 4
     }
 }
@@ -44,14 +45,14 @@ hf_handler_list = {
         "option.tensor_parallel_degree": 2
     },
     "gpt-j-6b": {
-        "option.s3url": "s3://djl-llm/gpt-j-6b/",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 2,
         "option.device_map": "auto",
         "option.dtype": "fp16"
     },
     "bloom-7b1": {
-        "option.s3url": "s3://djl-llm/bloom-7b1/",
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
         "option.tensor_parallel_degree": 4,
         "option.task": "text-generation",
         "option.load_in_8bit": "TRUE",
@@ -61,19 +62,19 @@ hf_handler_list = {
 
 ds_handler_list = {
     "gpt-j-6b": {
-        "option.s3url": "s3://djl-llm/gpt-j-6b/",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 2,
         "option.dtype": "bf16"
     },
     "bloom-7b1": {
-        "option.s3url": "s3://djl-llm/bloom-7b1/",
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
         "option.tensor_parallel_degree": 4,
         "option.task": "text-generation",
         "option.dtype": "fp16"
     },
     "opt-13b": {
-        "option.s3url": "s3://djl-llm/opt-13b/",
+        "option.model_id": "s3://djl-llm/opt-13b/",
         "option.tensor_parallel_degree": 2,
         "option.task": "text-generation",
         "option.dtype": "fp16"
@@ -82,17 +83,17 @@ ds_handler_list = {
 
 sd_handler_list = {
     "stable-diffusion-v1-5": {
-        "option.s3url": "s3://djl-llm/stable-diffusion-v1-5/",
+        "option.model_id": "s3://djl-llm/stable-diffusion-v1-5/",
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp16"
     },
     "stable-diffusion-2-1-base": {
-        "option.s3url": "s3://djl-llm/stable-diffusion-2-1-base/",
+        "option.model_id": "s3://djl-llm/stable-diffusion-2-1-base/",
         "option.tensor_parallel_degree": 2,
         "option.dtype": "fp16"
     },
     "stable-diffusion-2-depth": {
-        "option.s3url": "s3://djl-llm/stable-diffusion-2-depth/",
+        "option.model_id": "s3://djl-llm/stable-diffusion-2-depth/",
         "option.tensor_parallel_degree": 1,
         "option.dtype": "fp16",
         "gpu.maxWorkers": 1
@@ -101,13 +102,13 @@ sd_handler_list = {
 
 ft_handler_list = {
     "bigscience/bloom-3b": {
-        "option.s3url": "s3://djl-llm/bloom-3b/",
+        "option.model_id": "s3://djl-llm/bloom-3b/",
         "option.tensor_parallel_degree": 2,
         "option.dtype": "fp16",
         "gpu.maxWorkers": 1,
     },
     "flan-t5-xxl": {
-        "option.s3url": "s3://djl-llm/flan-t5-xxl/",
+        "option.model_id": "s3://djl-llm/flan-t5-xxl/",
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp32"
     }
@@ -123,18 +124,18 @@ ft_model_list = {
         "option.tensor_parallel_degree": 1,
     },
     "facebook/opt-6.7b": {
-        "option.s3url": "s3://djl-llm/opt-6b7/",
+        "option.model_id": "s3://djl-llm/opt-6b7/",
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp16",
     },
     "bigscience/bloom-3b": {
-        "option.s3url": "s3://djl-llm/bloom-3b/",
+        "option.model_id": "s3://djl-llm/bloom-3b/",
         "option.tensor_parallel_degree": 2,
         "option.dtype": "fp16",
         "gpu.maxWorkers": 1,
     },
     "flan-t5-xxl": {
-        "option.s3url": "s3://djl-llm/flan-t5-xxl/",
+        "option.model_id": "s3://djl-llm/flan-t5-xxl/",
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp32"
     }
@@ -152,7 +153,7 @@ transformers_neuronx_model_list = {
 
 transformers_neuronx_handler_list = {
     "opt-1.3b": {
-        "option.s3url": "s3://djl-llm/opt-1.3b/",
+        "option.model_id": "s3://djl-llm/opt-1.3b/",
         "option.batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 256,
@@ -160,7 +161,7 @@ transformers_neuronx_handler_list = {
         "option.model_loading_timeout": 600
     },
     "gpt-j-6b": {
-        "option.s3url": "s3://djl-llm/gpt-j-6b/",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
         "option.batch_size": 4,
         "option.tensor_parallel_degree": 8,
         "option.n_positions": 512,


### PR DESCRIPTION
- [serving] support load entryPoint with url
- [serving] deprecate s3Url and replace it with model_id

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
