### PR TITLE
[serving] Update tnx handler for 2.12 supported models

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -29,7 +29,7 @@ jobs:
 
   transformers-neuronx-test:
     runs-on: [ self-hosted, inf2 ]
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: create-runners
     steps:
       - uses: actions/checkout@v3
@@ -109,6 +109,39 @@ jobs:
           serve
           curl http://127.0.0.1:8080/models
           python3 llm/client.py transformers_neuronx gpt-j-6b
+          docker rm -f $(docker ps -aq)
+          sudo rm -rf models
+      - name: Test transformers-neuronx bloom-7b1 with handler
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py transformers_neuronx bloom-7b1
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-6 \
+          serve
+          curl http://127.0.0.1:8080/models
+          python3 llm/client.py transformers_neuronx bloom-7b1
+          docker rm -f $(docker ps -aq)
+          sudo rm -rf models
+      - name: Test transformers-neuronx open-llama-7b with handler
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py transformers_neuronx open-llama-7b
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-2 \
+          serve
+          curl http://127.0.0.1:8080/models
+          python3 llm/client.py transformers_neuronx open-llama-7b
+          docker rm -f $(docker ps -aq)
+          sudo rm -rf models
+      - name: Test transformers-neuronx gpt-neox-20b with handler
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py transformers_neuronx gpt-neox-20b
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-6 \
+          serve
+          curl http://127.0.0.1:8080/models
+          python3 llm/client.py transformers_neuronx gpt-neox-20b
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
       - name: Test streaming transformers-neuronx opt-1.3b with handler

--- a/engines/python/setup/djl_python/transformers-neuronx.py
+++ b/engines/python/setup/djl_python/transformers-neuronx.py
@@ -13,14 +13,18 @@
 import tempfile
 import os
 import logging
+import torch
 
 from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer
 from transformers_neuronx import dtypes
 from transformers_neuronx.generation_utils import HuggingFaceGenerationModelAdapter
+from transformers_neuronx.gptneox.model import GPTNeoXForSampling
 from transformers_neuronx.gptj.model import GPTJForSampling
 from transformers_neuronx.gpt2.model import GPT2ForSampling
-from transformers_neuronx.module import save_pretrained_split
 from transformers_neuronx.opt.model import OPTForSampling
+from transformers_neuronx.llama.model import LlamaForSampling
+from transformers_neuronx.bloom.model import BloomForSampling
+from transformers_neuronx.module import save_pretrained_split
 from djl_python import Input, Output
 from djl_python.stable_diffusion_inf2 import StableDiffusionService
 from djl_python.streaming_utils import StreamingUtils
@@ -29,7 +33,16 @@ model = None
 
 DTYPE_MAPPER = {"fp32": "f32", "fp16": "f16"}
 
-SUPPORTED_MODEL_TYPES = {"opt", "gpt2", "gptj"}
+SUPPORTED_MODEL_TYPES = {"opt", "gpt2", "gptj", "gpt_neox", "llama", "bloom"}
+
+MODEL_TYPE_TO_MODEL= {
+    "opt": OPTForSampling,
+    "gpt2": GPT2ForSampling,
+    "gptj": GPTJForSampling,
+    "gpt_neox": GPTNeoXForSampling,
+    "llama": LlamaForSampling,
+    "bloom": BloomForSampling
+}
 
 
 class TransformersNeuronXService(object):
@@ -42,98 +55,112 @@ class TransformersNeuronXService(object):
         self.model = None
         self.tokenizer = None
         self.enable_streaming = None
+        self.download_dir = None
+        self.amp = None
+        self.unroll = None
+        self.n_positions = None
+        self.model_type = None
 
