### PR TITLE
Infer lmi engine

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -41,7 +41,6 @@ import ai.djl.util.cuda.CudaUtils;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import jdk.jshell.execution.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.management.MemoryUsage;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -619,7 +617,11 @@ public final class ModelInfo<I, O> {
         if (huggingFaceHubModelId == null && Files.isRegularFile(modelDir.resolve("config.json"))) {
             modelConfigUri = modelDir.resolve("config.json").toUri();
         } else {
-            modelConfigUri = URI.create("https://huggingface.co/" + huggingFaceHubModelId + "/raw/main/config.json");
+            modelConfigUri =
+                    URI.create(
+                            "https://huggingface.co/"
+                                    + huggingFaceHubModelId
+                                    + "/raw/main/config.json");
         }
 
         JsonObject modelConfig;

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -726,8 +726,11 @@ public final class ModelInfo<I, O> {
                         new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             return JsonUtils.GSON.fromJson(reader, JsonElement.class).getAsJsonObject();
         } catch (IOException e) {
-            logger.warn("Could not read model config from {}", modelConfigUri, e);
-            return null;
+            logger.error(
+                    "The huggingface hub model_id {} is not valid. Please verify this is a valid"
+                            + " model_id",
+                    modelId);
+            throw e;
         }
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -603,9 +603,12 @@ public final class ModelInfo<I, O> {
             } catch (IOException e) {
                 logger.warn("Failed search parameter files in folder: " + modelDir, e);
             }
-            engine = inferLMIEngine();
-            if (engine != null) {
-                return engine;
+            String huggingFaceHubModelId = Utils.getEnvOrSystemProperty("HF_MODEL_ID");
+            if (huggingFaceHubModelId == null) {
+                huggingFaceHubModelId = prop.get("option.modelId").toString();
+            }
+            if (huggingFaceHubModelId != null && !huggingFaceHubModelId.startsWith("s3://")) {
+                return inferLMIEngine();
             }
         }
         throw new ModelNotFoundException("Failed to detect engine of the model: " + modelDir);
@@ -623,7 +626,7 @@ public final class ModelInfo<I, O> {
             modelConfig = JsonUtils.GSON.fromJson(reader, JsonElement.class).getAsJsonObject();
         } catch (IOException e) {
             logger.error("Could not read model config for {} from huggingface hub", huggingFaceHubModelId, e);
-            return null;
+            return "Python";
         }
 
         String modelType = modelConfig.get("model_type").getAsString();

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -83,8 +83,7 @@ public final class ModelInfo<I, O> {
                     "gptj",
                     "opt",
                     "gpt_neox",
-                    "bloom",
-                    "stable-diffusion");
+                    "bloom");
 
     private transient String id;
     private String version;
@@ -654,10 +653,6 @@ public final class ModelInfo<I, O> {
                     Integer.parseInt(prop.get("option.tensor_parallel_degree").toString());
         }
 
-        logger.info("model_type: {}", modelType);
-        logger.info("tensor_parallel_degree: {}", tensorParallelDegree);
-        logger.info("num attention heads: {}", numAttentionHeads);
-
         if (tensorParallelDegree > 0) {
             prop.put("option.tensor_parallel_degree", tensorParallelDegree);
         }
@@ -667,6 +662,7 @@ public final class ModelInfo<I, O> {
         }
 
         if ("stable-diffusion".equals(modelType)) {
+            // TODO: Move this from hardcoded to deduced in PyModel
             prop.put("option.entryPoint", "djl_python.stable-diffusion");
             return "DeepSpeed";
         }

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -38,8 +38,6 @@ import ai.djl.util.NeuronUtils;
 import ai.djl.util.Utils;
 import ai.djl.util.cuda.CudaUtils;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 
