### PR TITLE
KServe data to bytes fix

### DIFF
--- a/plugins/kserve/src/test/java/ai/djl/serving/kserve/KServeTensorTest.java
+++ b/plugins/kserve/src/test/java/ai/djl/serving/kserve/KServeTensorTest.java
@@ -20,8 +20,6 @@ import ai.djl.ndarray.types.Shape;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-
 public class KServeTensorTest {
 
     @Test
@@ -46,7 +44,6 @@ public class KServeTensorTest {
                         && type != DataType.UNKNOWN
                         && type != DataType.COMPLEX64) {
 
-                    System.out.println(Arrays.toString(data));
                     KServeTensor tensor = getKServeTensor(shape, type, data);
                     NDArray ndArray = tensor.toTensor(manager);
 

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -1082,7 +1082,7 @@ public class ModelServerTest {
         output.put("name", "output0");
         Map<String, Object> input = new ConcurrentHashMap<>();
         input.put("name", "input0");
-        input.put("dataType", "INT8");
+        input.put("datatype", "INT8");
         input.put("shape", new long[] {1, 10});
         input.put("data", new double[10]);
         Map<String, Object> data = new ConcurrentHashMap<>();


### PR DESCRIPTION
Kserve data conversion to bytes was faulty. Fixed by conversion to bytes according to datatype. 

Renamed dataType -> datatype (lowercase T), as this was the requirement in v2 protocol. (https://kserve.github.io/website/0.8/modelserving/inference_api/#model-metadata-response-json-object)