### PR TITLE
SM Training job changes for AOT

### DIFF
--- a/serving/docker/dockerd-entrypoint.sh
+++ b/serving/docker/dockerd-entrypoint.sh
@@ -9,7 +9,7 @@ if [[ "$1" = "serve" ]]; then
         /usr/bin/djl-serving "$@"
         code=$?
     done
-elif [[ "$1" = "partition" ]]; then
+elif [[ "$1" = "partition" ]] || [[ "$1" = "train" ]]; then
     shift 1
     /usr/bin/python3 /opt/djl/partition/partition.py "$@"
 else

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -139,6 +139,9 @@ class PartitionService(object):
         if not saved_checkpoints_dir.endswith('/'):
             saved_checkpoints_dir = saved_checkpoints_dir + '/'
 
+        if not s3url.endswith('/'):
+            s3url = s3url + '/'
+
         if Path("/opt/djl/bin/s5cmd").is_file():
             commands = [
                 "/opt/djl/bin/s5cmd", "--retry-count", "1", "sync",
@@ -166,6 +169,7 @@ class PartitionService(object):
         logging.info(result)
         if result.returncode == 0:
             logging.info(f"Partitioning done.")
+            self.properties_manager.validate_and_correct_checkpoints_json()
             self.properties_manager.generate_properties_file()
             self.copy_config_files()
             self.upload_checkpoints_to_s3()
@@ -184,6 +188,8 @@ if __name__ == "__main__":
     parser.add_argument(
         '--model-dir',
         type=str,
+        required=False,
+        default='/opt/ml/input/data/training',
         help='path of the model directory containing model/properties file')
 
     args = parser.parse_args()

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import glob
+import json
 import torch
 import requests
 
@@ -90,6 +91,35 @@ class PropertiesManager(object):
                     'Please specify the option.model_dir or option.model_id or include model files in the model-dir.'
                 )
 
+    def validate_and_correct_checkpoints_json(self):
+        """
+        Removes base_dir from ds_inference_checkpoints.json file.
+
+        DeepSpeed writes base_dir directory, which is the path of checkpoints saved to the file.
+        Removing the base_dir since the user's deployment environment could be different from partition environment.
+        User can specify base_dir argument in deepspeed.init_inference while using this file.
+
+        :return:
+        """
+        if self.properties['engine'] == 'DeepSpeed':
+            config_file = os.path.join(
+                self.properties['save_mp_checkpoint_path'],
+                'ds_inference_config.json')
+            if not os.path.exists(config_file):
+                raise Exception("Checkpoints json file was not generated."
+                                "Partition was not successful.")
+
+            configs = {}
+            with open(config_file) as f:
+                configs = json.load(f)
+
+            if not configs.get('base_dir'):
+                return
+
+            configs.pop('base_dir')
+            with open(config_file, "w") as f:
+                json.dump(configs, f)
+
     def generate_properties_file(self):
         checkpoint_path = self.properties.get('save_mp_checkpoint_path')
         configs = {
@@ -145,7 +175,7 @@ class PropertiesManager(object):
                     self.properties['entryPoint'] = 'model.py'
                 else:
                     engine = self.properties['engine']
-                    if engine == "Deepspeed":
+                    if engine == "DeepSpeed":
                         entry_point = "djl_python.deepspeed"
                     elif engine == "FasterTransformer":
                         entry_point = "djl_python.fastertransformer"


### PR DESCRIPTION
## Description ##

By default, Sagemaker training job, 
- invokes the docker container with entrypoint command `train`
- downloads the input model to `/opt/ml/input/data/` with the channel name `training`. So input model will be downloaded to `/opt/ml/input/data/training`
-  SM looks for the files in `/opt/ml/model` and upload it to s3 output url provided. 


AOT in SM using Estimator
```
from sagemaker.estimator import Estimator

algo = Estimator(
   image_uri='125045733377.dkr.ecr.us-east-1.amazonaws.com/sm-test:smtrain_ft',
   role='AmazonSageMaker-ExecutionRole-djl',
   instance_count=1,
   instance_type='ml.g5.12xlarge')

algo.fit('s3://djl-sm-test/models/opt-1.3b-ft/')
```

AOT using DJLModel
```
from sagemaker.djl_inference import DJLModel

djl_model = DJLModel(
    "facebook/opt-1.3b",
    "AmazonSageMaker-ExecutionRole-djl",
    data_type="fp16",
    task="text-generation",
    number_of_partitions=2,
    image_uri="125045733377.dkr.ecr.us-east-1.amazonaws.com/sm-test:smtrain_ft")
    
djl_model.partition("ml.g5.12xlarge", "s3://djl-sm-test/models/opt-1.3b-ft-sharded")

djl_model.deploy("ml.g5.12xlarge", initial_instance_count=1)
```
