### PR TITLE
[fix] add current device for tp > 1 scenario on huggingface handler

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -384,6 +384,8 @@ class HuggingFaceService(object):
             input_tokens = tokenizer(inputs, padding=True, return_tensors="pt")
             if self.device:
                 input_tokens = input_tokens.to(self.device)
+            else:
+                input_tokens = input_tokens.to(torch.cuda.current_device())
 
             with torch.no_grad():
                 output_tokens = model.generate(


### PR DESCRIPTION
Current HF handler sets self.device to None when running on multiple GPU's, but our wrapped pipeline uses self.device for moving the input tokens to the device. Since this is None we needed another control path for getting the input tokens onto the GPU. The current implementation leaves the input tokens on CPU, degrading the performance.
