### PR TITLE
[fix] pin triton due to SD triton flash failing for deepspeed

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu118 \
     ${deepspeed_wheel} transformers==${transformers_version} \
-    triton==2.0.0 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
+    triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
     pip3 install diffusers[torch]==${diffusers_version} xformers==${xformers_version} && \
     scripts/install_aitemplate.sh && \
     scripts/patch_oss_dlc.sh python && \


### PR DESCRIPTION
## Description ##

DeepSpeed container failing on stable diffusion ci due to an error from triton 2.0 flash attention, pinning to 2.0.0.dev20221202 while we resolve.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
