### PR TITLE
Refactor logic for supporting HF_MODEL_ID to support MME use case

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -469,23 +469,21 @@ public class ModelServer {
         Path parent = downloadDir == null ? Utils.getCacheDir() : Paths.get(downloadDir);
         parent = parent.resolve(modelId);
         Path huggingFaceModelDir = parent.resolve(hash);
-        if (Files.exists(huggingFaceModelDir)) {
-            logger.warn("HuggingFace Model {} already exists", huggingFaceModelDir);
-            return null;
+        if (!Files.exists(huggingFaceModelDir)) {
+            Properties huggingFaceProperties = new Properties();
+            huggingFaceProperties.put("option.model_id", modelId);
+            String task = Utils.getEnvOrSystemProperty("HF_TASK");
+            if (task != null) {
+                huggingFaceProperties.put("option.task", task);
+            }
+            Files.createDirectories(huggingFaceModelDir);
+            Path propertiesFile = huggingFaceModelDir.resolve("serving.properties");
+            Files.createFile(propertiesFile);
+            try (BufferedWriter writer = Files.newBufferedWriter(propertiesFile)) {
+                huggingFaceProperties.store(writer, null);
+            }
+            logger.info("Created serving.properties for model at path {}", propertiesFile);
         }
-        Properties huggingFaceProperties = new Properties();
-        huggingFaceProperties.put("option.model_id", modelId);
-        String task = Utils.getEnvOrSystemProperty("HF_TASK");
-        if (task != null) {
-            huggingFaceProperties.put("option.task", task);
-        }
-        Files.createDirectories(huggingFaceModelDir);
-        Path propertiesFile = huggingFaceModelDir.resolve("serving.properties");
-        Files.createFile(propertiesFile);
-        try (BufferedWriter writer = Files.newBufferedWriter(propertiesFile)) {
-            huggingFaceProperties.store(writer, null);
-        }
-        logger.info("Created serving.properties for model at path {}", propertiesFile);
         return huggingFaceModelDir.toString();
     }
 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
@@ -83,10 +83,6 @@ public final class LmiUtils {
         if (tensorParallelDegree > 0) {
             prop.setProperty("option.tensor_parallel_degree", String.valueOf(tensorParallelDegree));
         }
-        String huggingFaceTask = Utils.getEnvOrSystemProperty("HF_TASK");
-        if (huggingFaceTask != null) {
-            prop.setProperty("option.task", huggingFaceTask);
-        }
 
         if ("stable-diffusion".equals(modelConfig.getModelType())) {
             // TODO: Move this from hardcoded to deduced in PyModel
@@ -140,10 +136,7 @@ public final class LmiUtils {
 
     private static HuggingFaceModelConfig getHuggingFaceModelConfig(ModelInfo<?, ?> modelInfo)
             throws ModelException {
-        String modelId = Utils.getEnvOrSystemProperty("HF_MODEL_ID");
-        if (modelId == null) {
-            modelId = modelInfo.prop.getProperty("option.model_id");
-        }
+        String modelId = modelInfo.prop.getProperty("option.model_id");
         if (modelId == null) {
             // Deprecated but for backwards compatibility
             modelId = modelInfo.prop.getProperty("option.s3url");

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -592,7 +592,7 @@ public final class ModelInfo<I, O> {
         return Files.isDirectory(modelDir.resolve("MAR-INF"))
                 || Files.isRegularFile(modelDir.resolve("model.py"))
                 || Files.isRegularFile(modelDir.resolve(prefix + ".py"))
-                || Utils.getEnvOrSystemProperty("HF_MODEL_ID") != null
+                || prop.getProperty("option.model_id") != null
                 || Files.isRegularFile(modelDir.resolve("config.json"));
     }
 


### PR DESCRIPTION
## Description ##

Will move out of draft once tested.

This PR fixes a couple issues:
- Right now, MME is broken through the docker containers due to creation of /opt/ml/model path (model store). The startup of the model server fails when no models are present
- LMI Engine Selection is also incomplete. We should support auto detection of engine when either HF_MODEL_ID env var provided, or option.model_id is present in serving.properties.

To fix these issues, we create model properties when HF_MODEL_ID is present in a tmp model store, and remove the creation of model store from the docker container.
