### PR TITLE
Refactor CacheManager, Working Async

### DIFF
--- a/serving/src/main/java/ai/djl/serving/cache/CacheEngine.java
+++ b/serving/src/main/java/ai/djl/serving/cache/CacheEngine.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.cache;
+
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+/**
+ * A cache that can be used for streaming online caching, streaming pagination, or async
+ * predictions.
+ */
+public interface CacheEngine {
+
+    /**
+     * Returns whether the cache should combine results from multiple users.
+     *
+     * @return whether the cache should combine results from multiple users
+     */
+    boolean isMultiTenant();
+
+    /**
+     * Creates a new key to store in the cache.
+     *
+     * @return the cache key
+     */
+    default String create() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Adds the {@code Output} to cache and return the cache key.
+     *
+     * @param input the {@code Input} that could be used to build a key
+     * @return the cache key
+     */
+    default String create(Input input) {
+        if (isMultiTenant() && input != null) {
+            int hash = Arrays.hashCode(input.getData().getAsBytes());
+            return String.valueOf(hash);
+        }
+
+        return create();
+    }
+
+    /**
+     * Adds the {@code Output} to cache and return the cache key.
+     *
+     * @param key the cache key
+     * @param output the {@code Output} to be added in cache
+     */
+    void put(String key, Output output);
+
+    /**
+     * Adds the {@code Output} to cache and return the cache key.
+     *
+     * @param input the {@code Input} that could be used to build a key
+     * @param output the {@code Output} to be added in cache
+     * @return the cache key
+     */
+    default String put(Input input, Output output) {
+        String key = create(input);
+        put(key, output);
+        return key;
+    }
+
+    /**
+     * Returns the cached {@link Output} from the cache.
+     *
+     * @param key the cache key
+     * @return the item
+     */
+    Output get(String key);
+
+    /**
+     * Removes the cache from the key.
+     *
+     * @param key the cache key
+     */
+    void remove(String key);
+}

--- a/serving/src/main/java/ai/djl/serving/cache/CacheManager.java
+++ b/serving/src/main/java/ai/djl/serving/cache/CacheManager.java
@@ -12,67 +12,28 @@
  */
 package ai.djl.serving.cache;
 
-import ai.djl.modality.Output;
-
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
 /** A class that manages response cache. */
