### PR TITLE
[python] Only override minWorkers when tp > 1

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -230,8 +230,10 @@ public class PyModel extends BaseModel {
         } else {
             int tensorParallelDegree = pyEnv.getTensorParallelDegree();
             if (tensorParallelDegree > 0) {
-                setProperty("gpu.minWorkers", "1");
-                setProperty("gpu.maxWorkers", "1");
+                if (tensorParallelDegree > 1) {
+                    setProperty("gpu.minWorkers", "1");
+                    setProperty("gpu.maxWorkers", "1");
+                }
                 setProperty("tensor_parallel_degree", String.valueOf(tensorParallelDegree));
             }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
