### PR TITLE
[serving] Disconnect client when streaming timed out

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -384,6 +384,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                 ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             } catch (InterruptedException | IllegalStateException e) {
                 logger.warn("Chunk reading interrupted", e);
+                ctx.disconnect();
                 ctx.newFailedFuture(e);
             }
             return;


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
