### PR TITLE
Allow overriding truncate parameter in request

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -151,7 +151,8 @@ class LmiDistRollingBatch(RollingBatch):
                     id=r.id,
                     inputs=r.input_text,
                     parameters=parameters,
-                    stopping_parameters=stop_parameters))
+                    stopping_parameters=stop_parameters,
+                    truncate=param.get("truncate", 1000)))
 
         if preprocessed_requests:
             batch = Batch(id=self.batch_id_counter,


### PR DESCRIPTION
## Description ##

Allows overriding the default 1000 value for truncation in the request parameters

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
