### PR TITLE
[ci] remove oom tests for hf accelerate performance

### DIFF
--- a/tests/integration/profiles/opt_30b.json
+++ b/tests/integration/profiles/opt_30b.json
@@ -5,7 +5,7 @@
 	"dtype": ["fp16","bf16"],
 	"tensor_parallel": 4,
 	"batch_size": 4,
-	"in_tokens": [256, 512],
+	"in_tokens": [256],
 	"out_tokens": 256,
 	"count": 10,
 	"log_metrics": true


### PR DESCRIPTION
Removing the 512 token performance test due to oom on gpu 0 using accelerate.
