### PR TITLE
[docker] add llama support and integration tests

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -152,6 +152,15 @@ jobs:
           serve
           python3 llm/client.py huggingface bloom-7b1
           docker rm -f $(docker ps -aq)
+      - name: Test LLAMA-7b
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py huggingface open-llama-7b
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          serve
+          python3 llm/client.py huggingface open-llama-7b
+          docker rm -f $(docker ps -aq)
       - name: Test GPTJ-6B
         working-directory: tests/integration
         run: |
@@ -255,6 +264,15 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
           python3 llm/client.py deepspeed bloom-7b1
+          docker rm -f $(docker ps -aq)
+      - name: Test LLAMA-7B
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py deepspeed open-llama-7b
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          serve
+          python3 llm/client.py deepspeed open-llama-7b
           docker rm -f $(docker ps -aq)
       - name: Test GPTJ-6B
         working-directory: tests/integration

--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -36,6 +36,7 @@ OPTIMIZED_MODEL_TYPES = {
     "opt",
     "gpt_neox",
     "bloom",
+    "llama",
 }
 
 SUPPORTED_TASKS = {

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -16,6 +16,7 @@ ARG python_version=3.9
 ARG torch_version=2.0.1
 ARG torch_vision_version=0.15.2
 ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-0.9.2-py2.py3-none-any.whl"
+ARG protobuf_version=3.20.3
 ARG transformers_version=4.29.2
 ARG accelerate_version=0.19.0
 ARG diffusers_version=0.15.0
@@ -56,7 +57,7 @@ RUN apt-get update && \
     scripts/install_s5cmd.sh x64 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev && \
     pip3 install torch==${torch_version} torchvision==${torch_vision_version} --extra-index-url https://download.pytorch.org/whl/cu118 \
-    ${deepspeed_wheel} transformers==${transformers_version} \
+    ${deepspeed_wheel} protobuf==${protobuf_version} transformers==${transformers_version} \
     mpi4py sentencepiece einops accelerate==${accelerate_version} bitsandbytes==${bitsandbytes_version}\
     diffusers[torch]==${diffusers_version} opencv-contrib-python-headless safetensors && \
     scripts/install_aitemplate.sh && \

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -92,6 +92,11 @@ hf_model_spec = {
         "seq_length": [64, 128, 256],
         "worker": 2
     },
+    "open-llama-7b": {
+        "max_memory_per_gpu": [10.0, 7.0, 7.0, 17.0],
+        "batch_size": [1, 2, 4, 8],
+        "seq_length": [64, 128, 256]
+    },
     "bloom-7b1": {
         "max_memory_per_gpu": [7.0, 7.0, 8.0, 9.0],
         "batch_size": [1, 2, 4, 8],
@@ -140,6 +145,11 @@ ds_model_spec = {
     },
     "bloom-7b1": {
         "max_memory_per_gpu": [7.0, 8.0, 8.0, 9.0],
+        "batch_size": [1, 2, 4, 8],
+        "seq_length": [64, 128, 256]
+    },
+    "open-llama-7b": {
+        "max_memory_per_gpu": [8.0, 7.0, 7.0, 7.0],
         "batch_size": [1, 2, 4, 8],
         "seq_length": [64, 128, 256]
     },

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -91,6 +91,13 @@ hf_handler_list = {
         "option.device_map": "auto",
         "option.dtype": "fp16"
     },
+    "open-llama-7b": {
+        "option.model_id": "s3://djl-llm/open-llama-7b/",
+        "option.task": "text-generation",
+        "option.tensor_parallel_degree": 4,
+        "option.device_map": "auto",
+        "option.dtype": "fp16"
+    },
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
         "option.tensor_parallel_degree": 4,
@@ -125,6 +132,12 @@ ds_handler_list = {
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
         "option.task": "text-generation",
+        "option.dtype": "fp16"
+    },
+    "open-llama-7b": {
+        "option.model_id": "s3://djl-llm/open-llama-7b/",
+        "option.task": "text-generation",
+        "option.tensor_parallel_degree": 4,
         "option.dtype": "fp16"
     },
     "opt-13b": {


### PR DESCRIPTION
Update to deepspeed container, adds and pins protobuf 3.20.3 as a dependency for conversion of the fast llama tokenizer. Adds integration tests for llama using HF accelerate and DS.

--Edit: Now uses fused kernels
