### PR TITLE
[python] Fixes retry_threshold bug

### DIFF
--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -411,7 +411,7 @@ public class PyEngineTest {
             Input input = new Input();
             input.add("exit", "true");
             Assert.assertThrows(EngineException.class, () -> predictor.predict(input));
-            Assert.assertEquals(model.getProperty("failed"), "true");
+            Assert.assertEquals(model.getProperty("failed"), "1");
 
             Input input2 = new Input();
             input2.add("data", "input");

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -334,9 +334,15 @@ public final class ModelInfo<I, O> {
         } else if (status == Status.FAILED) {
             return Status.FAILED;
         }
+
         for (Model m : getModels().values()) {
-            if (Boolean.parseBoolean(m.getProperty("failed"))) {
-                return Status.FAILED;
+            int failures = Integer.parseInt(m.getProperty("failed", "0"));
+            if (failures > 0) {
+                String def = Utils.getenv("SERVING_RETRY_THRESHOLD", "10");
+                int threshold = Integer.parseInt(m.getProperty("retry_threshold", def));
+                if (failures > threshold) {
+                    return Status.FAILED;
+                }
             }
         }
         return status;

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -105,6 +105,7 @@ public class WorkLoadManager {
         }
         LinkedBlockingDeque<WorkerJob<I, O>> queue = pool.getJobQueue();
         if ((queue.remainingCapacity() == 1 && pool.isAllWorkerBusy())
+                || pool.isAllWorkerDied()
                 || !queue.offer(new WorkerJob<>(job, result))) {
             result.completeExceptionally(
                     new WlmCapacityException(

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
@@ -125,6 +125,22 @@ public class WorkerPool<I, O> {
     }
 
     /**
+     * Return if all workers died.
+     *
+     * @return true if all workers died
+     */
+    public boolean isAllWorkerDied() {
+        for (WorkerGroup<I, O> group : workerGroups.values()) {
+            for (WorkerThread<?, ?> thread : group.getWorkers()) {
+                if (thread.isRunning()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns {@code true} if all workers are busy.
      *
      * @return {@code true} if all workers are busy


### PR DESCRIPTION
For python worker, PyProcess is recreated for each worker, restart count is lost.
which lead the model is never marked as failure, and PING will alwasy report healthy.

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
