### PR TITLE
Move tp detection logic to PyModel from LmiUtils

### DIFF
--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -260,7 +260,7 @@ public class ModelInfoTest {
         }
         ModelInfo<Input, Output> model = new ModelInfo<>("build/models/lmi_test_model");
         model.initialize();
-        assertEquals(model.getEngineName(), "Python");
+        assertEquals(model.getEngineName(), "DeepSpeed");
         assertEquals(model.prop.getProperty("option.model_id"), "gpt2-xl");
 
         try (BufferedWriter writer = Files.newBufferedWriter(prop)) {
@@ -271,17 +271,11 @@ public class ModelInfoTest {
 
         Map<String, String> modelConfig = new ConcurrentHashMap<>();
         modelConfig.put("model_type", "codegen");
-        modelConfig.put("num_heads", "12");
-        System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
-        try {
-            Files.writeString(
-                    modelDir.resolve("config.json"), JsonUtils.GSON_PRETTY.toJson(modelConfig));
-            Files.delete(prop);
-            model = new ModelInfo<>("build/models/lmi_test_model");
-            model.initialize();
-            assertEquals(model.getEngineName(), "Python");
-        } finally {
-            System.clearProperty("TENSOR_PARALLEL_DEGREE");
-        }
+        Files.writeString(
+                modelDir.resolve("config.json"), JsonUtils.GSON_PRETTY.toJson(modelConfig));
+        Files.delete(prop);
+        model = new ModelInfo<>("build/models/lmi_test_model");
+        model.initialize();
+        assertEquals(model.getEngineName(), "Python");
     }
 }


### PR DESCRIPTION
## Description ##

By moving the tp logic from LmiUtils to PyModel, we can now support the case where user defines model like:
```
engine=DeepSpeed
option.model_id=<model_id>
```

The one use case this does break is gpt2-xl running on a machine with an even number of gpus. Though, that model is so small and such an edge case I don't think it's worth designing around at this moment. 

To fix that issue, and make the logic here a little better, we want to download the huggingface model from the hub on the front end, and then parse the config/file sizes and make judgement based on that.

Another thing I noticed is that we have the logic for reading tp degree from env var/props in multiple places. I'm looking into how we consolidate that better.
