### PR TITLE
Remove streaming from no-code test

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -70,7 +70,6 @@ hf_model_spec = {
         "batch_size": [1, 4],
         "seq_length": [16, 32],
         "worker": 2,
-        "stream_output": True,
     },
     "no-code/google/flan-t5-xl": {
         "max_memory_per_gpu": [7.0, 7.0, 7.0, 7.0],


### PR DESCRIPTION
## Description ##

The no-code test client should not expect streaming output. With no code, we don't provide any serving.properties which means by default streaming is disabled. client should not try to read response in streaming fashion.
