### PR TITLE
Move tp detection logic to PyModel from LmiUtils

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -21,6 +21,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.translate.Translator;
 import ai.djl.util.Utils;
+import ai.djl.util.cuda.CudaUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.stream.Stream;
 
 /** {@code PyModel} is the Python engine implementation of {@link Model}. */
 public class PyModel extends BaseModel {
@@ -184,23 +184,10 @@ public class PyModel extends BaseModel {
         if (pyEnv.isMpiMode()) {
             int partitions = pyEnv.getTensorParallelDegree();
             if (partitions == 0) {
-                // TODO: avoid use hardcoded "partitioned_model_" name
-                try (Stream<Path> stream = Files.list(modelPath)) {
-                    partitions =
-                            (int)
-                                    stream.filter(
-                                                    p ->
-                                                            p.toFile()
-                                                                    .getName()
-                                                                    .startsWith(
-                                                                            "partitioned_model_"))
-                                            .count();
-                }
-                if (partitions == 0) {
-                    throw new FileNotFoundException(
-                            "partitioned_model_ file not found in: " + modelPath);
-                }
+                partitions = CudaUtils.getGpuCount();
                 pyEnv.setTensorParallelDegree(partitions);
+                logger.info(
+                        "No tensor parallel degree specified. Defaulting to all available GPUs.");
             }
             logger.info("Loading model in MPI mode with TP: {}.", partitions);
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -124,7 +124,6 @@ ds_handler_list = {
     },
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
-        "option.tensor_parallel_degree": 4,
         "option.task": "text-generation",
         "option.dtype": "fp16"
     },
@@ -186,7 +185,6 @@ ft_model_list = {
     "t5-small": {
         "engine": "FasterTransformer",
         "option.model_id": "t5-small",
-        "option.tensor_parallel_degree": 4,
     },
     "gpt2-xl": {
         "engine": "FasterTransformer",

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -23,7 +23,6 @@ import ai.djl.modality.Output;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.translate.TranslateException;
-import ai.djl.util.JsonUtils;
 import ai.djl.util.Utils;
 import ai.djl.util.ZipUtils;
 
@@ -40,9 +39,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class ModelInfoTest {
 
@@ -268,20 +265,5 @@ public class ModelInfoTest {
         }
         model = new ModelInfo<>("build/models/lmi_test_model");
         Assert.assertThrows(model::initialize);
-
-        Map<String, String> modelConfig = new ConcurrentHashMap<>();
-        modelConfig.put("model_type", "codegen");
-        modelConfig.put("num_heads", "12");
-        System.setProperty("TENSOR_PARALLEL_DEGREE", "4");
-        try {
-            Files.writeString(
-                    modelDir.resolve("config.json"), JsonUtils.GSON_PRETTY.toJson(modelConfig));
-            Files.delete(prop);
-            model = new ModelInfo<>("build/models/lmi_test_model");
-            model.initialize();
-            assertEquals(model.getEngineName(), "Python");
-        } finally {
-            System.clearProperty("TENSOR_PARALLEL_DEGREE");
-        }
     }
 }


### PR DESCRIPTION
## Description ##

This changes moves the default tensor parallel number detection from LmiUtils to PyModel. As a result, we now fix an issue where a model defined like this would not work.
```
engine=DeepSpeed
option.model_id=<model_id>
```

I've modified the integration tests to test this case across the 3 engines.

One thing to note for this change, is that we default to maximizing the gpus for both mpi mode and non mpi mode. For non mpi mode, the value of tensor parallel doesn't matter. We just use the fact that tp > 0 to determine which device map to set (if a device map is not specified by the user). 

This change does break the above example when using gpt2-xl. While that's technically a regression, this model is so small that I would argue it should only be used on a single gpu. To fix this (and make the overall logic here better), we'll want to move the model downloading to the frontend, and then parse the config.json and use that information in PyModel. That enhancement will be done as a follow up.