@@ -711,11 +709,7 @@ public final class ModelInfo<I, O> {
         try (InputStream is = modelConfigUri.toURL().openStream();
                 BufferedReader reader =
                         new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-            Gson gson =
-                    JsonUtils.builder()
-                            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                            .create();
-            return gson.fromJson(reader, HuggingFaceModelConfig.class);
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
         } catch (IOException | JsonSyntaxException e) {
             throw new ModelException("Invalid huggingface model id: " + modelId, e);
         }
@@ -1079,10 +1073,10 @@ public final class ModelInfo<I, O> {
         FAILED
     }
 
-    //  This represents  the config of huggingface models NLP models as well
+    // This represents  the config of huggingface models NLP models as well
     // as the config of diffusers models. The config is different for both, but for
     // now we can leverage a single class since we don't need too much information from the config.
-    static class HuggingFaceModelConfig {
+    static final class HuggingFaceModelConfig {
         @SerializedName("model_type")
         private String modelType;
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.management.MemoryUsage;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -626,7 +627,8 @@ public final class ModelInfo<I, O> {
 
         JsonObject modelConfig;
         try (InputStream is = modelConfigUri.toURL().openStream();
-                BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+                BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             modelConfig = JsonUtils.GSON.fromJson(reader, JsonElement.class).getAsJsonObject();
         } catch (IOException e) {
             logger.warn(

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -27,6 +27,7 @@ import ai.djl.util.Utils;
 import ai.djl.util.ZipUtils;
 
 import com.google.gson.JsonObject;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -250,41 +251,43 @@ public class ModelInfoTest {
     @Test
     public void testInferLMIEngine() throws IOException, ModelException {
         Path modelStore = Paths.get("build/models");
-        Path modelDir = modelStore.resolve("test_model");
+        Path modelDir = modelStore.resolve("lmi_test_model");
         Files.createDirectories(modelDir);
 
         System.setProperty("HF_MODEL_ID", "gpt2");
         System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
-        ModelInfo<Input, Output> model = new ModelInfo<>("build/models/test_model");
+        ModelInfo<Input, Output> model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "DeepSpeed");
 
         System.setProperty("HF_MODEL_ID", "google/flan-t5-xl");
-        model = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "FasterTransformer");
 
         System.setProperty("HF_MODEL_ID", "gpt2-xl");
-        model = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
         System.setProperty("HF_MODEL_ID", "Salesforce/codegen-6B-mono");
-        model = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
         System.setProperty("HF_MODEL_ID", "invalid-model-id");
-        model = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
         JsonObject modelConfig = new JsonObject();
         modelConfig.addProperty("model_type", "bloom");
         modelConfig.addProperty("num_heads", "12");
-        Files.write(modelDir.resolve("config.json"), modelConfig.toString().getBytes());
+        Files.write(
+                modelDir.resolve("config.json"),
+                modelConfig.toString().getBytes(StandardCharsets.UTF_8));
         System.clearProperty("HF_MODEL_ID");
-        model = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "DeepSpeed");
 

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -277,8 +277,7 @@ public class ModelInfoTest {
 
         System.setProperty("HF_MODEL_ID", "invalid-model-id");
         model = new ModelInfo<>("build/models/lmi_test_model");
-        model.initialize();
-        assertEquals(model.getEngineName(), "Python");
+        Assert.assertThrows(model::initialize);
 
         System.setProperty("HF_MODEL_ID", "stabilityai/stable-diffusion-2-1");
         System.clearProperty("TENSOR_PARALLEL_DEGREE");

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -253,6 +253,18 @@ public class ModelInfoTest {
         Path modelStore = Paths.get("build/models");
         Path modelDir = modelStore.resolve("lmi_test_model");
         Files.createDirectories(modelDir);
+        Path deepspeedLocation = Paths.get("/usr/local/bin/deepspeed");
+        boolean deepspeedExisted = true;
+        if (!Files.exists(deepspeedLocation)) {
+            Files.createDirectories(deepspeedLocation);
+            deepspeedExisted = false;
+        }
+        Path fastertransformerLocation = Paths.get("/usr/local/backends/fastertransformer");
+        boolean fastertransformerExisted = true;
+        if (!Files.exists(fastertransformerLocation)) {
+            Files.createDirectories(fastertransformerLocation);
+            fastertransformerExisted = false;
+        }
 
         System.setProperty("HF_MODEL_ID", "gpt2");
         System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
@@ -298,7 +310,12 @@ public class ModelInfoTest {
         assertEquals(model.getEngineName(), "DeepSpeed");
 
         System.clearProperty("HF_MODEL_ID");
-        System.clearProperty("HF_TASK");
         System.clearProperty("TENSOR_PARALLEL_DEGREE");
+        if (!deepspeedExisted) {
+            Files.delete(deepspeedLocation);
+        }
+        if (!fastertransformerExisted) {
+            Files.delete(fastertransformerLocation);
+        }
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -252,26 +252,27 @@ public class ModelInfoTest {
         Files.createDirectories(modelDir);
 
         System.setProperty("HF_MODEL_ID", "gpt2");
-        System.setProperty("HF_TASK", "text-generation");
         System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
         ModelInfo<Input, Output> model = new ModelInfo<>("build/models/test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "DeepSpeed");
 
         System.setProperty("HF_MODEL_ID", "google/flan-t5-xl");
-        System.setProperty("HF_TASK", "text2text-generation");
         model = new ModelInfo<>("build/models/test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "FasterTransformer");
 
         System.setProperty("HF_MODEL_ID", "gpt2-xl");
-        System.setProperty("HF_TASK", "text-generation");
-        model  = new ModelInfo<>("build/models/test_model");
+        model = new ModelInfo<>("build/models/test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
         System.setProperty("HF_MODEL_ID", "Salesforce/codegen-6B-mono");
-        System.setProperty("HF_TASK", "text-generation");
+        model = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "Python");
+
+        System.setProperty("HF_MODEL_ID", "invalid-model-id");
         model = new ModelInfo<>("build/models/test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
@@ -279,6 +280,5 @@ public class ModelInfoTest {
         System.clearProperty("HF_MODEL_ID");
         System.clearProperty("HF_TASK");
         System.clearProperty("TENSOR_PARALLEL_DEGREE");
-
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -244,4 +244,13 @@ public class ModelInfoTest {
         model.initialize();
         assertEquals(model.getEngineName(), "PyTorch");
     }
+
+    @Test
+    public void testInitHuggingFaceHubModel() throws IOException, ModelException {
+        System.setProperty("HF_MODEL_ID", "gpt2");
+        System.setProperty("HF_TASK", "text-generation");
+        ModelInfo<Input, Output> model = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        Assert.assertEquals(model.getEngineName(), "DeepSpeed");
+    }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -246,11 +246,39 @@ public class ModelInfoTest {
     }
 
     @Test
-    public void testInitHuggingFaceHubModel() throws IOException, ModelException {
+    public void testInferLMIEngine() throws IOException, ModelException {
+        Path modelStore = Paths.get("build/models");
+        Path modelDir = modelStore.resolve("test_model");
+        Files.createDirectories(modelDir);
+
         System.setProperty("HF_MODEL_ID", "gpt2");
         System.setProperty("HF_TASK", "text-generation");
+        System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
         ModelInfo<Input, Output> model = new ModelInfo<>("build/models/test_model");
         model.initialize();
-        Assert.assertEquals(model.getEngineName(), "DeepSpeed");
+        assertEquals(model.getEngineName(), "DeepSpeed");
+
+        System.setProperty("HF_MODEL_ID", "google/flan-t5-xl");
+        System.setProperty("HF_TASK", "text2text-generation");
+        model = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "FasterTransformer");
+
+        System.setProperty("HF_MODEL_ID", "gpt2-xl");
+        System.setProperty("HF_TASK", "text-generation");
+        model  = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "Python");
+
+        System.setProperty("HF_MODEL_ID", "Salesforce/codegen-6B-mono");
+        System.setProperty("HF_TASK", "text-generation");
+        model = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "Python");
+
+        System.clearProperty("HF_MODEL_ID");
+        System.clearProperty("HF_TASK");
+        System.clearProperty("TENSOR_PARALLEL_DEGREE");
+
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -280,9 +280,16 @@ public class ModelInfoTest {
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
+        System.setProperty("HF_MODEL_ID", "stabilityai/stable-diffusion-2-1");
+        System.clearProperty("TENSOR_PARALLEL_DEGREE");
+        model = new ModelInfo<>("build/models/lmi_test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "DeepSpeed");
+
         JsonObject modelConfig = new JsonObject();
         modelConfig.addProperty("model_type", "bloom");
         modelConfig.addProperty("num_heads", "12");
+        System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
         Files.write(
                 modelDir.resolve("config.json"),
                 modelConfig.toString().getBytes(StandardCharsets.UTF_8));

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -253,37 +253,9 @@ public class ModelInfoTest {
         Path modelStore = Paths.get("build/models");
         Path modelDir = modelStore.resolve("lmi_test_model");
         Files.createDirectories(modelDir);
-        Path deepspeedLocation = Paths.get("/usr/local/bin/deepspeed");
-        boolean deepspeedExisted = true;
-        if (!Files.exists(deepspeedLocation)) {
-            Files.createDirectories(deepspeedLocation);
-            deepspeedExisted = false;
-        }
-        Path fastertransformerLocation = Paths.get("/usr/local/backends/fastertransformer");
-        boolean fastertransformerExisted = true;
-        if (!Files.exists(fastertransformerLocation)) {
-            Files.createDirectories(fastertransformerLocation);
-            fastertransformerExisted = false;
-        }
-
-        System.setProperty("HF_MODEL_ID", "gpt2");
-        System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
-        ModelInfo<Input, Output> model = new ModelInfo<>("build/models/lmi_test_model");
-        model.initialize();
-        assertEquals(model.getEngineName(), "DeepSpeed");
-
-        System.setProperty("HF_MODEL_ID", "google/flan-t5-xl");
-        model = new ModelInfo<>("build/models/lmi_test_model");
-        model.initialize();
-        assertEquals(model.getEngineName(), "FasterTransformer");
 
         System.setProperty("HF_MODEL_ID", "gpt2-xl");
-        model = new ModelInfo<>("build/models/lmi_test_model");
-        model.initialize();
-        assertEquals(model.getEngineName(), "Python");
-
-        System.setProperty("HF_MODEL_ID", "Salesforce/codegen-6B-mono");
-        model = new ModelInfo<>("build/models/lmi_test_model");
+        ModelInfo<Input, Output> model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
 
@@ -291,14 +263,8 @@ public class ModelInfoTest {
         model = new ModelInfo<>("build/models/lmi_test_model");
         Assert.assertThrows(model::initialize);
 
-        System.setProperty("HF_MODEL_ID", "stabilityai/stable-diffusion-2-1");
-        System.clearProperty("TENSOR_PARALLEL_DEGREE");
-        model = new ModelInfo<>("build/models/lmi_test_model");
-        model.initialize();
-        assertEquals(model.getEngineName(), "DeepSpeed");
-
         JsonObject modelConfig = new JsonObject();
-        modelConfig.addProperty("model_type", "bloom");
+        modelConfig.addProperty("model_type", "codegen");
         modelConfig.addProperty("num_heads", "12");
         System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
         Files.write(
@@ -307,15 +273,9 @@ public class ModelInfoTest {
         System.clearProperty("HF_MODEL_ID");
         model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
-        assertEquals(model.getEngineName(), "DeepSpeed");
+        assertEquals(model.getEngineName(), "Python");
 
         System.clearProperty("HF_MODEL_ID");
         System.clearProperty("TENSOR_PARALLEL_DEGREE");
-        if (!deepspeedExisted) {
-            Files.delete(deepspeedLocation);
-        }
-        if (!fastertransformerExisted) {
-            Files.delete(fastertransformerLocation);
-        }
     }
 }

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -26,6 +26,7 @@ import ai.djl.translate.TranslateException;
 import ai.djl.util.Utils;
 import ai.djl.util.ZipUtils;
 
+import com.google.gson.JsonObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
@@ -276,6 +277,15 @@ public class ModelInfoTest {
         model = new ModelInfo<>("build/models/test_model");
         model.initialize();
         assertEquals(model.getEngineName(), "Python");
+
+        JsonObject modelConfig = new JsonObject();
+        modelConfig.addProperty("model_type", "bloom");
+        modelConfig.addProperty("num_heads", "12");
+        Files.write(modelDir.resolve("config.json"), modelConfig.toString().getBytes());
+        System.clearProperty("HF_MODEL_ID");
+        model = new ModelInfo<>("build/models/test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "DeepSpeed");
 
         System.clearProperty("HF_MODEL_ID");
         System.clearProperty("HF_TASK");


### PR DESCRIPTION
## Description ##

This PR adds support for inferring the specific Python engine to use. This logic should only be called when users don't specify engine in `serving.properties`, and we can reasonably assume the model is intended to be run with a Python backend.

Use Cases covered:
- User only specifies HF_MODEL_ID environment variable (no serving properties, model artifacts, or user code)
- User provides serving properties with model id (either hf hub id or s3 url), but does not specify engine
- model_id is not provided in any form, but model artifacts are present in model_dir

This does not support the use case where users provide their own code that is expected to be invoked via the hugging face inference toolkit. There's no special error handling for that now, it will just fail when the PyProcess tries to load the handler and invoke it.

The logic for inferring the backend is largely copied over from the logic in the PySDK.



