### PR TITLE
[wlm] Sets default maxWorkers the same as earlier version

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/util/WlmConfigManager.java
@@ -207,7 +207,7 @@ public final class WlmConfigManager {
             if (ompThreads > cpuCores) {
                 ompThreads = cpuCores;
             }
-            return cpuCores * 2 / ompThreads;
+            return cpuCores / ompThreads;
         }
         return 2;
     }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
