### PR TITLE
[python] Makes download entryPoint atomic

### DIFF
--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -336,6 +336,9 @@ public class PyEngineTest {
                         .setTypes(Input.class, Output.class)
                         .optEngine("Python")
                         .optModelPath(Paths.get("src/test/resources/huggingface"))
+                        .optOption(
+                                "entryPoint",
+                                "https://raw.githubusercontent.com/deepjavalibrary/djl-serving/master/engines/python/setup/djl_python/huggingface.py")
                         .build();
         try (ZooModel<Input, Output> model = criteria.loadModel();
                 Predictor<Input, Output> predictor = model.newPredictor()) {


### PR DESCRIPTION
Also avoid download the file into fixed location

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
