### PR TITLE
Add support for testing nightly images in sagemaker endpoint tests

### DIFF
--- a/.github/workflows/sagemaker-integration.yml
+++ b/.github/workflows/sagemaker-integration.yml
@@ -3,6 +3,10 @@ name: SageMaker PythonSDK Integration Tests
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "release/nightly containers to test. Default is nightly"
+        required: false
+        default: nightly
       sagemaker-repository:
         description: 'Link to Github repository for SageMaker Python SDK. Can be a personal fork.'
         required: false
@@ -73,32 +77,32 @@ jobs:
       - name: MME Test
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py deepspeed-mme djl_mme
+          python3 llm/sagemaker-endpoint-tests.py deepspeed-mme djl_mme ${{ github.event.inputs.mode }}
       - name: Test gpt2xl
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py gpt2-xl djl
+          python3 llm/sagemaker-endpoint-tests.py gpt2-xl djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test stable diffusion
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py stable-diffusion-2-1-base djl
+          python3 llm/sagemaker-endpoint-tests.py stable-diffusion-2-1-base djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test opt-1.3b
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py opt-1-3-b djl
+          python3 llm/sagemaker-endpoint-tests.py opt-1-3-b djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test flan-t5-xxl
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py flan-t5-xxl djl
+          python3 llm/sagemaker-endpoint-tests.py flan-t5-xxl djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
         
@@ -128,28 +132,28 @@ jobs:
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py gpt-j-6b djl
+          python3 llm/sagemaker-endpoint-tests.py gpt-j-6b djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test gpt-neo-2.7b no code DeepSpeed
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py gpt-neo-2-7-b no_code
+          python3 llm/sagemaker-endpoint-tests.py gpt-neo-2-7-b no_code ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test bloom-7b1 no code FasterTransformer
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py bloom-7b1 no_code
+          python3 llm/sagemaker-endpoint-tests.py bloom-7b1 no_code ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
       - name: Test DeepSpeed pythia-12b
         if: success() || failure()
         working-directory: tests/integration
         run: |
-          python3 llm/sagemaker-endpoint-tests.py pythia-12b djl
+          python3 llm/sagemaker-endpoint-tests.py pythia-12b djl ${{ github.event.inputs.mode }}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
 

--- a/engines/python/setup/djl_python/transformers-neuronx.py
+++ b/engines/python/setup/djl_python/transformers-neuronx.py
@@ -189,8 +189,8 @@ class TransformersNeuronXService(object):
                     "transformers-neuronx")
                 model_kwargs["engine"] = "transformers-neuronx"
                 outputs.add_stream_content(
-                    stream_generator(self.model, self.tokenizer,
-                                     input_text, **model_kwargs))
+                    stream_generator(self.model, self.tokenizer, input_text,
+                                     **model_kwargs))
                 return outputs
 
             encoded_inputs = self.tokenizer.batch_encode_plus(


### PR DESCRIPTION
## Description ##

This adds nightly image testing to sagemaker endpoints. With this we now have most permutations covered for testing our changes with sagemaker:
- Testing changes in DLCs via nightly/release images. nightly images are from alpha ecr, release images are the publically available ones in DLC accounts
- Testing changes in SageMaker Python SDK dev forks. Any changes we introduce to the sagemaker python sdk can now be fully tested before PRs
