### PR TITLE
Minimal followup for BytesSupplier changes

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -14,7 +14,7 @@ package ai.djl.python.engine;
 
 import ai.djl.Model;
 import ai.djl.engine.EngineException;
-import ai.djl.modality.ChunkedBytesSupplier;
+import ai.djl.inference.streaming.ChunkedBytesSupplier;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.BytesSupplier;

--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -16,7 +16,7 @@ import ai.djl.ModelException;
 import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.inference.Predictor;
-import ai.djl.modality.ChunkedBytesSupplier;
+import ai.djl.inference.streaming.ChunkedBytesSupplier;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.BytesSupplier;

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -13,8 +13,8 @@
 package ai.djl.serving.http;
 
 import ai.djl.ModelException;
+import ai.djl.inference.streaming.ChunkedBytesSupplier;
 import ai.djl.metric.Metric;
-import ai.djl.modality.ChunkedBytesSupplier;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.BytesSupplier;


### PR DESCRIPTION
This fixes serving for changes from
https://github.com/deepjavalibrary/djl/pull/2470. Some more extensive changes should follow including using the servingPredict and PublisherBytesSupplier. To fix CI, they will be part of a separate PR.