### PR TITLE
Pinning aws-neuronx-* packages for Inf2 containers

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     scripts/install_python.sh ${python_version} && \
     scripts/install_djl_serving.sh $djl_version && \
     scripts/install_inferentia2.sh $torch_neuronx_version && \
-    pip install git+https://github.com/aws-neuron/transformers-neuronx.git && \
+    pip install git+https://github.com/aws-neuron/transformers-neuronx.git@v2.8.0 && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \
     useradd -m -d /home/djl djl && \

--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -14,12 +14,13 @@ apt-get update -y && apt-get install -y --no-install-recommends \
 echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc/apt/sources.list.d/neuron.list
 curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 
-apt-get update -y && apt-get install -y linux-headers-$(uname -r) && apt-get install -y aws-neuronx-dkms=2.* \
-    aws-neuronx-collectives=2.* \
-    aws-neuronx-runtime-lib=2.* \
-    aws-neuronx-tools=2.*
+# https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#inf2-packages
+apt-get update -y && apt-get install -y linux-headers-$(uname -r) && apt-get install -y aws-neuronx-dkms=2.8.4.* \
+    aws-neuronx-collectives=2.12.27.* \
+    aws-neuronx-runtime-lib=2.12.16.* \
+    aws-neuronx-tools=2.9.5.*
 
 export PATH=/opt/aws/neuron/bin:$PATH
 
 python3 -m pip install numpy awscli
-python3 -m pip install neuronx-cc==2.* torch_neuronx==${TORCH_NEURONX_VERSION} --extra-index-url=https://pip.repos.neuron.amazonaws.com
+python3 -m pip install neuronx-cc==2.4.* torch_neuronx==${TORCH_NEURONX_VERSION} --extra-index-url=https://pip.repos.neuron.amazonaws.com


### PR DESCRIPTION
## Description ##

Pinning `aws-neuronx-*` packages to 2.8 for Inf2 containers

- If this change is a backward incompatible change, why must this change be made? N/A
- Interesting edge cases to note here N/A