-    def convert_opt(self, amp):
-        logging.warning(
-            "Model conversion is a slow process to do in runtime, please consider convert it"
-            " Ahead-of-Time next time")
-        logging.info(f"Start loading the model {self.model_id_or_path}...")
-        self.model = AutoModelForCausalLM.from_pretrained(
-            self.model_id_or_path, low_cpu_mem_usage=True)
+    def convert_dtype(self, dtype, model_type):
+        if model_type == "opt":
+            for block in self.model.model.decoder.layers:
+                block.self_attn.to(dtype)
+                block.fc1.to(dtype)
+                block.fc2.to(dtype)
+            self.model.lm_head.to(dtype)
+        elif model_type == "bloom":
+            for block in self.model.transformer.h:
+                block.self_attention.to(dtype)
+                block.mlp.to(dtype)
+            self.model.lm_head.to(dtype)
+        elif model_type in ["gpt2", "gptj"]:
+            for block in self.model.transformer.h:
+                block.attn.to(dtype)
+                block.mlp.to(dtype)
+            self.model.lm_head.to(dtype)
+        elif model_type == "gpt_neox":
+            for block in self.model.gpt_neox.layers:
+                block.attention.to(dtype)
+                block.mlp.to(dtype)
+            self.model.embed_out.to(dtype)
+        elif model_type == "llama":
+            for block in self.model.model.layers:
+                block.self_attn.q_proj.to(dtype)
+                block.self_attn.k_proj.to(dtype)
+                block.self_attn.v_proj.to(dtype)
+                block.self_attn.o_proj.to(dtype)
+                block.mlp.gate_proj.to(dtype)
+                block.mlp.down_proj.to(dtype)
+                block.mlp.up_proj.to(dtype)
+            self.model.lm_head.to(dtype)
+        else:
+            raise AttributeError(f"Model architecture format is not implemented")
+
+    @staticmethod
+    def is_inf2_model(model_path):
+        return os.path.exists(os.path.join(model_path, "verify"))
+
+    def model_amp_match(self, model_path):
+        if not self.is_inf2_model(model_path):
+            return False
+        with open(os.path.join(model_path, "verify")) as f:
+            return self.amp in f.read()
+
+    def init_load_path(self, model_type):
         path = os.environ.get("SERVING_DOWNLOAD_DIR")
+        folder = f"inf2_{model_type}_{self.amp}"
         if not path:
             path = tempfile.gettempdir()
+        if not os.path.exists(os.path.join(path, folder)):
+            os.mkdir(os.path.join(path, folder))
+        self.download_dir = os.path.join(path, folder)
+        return self.download_dir
 
-        load_path = tempfile.mkdtemp(dir=path, prefix="inf2_")
+    def convert_model(self, model_type, load_path):
+        if self.is_inf2_model(load_path):
+            return
+        self.model = self.load_hf_model()
         logging.info("Start model conversion to INF2 format...")
-        dtype = dtypes.to_torch_dtype(amp)
-        for block in self.model.model.decoder.layers:
-            block.self_attn.to(dtype)
-            block.fc1.to(dtype)
-            block.fc2.to(dtype)
-        self.model.lm_head.to(dtype)
+        dtype = dtypes.to_torch_dtype(self.amp)
+        self.convert_dtype(dtype, model_type)
         logging.info(f"Saving INF2 model to {load_path} ...")
         save_pretrained_split(self.model, load_path)
         with open(os.path.join(load_path, "verify"), "w") as f:
-            f.writelines("opt-converted")
+            f.writelines(f"{model_type}-converted-{self.amp}")
+
+    def get_load_path(self, model_type):
+        if self.is_inf2_model(self.model_id_or_path):
+            load_path = self.model_id_or_path
+        elif self.download_dir:
+            load_path = self.download_dir
+        else:
+            load_path = self.init_load_path(model_type)
         return load_path
 
-    def convert_gpt(self, amp, gpt_type="gpt2"):
-        logging.warning(
-            "Model conversion is a slow process to do in runtime, please consider convert it"
-            " Ahead-of-Time next time")
+    def load_hf_model(self):
         logging.info(f"Start loading the model {self.model_id_or_path}...")
