### PR TITLE
Fix typo in streaming utils

### DIFF
--- a/engines/python/setup/djl_python/streaming_utils.py
+++ b/engines/python/setup/djl_python/streaming_utils.py
@@ -81,7 +81,7 @@ class StreamingUtils:
     @torch.inference_mode()
     def _transformers_neuronx_stream_generator(model, tokenizer, inputs,
                                                **kwargs):
-        sequence_length = kwargs.get("seq_len", 50)
+        sequence_length = kwargs.get("seq_length", 50)
         top_k = kwargs.get("top_k", 50)
         input_ids = torch.as_tensor(
             [tokenizer.encode(text) for text in inputs])


### PR DESCRIPTION
## Description ##

In the [handler](https://github.com/deepjavalibrary/djl-serving/blob/master/engines/python/setup/djl_python/transformers-neuronx.py#L180) `seq_length` is set.