-public class CacheManager {
+public final class CacheManager {
 
-    private static CacheManager instance = new CacheManager();
+    private static CacheEngine instance = new MemoryCacheEngine();
 
-    private Map<String, Output> cache = new ConcurrentHashMap<>();
-
-    protected CacheManager() {}
+    private CacheManager() {}
 
     /**
-     * Returns the registered {@code CacheManager} instance.
+     * Returns the registered {@code CacheEngine} instance.
      *
-     * @return the registered {@code CacheManager} instance
+     * @return the registered {@code CacheEngine} instance
      */
-    public static CacheManager getInstance() {
+    public static CacheEngine getInstance() {
         return instance;
     }
 
     /**
-     * Sets the {@code CacheManager} instance.
+     * Sets the {@code CacheEngine} instance.
      *
-     * @param instance the {@code CacheManager} instance
+     * @param instance the {@code CacheEngine} instance
      */
-    public static void setCacheManager(CacheManager instance) {
+    public static void setCacheManager(CacheEngine instance) {
         CacheManager.instance = instance;
-    }
-
-    /**
-     * Adds the {@code Output} to cache and return the cache key.
-     *
-     * @param output the {@code Output} to be added in cache
-     * @return the cache key
-     */
-    public String put(Output output) {
-        String key = UUID.randomUUID().toString();
-        cache.put(key, output);
-        return key;
-    }
-
-    /**
-     * Returns the cached {@code Output} object witch the specified key.
-     *
-     * @param key the cache key
-     * @return the cached {@code Output} object
-     */
-    public Output get(String key) {
-        return cache.get(key);
-    }
-
-    /**
-     * Removes the cache from the key.
-     *
-     * @param key the cache key
-     */
-    public void remove(String key) {
-        cache.remove(key);
     }
 }

--- a/serving/src/main/java/ai/djl/serving/cache/CacheManager.java
+++ b/serving/src/main/java/ai/djl/serving/cache/CacheManager.java
@@ -15,7 +15,7 @@ package ai.djl.serving.cache;
 /** A class that manages response cache. */
 public final class CacheManager {
 
-    private static CacheEngine instance = new MemoryCacheEngine();
+    private static CacheEngine engine = new MemoryCacheEngine();
 
     private CacheManager() {}
 
@@ -24,8 +24,8 @@ public final class CacheManager {
      *
      * @return the registered {@code CacheEngine} instance
      */
-    public static CacheEngine getInstance() {
-        return instance;
+    public static CacheEngine getCacheEngine() {
+        return engine;
     }
 
     /**
@@ -33,7 +33,7 @@ public final class CacheManager {
      *
      * @param instance the {@code CacheEngine} instance
      */
-    public static void setCacheManager(CacheEngine instance) {
-        CacheManager.instance = instance;
+    public static void setCacheEngine(CacheEngine instance) {
+        CacheManager.engine = instance;
     }
 }

--- a/serving/src/main/java/ai/djl/serving/cache/MemoryCacheEngine.java
+++ b/serving/src/main/java/ai/djl/serving/cache/MemoryCacheEngine.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.cache;
+
+import ai.djl.modality.Output;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A {@link CacheEngine} that stores elements in working memory.
+ *
+ * <p>Note that this is not suitable if you expect the cache to work with a horizontally scaled
+ * system.
+ */
+public class MemoryCacheEngine implements CacheEngine {
+
+    private Map<String, Output> cache;
+    private boolean multiTenant;
+
+    /** Constructs a {@link MemoryCacheEngine}. */
+    public MemoryCacheEngine() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Constructs a {@link MemoryCacheEngine}.
+     *
+     * @param multiTenant whether to combine entries from multiple users
+     */
+    public MemoryCacheEngine(boolean multiTenant) {
+        this();
+        this.multiTenant = multiTenant;
+    }
+
+    /**
+     * Constructs an LRU {@link MemoryCacheEngine} with limited capacity.
+     *
+     * @param multiTenant whether to combine entries from multiple users
+     * @param capacity the maximum number of elements to store
+     */
+    public MemoryCacheEngine(boolean multiTenant, int capacity) {
+        // Simple LRU cache based on https://stackoverflow.com/a/224886/3483497
+        this.multiTenant = multiTenant;
+        cache =
+                new LinkedHashMap<>(capacity + 1, .75f, true) {
+                    /** {@inheritDoc} */
+                    @Override
+                    public boolean removeEldestEntry(Map.Entry<String, Output> eldest) {
+                        return size() > capacity;
+                    }
+                };
+        cache = Collections.synchronizedMap(cache);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isMultiTenant() {
+        return multiTenant;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void put(String key, Output output) {
+        cache.put(key, output);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Output get(String key) {
+        return cache.get(key);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void remove(String key) {
+        cache.remove(key);
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -277,7 +277,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                                 return null;
                             });
         } else { // Asynchronous
-            CacheEngine cache = CacheManager.getInstance();
+            CacheEngine cache = CacheManager.getCacheEngine();
             String nextToken = cache.create(input);
 
             // Store pending message to be sent for unfinished computations
@@ -314,7 +314,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             limit = Integer.MAX_VALUE;
         }
 
-        CacheEngine cache = CacheManager.getInstance();
+        CacheEngine cache = CacheManager.getCacheEngine();
         Output output = cache.get(startingToken);
         if (output == null) {
             throw new BadRequestException("Invalid " + X_STARTING_TOKEN);

--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** A flow of executing {@link ai.djl.Model}s and custom functions. */
@@ -46,12 +47,13 @@ public class Workflow {
     public static final String IN = "in";
     public static final String OUT = "out";
 
-    private static final Map<String, WorkflowFunction> BUILT_INS = new ConcurrentHashMap<>();
+    private static final Map<String, Supplier<WorkflowFunction>> BUILT_INS =
+            new ConcurrentHashMap<>();
 
     static {
-        BUILT_INS.put(IdentityWF.NAME, new IdentityWF());
-        BUILT_INS.put(EnsembleMerge.NAME, new EnsembleMerge());
-        BUILT_INS.put(FunctionsApply.NAME, new FunctionsApply());
+        BUILT_INS.put(IdentityWF.NAME, IdentityWF::new);
+        BUILT_INS.put(EnsembleMerge.NAME, EnsembleMerge::new);
+        BUILT_INS.put(FunctionsApply.NAME, FunctionsApply::new);
     }
 
     String name;
@@ -59,6 +61,7 @@ public class Workflow {
     Map<String, ModelInfo<Input, Output>> models;
     Map<String, WorkflowExpression> expressions;
     Map<String, WorkflowFunction> funcs;
+    Map<String, Map<String, Object>> configs;
 
     /**
      * Constructs a workflow containing only a single model.
@@ -74,6 +77,7 @@ public class Workflow {
                 Collections.singletonMap(
                         OUT, new WorkflowExpression(new Item(modelName), new Item(IN)));
         funcs = Collections.emptyMap();
+        configs = Collections.emptyMap();
     }
 
     /**
@@ -84,6 +88,7 @@ public class Workflow {
      * @param models a map of executableNames for a model (how it is referred to in the {@link
      *     WorkflowExpression}s to model
      * @param expressions a map of names to refer to an expression to the expression
+     * @param configs the configuration objects
      * @param funcs the custom functions used in the workflow
      */
     public Workflow(
@@ -91,12 +96,14 @@ public class Workflow {
             String version,
             Map<String, ModelInfo<Input, Output>> models,
             Map<String, WorkflowExpression> expressions,
+            Map<String, Map<String, Object>> configs,
             Map<String, WorkflowFunction> funcs) {
         this.name = name;
         this.version = version;
         this.models = models;
         this.expressions = expressions;
         this.funcs = funcs;
+        this.configs = configs;
     }
 
     /**
@@ -269,6 +276,16 @@ public class Workflow {
         /**
          * Returns the executable (model, function, or built-in) with a given name.
          *
+         * @param arg the workflow argument containing the name
+         * @return the function to execute the found executable
+         */
+        public WorkflowFunction getExecutable(WorkflowArgument arg) {
+            return getExecutable(arg.getItem().getString());
+        }
+
+        /**
+         * Returns the executable (model, function, or built-in) with a given name.
+         *
          * @param name the executable name
          * @return the function to execute the found executable
          */
@@ -283,10 +300,33 @@ public class Workflow {
             }
 
             if (BUILT_INS.containsKey(name)) {
-                return BUILT_INS.get(name);
+                // Built-in WorkflowFunctions should be one for each workflow
+                WorkflowFunction f = BUILT_INS.get(name).get();
+                funcs.put(name, f);
+                return f;
             }
 
             throw new IllegalArgumentException("Could not find find model or function: " + name);
+        }
+
+        /**
+         * Returns the configuration with the given name.
+         *
+         * @param name the configuration name
+         * @return the configuration
+         */
+        public Map<String, Object> getConfig(WorkflowArgument name) {
+            return getConfig(name.getItem().getString());
+        }
+
+        /**
+         * Returns the configuration with the given name.
+         *
+         * @param name the configuration name
+         * @return the configuration
+         */
+        public Map<String, Object> getConfig(String name) {
+            return configs.get(name);
         }
     }
 

--- a/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
@@ -66,6 +66,9 @@ public class WorkflowDefinition {
     @SerializedName("functions")
     Map<String, String> funcs;
 
+    @SerializedName("configs")
+    Map<String, Map<String, Object>> configs;
+
     int queueSize;
     int maxIdleSeconds;
     int maxBatchDelayMillis;
@@ -176,7 +179,7 @@ public class WorkflowDefinition {
             }
         }
 
-        return new Workflow(name, version, models, expressions, loadedFunctions);
+        return new Workflow(name, version, models, expressions, configs, loadedFunctions);
     }
 
     private int firstValid(int... inputs) {

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -743,6 +743,7 @@ public class ModelServerTest {
         assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
         String nextToken = headers.get("x-next-token");
         assertNotNull(nextToken);
+        Thread.sleep(500); // Sleep to wait for async to be finished
 
         url = "/predictions/echo";
         req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);


### PR DESCRIPTION
Splits the CacheManager into a CacheEngine interface along with a manager to manage a global cache. This then modifies the CacheEngine to also include a few additional pieces. It has a way to create a cache key before needing to store it which is used by the async and streaming sections. There is also some tentative features for multiTenant online caches.

It also modifies the InferenceRequestHandler's handling of async. Before, it wasn't actually asynchronous as it had to wait for the result to send the response. This sends the response before the computation is started.

Additionally, this PR also contains some changes adding a config to the Workflow system.

