### PR TITLE
Fix Jacoco report on some python code and artifacts

### DIFF
--- a/jacoco/build.gradle
+++ b/jacoco/build.gradle
@@ -30,3 +30,11 @@ reporting {
 tasks.named("check") {
     dependsOn tasks.named("testCodeCoverageReport", JacocoReport)
 }
+
+testCodeCoverageReport {
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: [
+                "**/python/setup/*"
+        ])
+    }))
+}


### PR DESCRIPTION
## Description ##

Skip python for invalid content validation
