### PR TITLE
Add mme tests to sagemaker tests

### DIFF
--- a/.github/workflows/sagemaker-integration.yml
+++ b/.github/workflows/sagemaker-integration.yml
@@ -46,7 +46,7 @@ jobs:
   # If you add a test, please try to keep the groups balanced
   endpoint-tests-group-1:
     runs-on: [ self-hosted, cpu ]
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: create-runners
     steps:
       - uses: actions/checkout@v3
@@ -64,37 +64,41 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
+      - name: MME Test
+        working-directory: tests/integration
+        run: |
+          python3 llm/sagemaker-endpoint-tests.py deepspeed-mme djl_mme
       - name: Test gpt2xl
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py gpt2-xl djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test stable diffusion
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py stable-diffusion-2-1-base djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test opt-1.3b
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py opt-1-3-b djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test flan-t5-xxl
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py flan-t5-xxl djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
         
   endpoint-tests-group-2:
     runs-on: [ self-hosted, cpu ]
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: create-runners
     steps:
       - uses: actions/checkout@v3
@@ -117,35 +121,39 @@ jobs:
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py gpt-j-6b djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test gpt-neo-2.7b no code DeepSpeed
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py gpt-neo-2-7-b no_code
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test bloom-7b1 no code FasterTransformer
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py bloom-7b1 no_code
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
       - name: Test DeepSpeed pythia-12b
         if: success() || failure()
         working-directory: tests/integration
         run: |
           python3 llm/sagemaker-endpoint-tests.py pythia-12b djl
-          echo "sleep 10 seconds to allow endpoint deletion"
-          sleep 10
+          echo "sleep 30 seconds to allow endpoint deletion"
+          sleep 30
 
   stop-runners:
     if: always()
     runs-on: [ self-hosted, scheduler ]
     needs: [ create-runners, endpoint-tests-group-1, endpoint-tests-group-2 ]
     steps:
+      - name: Cleanup dangling SageMaker resources
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          ./cleanup_sagemaker_resources.sh sm-integration-test us-east-1
       - name: Stop all instances
         run: |
           cd /home/ubuntu/djl_benchmark_script/scripts


### PR DESCRIPTION
## Description ##

The main change is adding single gpu MME test case with DeepSpeed image.

I also refactored the script slightly to do the following:
- cleanup any dangling resources from the tests at the end of the workflow
- cleanup s3 model artifacts during the tests. Deleting a sagemaker model still leaves the artifacts in S3
- standardize naming of resources so that the cleanup is simple

Testing:
- MME tests are successful in this run, but I want to do one more full run with all the changes to make sure i didn't break anything else. https://github.com/deepjavalibrary/djl-serving/actions/runs/5083982768/jobs/9135696386

Follow Up:
- I'll raise another PR that better supports running the nightly images from alpha ecr
