### PR TITLE
Fix skip special tokens in lmi-dist

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -104,7 +104,9 @@ class LmiDistRollingBatch(RollingBatch):
             is_last_token = generation.generated_text is not None
             if not is_last_token:
                 req_ids.append(r.id)
-            r.set_next_token(generation.token_text, last_token=is_last_token)
+            r.set_next_token(
+                "" if generation.token_is_special else generation.token_text,
+                last_token=is_last_token)
 
         # filter the requests that are stopped.
         if self.cache:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