-        self.model = AutoModelForCausalLM.from_pretrained(
+        return AutoModelForCausalLM.from_pretrained(
             self.model_id_or_path, low_cpu_mem_usage=True)
-        path = os.environ.get("SERVING_DOWNLOAD_DIR")
-        if not path:
-            path = tempfile.gettempdir()
 
-        load_path = tempfile.mkdtemp(dir=path, prefix="inf2_")
-        logging.info("Start model conversion to INF2 format...")
-        dtype = dtypes.to_torch_dtype(amp)
-        for block in self.model.transformer.h:
-            block.attn.to(dtype)
-            block.mlp.to(dtype)
-        self.model.lm_head.to(dtype)
-        logging.info(f"Saving to INF2 model to {load_path} ...")
-        self.model.save_pretrained(load_path, max_shard_size="100GB")
-        with open(os.path.join(load_path, "verify"), "w") as f:
-            f.writelines(f"{gpt_type}-converted")
-        return load_path
-
-    def load_opt(self, amp, unroll, n_positions):
-        load_path = self.model_id_or_path
-        if not os.path.exists(os.path.join(load_path, "verify")):
-            load_path = self.convert_opt(amp)
-        self.model = OPTForSampling.from_pretrained(
+    def load_inf2_model(self, model_type, load_path):
+        return MODEL_TYPE_TO_MODEL[model_type].from_pretrained(
             load_path,
             batch_size=self.batch_size,
-            amp=amp,
+            amp=self.amp,
             tp_degree=self.tensor_parallel_degree,
-            n_positions=n_positions,
-            unroll=unroll)
-        self.model.to_neuron()
+            n_positions=self.n_positions,
+            unroll=self.unroll)
 
-    def load_gpt2(self, amp, unroll, n_positions):
-        load_path = self.model_id_or_path
-        if not os.path.exists(os.path.join(load_path, "verify")):
-            load_path = self.convert_gpt(amp, gpt_type="gpt2")
-        self.model = GPT2ForSampling.from_pretrained(
-            load_path,
-            batch_size=self.batch_size,
-            amp=amp,
-            tp_degree=self.tensor_parallel_degree,
-            n_positions=n_positions,
-            unroll=unroll)
-        # load GPT2 compiled artifacts if exist
-        self.model._load_compiled_artifacts(load_path)
-        self.model.to_neuron()
-        # save GPT2 compiled artifacts
-        self.model._save_compiled_artifacts(load_path)
-
-    def load_gptj(self, amp, unroll, n_positions):
-        load_path = self.model_id_or_path
-        if not os.path.exists(os.path.join(load_path, "verify")):
-            load_path = self.convert_gpt(amp, gpt_type="gptj")
-        self.model = GPTJForSampling.from_pretrained(
-            load_path,
-            batch_size=self.batch_size,
-            amp=amp,
-            tp_degree=self.tensor_parallel_degree,
-            n_positions=n_positions,
-            unroll=unroll)
-        self.model.to_neuron()
+    def load_model(self, model_type):
+        load_path = self.get_load_path(model_type)
+        self.convert_model(model_type, load_path)
+        self.model = self.load_inf2_model(model_type, load_path)
+        if model_type == "gpt2":
+            self.model._load_compiled_artifacts(load_path)
+            self.model.to_neuron()
+            self.model._save_compiled_artifacts(load_path)
+        else:
+            self.model.to_neuron()
 
     def initialize(self, properties):
         self.batch_size = int(properties.get("batch_size", 1))
@@ -145,72 +172,83 @@ class TransformersNeuronXService(object):
         if self.enable_streaming and self.enable_streaming.lower() == "false":
             self.enable_streaming = None
         dtype = properties.get("dtype", "fp32")
-        n_positions = int(properties.get("n_positions", 128))
-        unroll = properties.get("unroll", None)
+        self.n_positions = int(properties.get("n_positions", 128))
+        self.unroll = properties.get("unroll", None)
         if dtype not in DTYPE_MAPPER:
             raise ValueError(f"{dtype} data type not supported!")
-        amp = DTYPE_MAPPER[dtype]
+        self.amp = DTYPE_MAPPER[dtype]
         model_config = AutoConfig.from_pretrained(self.model_id_or_path)
         if model_config.model_type not in SUPPORTED_MODEL_TYPES:
             raise ValueError(
                 f"{model_config.model_type} type not supported for model {self.model_id_or_path}"
                 f"Supported model arch: {SUPPORTED_MODEL_TYPES}")
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id_or_path)
-        self.tokenizer.padding_side = 'left'
-        if not self.tokenizer.pad_token:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.model_type = model_config.model_type
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id_or_path, padding_side="left")
+        if not self.tokenizer.pad_token_id:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
 
