### PR TITLE
[ci] Upgrade jacoco to 0.8.8 to support JDK17+

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip

--- a/tools/gradle/check.gradle
+++ b/tools/gradle/check.gradle
@@ -56,7 +56,7 @@ tasks.withType(Checkstyle) {
 
 apply plugin: 'jacoco'
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.8"
 }
 jacocoTestReport {
     reports {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
