### PR TITLE
[ci] bump up deepspeed version

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -14,7 +14,7 @@ FROM nvidia/cuda:$version
 ARG djl_version=0.21.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG accelerate_version=0.16.0
-ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.8.0-py2.py3-none-any.whl"
+ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.8.3-py2.py3-none-any.whl"
 ARG transformers_version=4.26.0
 ARG diffusers_version=0.12.0
 


### PR DESCRIPTION
## Description ##

Updating the DeepSpeed version for the 0.21.0 dlc.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