-        if "opt" == model_config.model_type:
-            self.load_opt(amp, unroll, n_positions)
-        elif "gpt2" == model_config.model_type:
-            self.load_gpt2(amp, unroll, n_positions)
-        elif "gptj" == model_config.model_type:
-            self.load_gptj(amp, unroll, n_positions)
+        self.load_model(model_config.model_type)
+
         # HuggingFace compatible generate model
         self.model = HuggingFaceGenerationModelAdapter(model_config,
                                                        self.model)
         self.initialized = True
 
     def infer(self, inputs):
-        input_map = inputs.get_as_json()
-        input_text = input_map.pop("inputs", input_map)
-        parameters = input_map.pop("parameters", {})
-        if isinstance(input_text, str):
-            input_text = [input_text]
-        if len(input_text) != self.batch_size:
-            raise ValueError(
-                f"{self.batch_size} batch size not equal to {len(input_text)} prompt size"
-            )
-        outputs = Output()
-        model_kwargs = {}
+        try:
+            input_map = inputs.get_as_json()
+            input_text = input_map.pop("inputs", input_map)
+            parameters = input_map.pop("parameters", {})
+            if isinstance(input_text, str):
+                input_text = [input_text]
+            if len(input_text) != self.batch_size:
+                raise ValueError(
+                    f"{self.batch_size} batch size not equal to {len(input_text)} prompt size"
+                )
+            outputs = Output()
+            model_kwargs = {}
 
-        if self.enable_streaming:
-            outputs.add_property("content-type", "application/jsonlines")
-            if self.enable_streaming == "huggingface":
-                outputs.add_stream_content(
-                    StreamingUtils.use_hf_default_streamer(
-                        self.model, self.tokenizer, input_text, None,
-                        **model_kwargs))
+            if self.enable_streaming:
+                outputs.add_property("content-type", "application/jsonlines")
+                if self.enable_streaming == "huggingface":
+                    outputs.add_stream_content(
+                        StreamingUtils.use_hf_default_streamer(
+                            self.model, self.tokenizer, input_text, None,
+                            **model_kwargs))
+                else:
+                    stream_generator = StreamingUtils.get_stream_generator(
+                        "transformers-neuronx")
+                    model_kwargs["engine"] = "transformers-neuronx"
+                    outputs.add_stream_content(
+                        stream_generator(self.model, self.tokenizer,
+                                         input_text, "cpu", **model_kwargs))
+                return outputs
+
+            encoded_inputs = self.tokenizer.batch_encode_plus(
+                input_text, return_tensors="pt", padding=True)
+            use_sample = parameters.pop("use_sample", None)
+            if use_sample:
+                # TODO: Watch transformer-neuronx release for fix on gpt-neox generate functionality
+                output_tokens = self.model.sample(encoded_inputs.input_ids, sequence_length=self.n_positions,
+                                                  pad_token_id=self.tokenizer.pad_token_id,
+                                                  eos_token_id=self.tokenizer.eos_token_id,
+                                                  **parameters)
             else:
-                stream_generator = StreamingUtils.get_stream_generator(
-                    "transformers-neuronx")
-                model_kwargs["engine"] = "transformers-neuronx"
-                outputs.add_stream_content(
-                    stream_generator(self.model, self.tokenizer, input_text,
-                                     "cpu", **model_kwargs))
-            return outputs
+                output_tokens = self.model.generate(
+                    input_ids=encoded_inputs.input_ids,
+                    attention_mask=encoded_inputs.attention_mask,
+                    **parameters)
+            generated_text = self.tokenizer.batch_decode(
+                output_tokens, skip_special_tokens=True)
 
-        encoded_inputs = self.tokenizer.batch_encode_plus(input_text,
-                                                          return_tensors="pt",
-                                                          padding=True)
-        output_tokens = self.model.generate(
-            input_ids=encoded_inputs.input_ids,
-            attention_mask=encoded_inputs.attention_mask,
-            **parameters)
-        generated_text = self.tokenizer.batch_decode(output_tokens,
-                                                     skip_special_tokens=True)
+            return Output().add([{
+                "generated_text": s
+            } for s in generated_text])
 
-        return Output().add([{"generated_text": s} for s in generated_text])
+        except Exception as e:
+            logging.exception("TransformerNeuronX inference failed")
+            outputs = Output().error((str(e)))
+        return outputs
 
 
 _service = TransformersNeuronXService()
@@ -224,7 +262,7 @@ def handle(inputs: Input):
         _service.initialize(inputs.get_properties())
 
     if inputs.is_empty():
