### PR TITLE
[python] Fix the default value for rolling batch request parameters

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -134,11 +134,11 @@ class LmiDistRollingBatch(RollingBatch):
         for r in requests:
             param = r.parameters
             parameters = NextTokenChooserParameters(
-                temperature=param.get("temperature", None),
-                repetition_penalty=param.get("repetition_penalty", None),
-                top_k=param.get("top_k", None),
-                top_p=param.get("top_p", None),
-                typical_p=param.get("typical_p", None),
+                temperature=param.get("temperature", 1.0),
+                repetition_penalty=param.get("repetition_penalty", 1.0),
+                top_k=param.get("top_k", 0),
+                top_p=param.get("top_p", 1.0),
+                typical_p=param.get("typical_p", 1.0),
                 do_sample=param.get("do_sample", False),
                 seed=int(param.get("seed", 0)))
             stop_parameters = StoppingCriteriaParameters(


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
