### PR TITLE
[fix] update JSON format for performance metrics upload

### DIFF
--- a/tests/integration/lmic_test_builder.py
+++ b/tests/integration/lmic_test_builder.py
@@ -214,7 +214,7 @@ class LMITestRunner:
             file = open("llm/metrics.log", "r")
             metrics = re.sub("'", r'"', file.readline())
             command = f'aws cloudwatch put-metric-data --namespace "LMIC_performance_{sequence["engine"]}" ' \
-                      f'--region "us-east-1" --metric-data "{metrics}"'
+                      f'--region "us-east-1" --metric-data \'{metrics}\''
         logging.info(command)
         sp.call(command, shell=True)
         self.clean_metrics()


### PR DESCRIPTION
## Description ##

Updating the outer quotes to single quotes for metrics upload. Previous version was not being parsed correctly.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
