### PR TITLE
Fix issues with no code default handlers and tests

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -66,7 +66,7 @@ hf_model_spec = {
         "worker": 1
     },
     "no-code/databricks/dolly-v2-7b": {
-        "max_memory_per_gpu": [10.0, 10.0, 11.0, 12.0],
+        "max_memory_per_gpu": [10.0, 10.0, 12.0, 12.0],
         "batch_size": [1, 4],
         "seq_length": [16, 32],
         "worker": 2,
@@ -277,7 +277,9 @@ def test_handler(model, model_spec):
                     result
                 ) <= seq_length, "generated more takens than max_new_tokens"
                 result_0 = json.loads(result[0])['outputs']
-                assert len(result_0) == batch_size, "batch size number of tokens are not generated"
+                assert len(
+                    result_0
+                ) == batch_size, "batch size number of tokens are not generated"
             else:
                 res = res.json()
                 logging.info(f"res {res}")
@@ -422,7 +424,9 @@ def test_transformers_neuronx_handler(model, model_spec):
             if spec.get("stream_output", False):
                 logging.info(f"res: {res.content}")
                 result = res.content.decode().split("\n")[:-1]
-                assert len(result) <= seq_length, "generated more takens than max_new_tokens"
+                assert len(
+                    result
+                ) <= seq_length, "generated more takens than max_new_tokens"
             else:
                 res = res.json()
                 logging.info(f"res {res}")


### PR DESCRIPTION
## Description ##

Two issues:
- memory expectations for the dollyv2 model were off. updated those based on testing
- no code experience for huggingface accelerate backend is broken. the huggingface handler expects that task is provided, or the model config is available locally. It didn't support just huggingface model id. Fixed that issue as well

other changes from ./gradlew formatPython
