### PR TITLE
Add peft support to default deepspeed and huggingface handlers

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -170,6 +170,15 @@ jobs:
           serve
           python3 llm/client.py huggingface gpt-j-6b
           docker rm -f $(docker ps -aq)
+      - name: Test gpt4all-lora
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py huggingface gpt4all-lora
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          serve
+          python3 llm/client.py huggingface gpt4all-lora
+          docker rm -f $(docker ps -aq)
       - name: Test streaming bigscience/bloom-3b
         working-directory: tests/integration
         run: |
@@ -291,6 +300,15 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
           python3 llm/client.py deepspeed opt-13b
+          docker rm -f $(docker ps -aq)
+      - name: Test gpt4all-lora
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py deepspeed gpt4all-lora
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          serve
+          python3 llm/client.py deepspeed gpt4all-lora
           docker rm -f $(docker ps -aq)
       - name: Test streaming gpt-neo-1.3b
         working-directory: tests/integration

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -22,6 +22,7 @@ ARG transformers_version=4.29.2
 ARG accelerate_version=0.19.0
 ARG diffusers_version=0.15.0
 ARG bitsandbytes_version=0.39.1
+ARG peft_version=0.3.0
 
 EXPOSE 8080
 
@@ -60,7 +61,7 @@ RUN apt-get update && \
     pip3 install torch==${torch_version} torchvision==${torch_vision_version} --extra-index-url https://download.pytorch.org/whl/cu118 \
     ${deepspeed_wheel} ${lmi_dist_wheel} protobuf==${protobuf_version} transformers==${transformers_version} \
     mpi4py sentencepiece einops accelerate==${accelerate_version} bitsandbytes==${bitsandbytes_version}\
-    diffusers[torch]==${diffusers_version} opencv-contrib-python-headless safetensors scipy && \
+    diffusers[torch]==${diffusers_version} peft==${peft_version} opencv-contrib-python-headless safetensors scipy && \
     scripts/install_flash_attn.sh && \
     scripts/install_aitemplate.sh && \
     scripts/patch_oss_dlc.sh python && \

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -133,6 +133,12 @@ hf_model_spec = {
         "batch_size": [1, 4],
         "seq_length": [16, 32],
         "worker": 2,
+    },
+    "gpt4all-lora": {
+        "max_memory_per_gpu": [6.0, 8.0],
+        "batch_size": [1, 4],
+        "seq_length": [16, 32],
+        "worker": 1,
     }
 }
 
@@ -165,6 +171,12 @@ ds_model_spec = {
         "seq_length": [16],
         "worker": 1,
         "stream_output": True,
+    },
+    "gpt4all-lora": {
+        "max_memory_per_gpu": [6.0, 8.0],
+        "batch_size": [1, 4],
+        "seq_length": [16, 32],
+        "worker": 1,
     }
 }
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -120,6 +120,12 @@ hf_handler_list = {
         "option.device_map": "auto",
         "option.enable_streaming": True,
     },
+    "gpt4all-lora": {
+        "option.model_id": "nomic-ai/gpt4all-lora",
+        "option.tensor_parallel_degree": 4,
+        "option.task": "text-generation",
+        "option.dtype": "fp16"
+    }
 }
 
 ds_handler_list = {
@@ -153,6 +159,12 @@ ds_handler_list = {
         "option.dtype": "fp16",
         "option.enable_streaming": True
     },
+    "gpt4all-lora": {
+        "option.model_id": "nomic-ai/gpt4all-lora",
+        "option.tensor_parallel_degree": 4,
+        "option.task": "text-generation",
+        "option.dtype": "fp16"
+    }
 }
 
 sd_handler_list = {


### PR DESCRIPTION
## Description ##

This PR adds support for single adapter Lora models. Support is added for both huggingface accelerate, and deepspeed. 
This is achieved by leveraging the merge_and_unload() method of PeftModel, which adds the lora checkpoints into the base model, and unwraps it out of the peft context so it can be used/understood by deepspeed. It becomes a regular model in the sense that DeepSpeed (and FT in theory) can understand it.

To add support for FasterTransformer, I have to check that code to see whether this is feasible. It's not doable from the handler.

There are no changes or additional configurations that need to be set to use a peft model with djl serving. It's the same UX as any other model, just pass in your peft_model_id as option.model_id and everything should work.