-        # Model server makes an empty call to warmup the model on startup
+        # Model server makes an empty call to warm up the model on startup
         return None
 
     return _service.infer(inputs)

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -13,9 +13,9 @@ FROM ubuntu:20.04
 ARG djl_version=0.23.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG python_version=3.8
-ARG torch_neuronx_version=1.13.1.1.8.0
-ARG transformers_neuronx_version=0.4.60
-ARG neuronx_distributed_version=0.1.0
+ARG torch_neuronx_version=1.13.1.1.9.0
+ARG transformers_neuronx_version=0.4.149
+ARG neuronx_distributed_version=0.2.0
 ARG protobuf_version=3.20.3
 ARG transformers_version=4.30.1
 ARG accelerate_version=0.20.3
@@ -60,7 +60,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     scripts/install_inferentia2.sh && \
     pip install transformers==${transformers_version} accelerate==${accelerate_version} safetensors \
     neuronx-cc==2.6.* torch_neuronx==${torch_neuronx_version} transformers-neuronx==${transformers_neuronx_version} \
-    neuronx_distributed==${neuronx_distributed_version} protobuf==${protobuf_version} \
+    neuronx_distributed==${neuronx_distributed_version} protobuf==${protobuf_version} sentencepiece \
     diffusers==${diffusers_version} opencv-contrib-python-headless  Pillow --extra-index-url=https://pip.repos.neuron.amazonaws.com && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -101,7 +101,7 @@ echo "Launching ${container_id}..."
 total=24
 if $is_llm; then
   echo "extra sleep for 2 min on LLM models"
-  total=48
+  total=60
   sleep 120
 fi
 

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -285,6 +285,22 @@ transformers_neuronx_model_spec = {
         "seq_length": [128, 256],
         "batch_size": [4]
     },
+    "gpt-neox-20b": {
+        "worker": 1,
+        "seq_length": [128, 256],
+        "batch_size": [4],
+        "use_sample": True
+    },
+    "open-llama-7b": {
+        "worker": 1,
+        "seq_length": [128, 256],
+        "batch_size": [4]
+    },
+    "bloom-7b1": {
+        "worker": 1,
+        "seq_length": [128, 256],
+        "batch_size": [4]
+    },
     "gpt-j-6b": {
         "worker": 1,
         "seq_length": [128, 256, 512],
@@ -701,6 +717,8 @@ def test_transformers_neuronx_handler(model, model_spec):
         for seq_length in spec["seq_length"]:
             req = {"inputs": batch_generation(batch_size)}
             params = {"max_length": seq_length}
+            if "use_sample" in spec:
+                params["use_sample"] = True
             req["parameters"] = params
             logging.info(f"req {req}")
             res = send_json(req)

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -315,6 +315,30 @@ transformers_neuronx_handler_list = {
         "option.dtype": "fp32",
         "option.model_loading_timeout": 720
     },
+    "gpt-neox-20b": {
+        "option.model_id": "s3://djl-llm/gpt-neox-20b/",
+        "option.batch_size": 4,
+        "option.tensor_parallel_degree": 8,
+        "option.n_positions": 512,
+        "option.dtype": "fp16",
+        "option.model_loading_timeout": 720
+    },
+    "open-llama-7b": {
+        "option.model_id": "s3://djl-llm/open-llama-7b/",
+        "option.batch_size": 4,
+        "option.tensor_parallel_degree": 4,
+        "option.n_positions": 512,
+        "option.dtype": "fp16",
+        "option.model_loading_timeout": 900
+    },
+    "bloom-7b1": {
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
+        "option.batch_size": 4,
+        "option.tensor_parallel_degree": 4,
+        "option.n_positions": 256,
+        "option.dtype": "fp16",
+        "option.model_loading_timeout": 720
+    },
     "opt-1.3b-streaming": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",
         "option.batch_size": 2,


### PR DESCRIPTION
* [tnx] Update handler for 2.12 supported models

* [tnx] rewrite handler for 2.12.0 upgrade

* [docker] bump tnx image to 2.12.0

* [ci/cd] Add newly supported tnx models to ci/cd

* [fix] add use_sample from spec in handler test

(cherry picked from commit 6d42f75386cd870c1a3266418a054243d44ea92e)

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
