### PR TITLE
[Fix] [CI/CD] Check if input is empty

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ''
       run_test:
-        description: 'Run only the tests you need [ft, ds, hf, aot, all]'
+        description: 'Run only the tests you need [ft, ds, hf, aot]'
         required: false
         default: ''
   schedule:

--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -10,7 +10,7 @@ on:
       run_test:
         description: 'Run only the tests you need [ft, ds, hf, aot, all]'
         required: false
-        default: 'all'
+        default: ''
   schedule:
     - cron: '0 15 * * *'
 
@@ -52,7 +52,7 @@ jobs:
       gpu_instance_id_3: ${{ steps.create_gpu3.outputs.action_g5_instance_id }}
 
   ds-raw-test:
-    if: contains(fromJson('["all", "ds"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "ds"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -107,7 +107,7 @@ jobs:
           path: tests/integration/logs/
 
   hf-handler-test:
-    if: contains(fromJson('["all", "hf"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "hf"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -196,7 +196,7 @@ jobs:
           path: tests/integration/logs/
 
   ds-handler-test:
-    if: contains(fromJson('["all", "ds"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "ds"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -298,7 +298,7 @@ jobs:
           path: tests/integration/logs/
 
   ft-raw-test:
-    if: contains(fromJson('["all", "ft"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "ft"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -380,7 +380,7 @@ jobs:
           path: tests/integration/logs/
 
   ft-handler-test:
-    if: contains(fromJson('["all", "ft"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "ft"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -435,7 +435,7 @@ jobs:
           path: tests/integration/logs/
 
   ft-aot-raw-test:
-    if: contains(fromJson('["all", "aot"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "aot"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -564,7 +564,7 @@ jobs:
           path: tests/integration/logs/
 
   ft-aot-handler-test:
-    if: contains(fromJson('["all", "aot"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "aot"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -688,7 +688,7 @@ jobs:
           path: tests/integration/logs/
 
   ds-aot-test:
-    if: contains(fromJson('["all", "aot"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "aot"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -782,7 +782,7 @@ jobs:
 
 
   ds-handler-aot-test:
-    if: contains(fromJson('["all", "aot"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "aot"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -867,7 +867,7 @@ jobs:
           name: ds-aot-handler-logs
 
   huggingface-test:
-    if: contains(fromJson('["all", "hf"]'), github.event.inputs.run_test)
+    if: contains(fromJson('["", "hf"]'), github.event.inputs.run_test)
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners


### PR DESCRIPTION
## Description ##

Scheduler does not have the options to get inputs. Inputs are only seems to be available in worflow_dispatch. 

So, made the default value of run_test to be empty. Even if input is not even provided, github seems to set the input param name empty by default.  

Testing:
I removed the whole run_test input for yaml and ran the workflow,  github.event.inputs.run_test env variable is validated to be empty. So the tests were not skipped.

https://github.com/deepjavalibrary/djl-serving/actions/runs/5158317906