### PR TITLE
[fix] removing xformers due to torch 2.0.0 deps

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -14,7 +14,6 @@ FROM nvidia/cuda:$version
 ARG djl_version=0.22.1~SNAPSHOT
 ARG python_version=3.9
 ARG torch_version=1.13.1
-ARG xformers_version=0.0.18
 ARG accelerate_version=0.18.0
 ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.8.3-py2.py3-none-any.whl"
 ARG transformers_version=4.27.4
@@ -53,8 +52,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} --extra-index-url https://download.pytorch.org/whl/cu117 \
     ${deepspeed_wheel} transformers==${transformers_version} \
-    triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes && \
-    pip3 install diffusers[torch]==${diffusers_version} xformers==${xformers_version} && \
+    triton==2.0.0.dev20221202 mpi4py sentencepiece accelerate==${accelerate_version} bitsandbytes \
+    diffusers[torch]==${diffusers_version} && \
     scripts/install_aitemplate.sh && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh deepspeed && \


### PR DESCRIPTION
## Description ##

The xformers package was added to improve SD performance, but requires torch 2.0.0 due to pip limitation. Since we downgraded and because we having added the SD performance optimization I want to remove the package for now, so that it no longer installs torch 2.0.0 and triton 2.0.0 when installed.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
