### PR TITLE
Fix do sample type

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -68,8 +68,7 @@ class SchedulerRollingBatch(RollingBatch):
                                               self.search_algorithm)
 
             # TODO: This is not needed when search algorithm automatically chosen for the user.
-            if parameters.get("do_sample",
-                              self.search_config.sampling).lower() == "true":
+            if parameters.get("do_sample", self.search_config.sampling):
                 search_algorithm = "sample"
 
             new_requests.input_texts[search_algorithm].append(


### PR DESCRIPTION
## Description ##

do_sample comes from each request from the user like below. It should be expected as a bool.

```
'{"inputs": "The new movie that got Oscar this year", 
"parameters":{"max_new_tokens" : 256, "do_sample": true}}
```

Todo: Need to add validations for these input parameters of each request. 
