### PR TITLE
[ci] Update client for llama inf2 and move hf testing off for opt performance testing

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -294,7 +294,8 @@ transformers_neuronx_model_spec = {
     "open-llama-7b": {
         "worker": 1,
         "seq_length": [128, 256],
-        "batch_size": [4]
+        "batch_size": [4],
+        "use_sample": True
     },
     "bloom-7b1": {
         "worker": 1,

--- a/tests/integration/profiles/opt_30b.json
+++ b/tests/integration/profiles/opt_30b.json
@@ -1,11 +1,11 @@
 {
 	"test_series":"performance",
-	"engine":["deepspeed","huggingface"],
+	"engine":["deepspeed"],
 	"model": "opt-30b",
 	"dtype": ["fp16","bf16"],
 	"tensor_parallel": 4,
 	"batch_size": 4,
-	"in_tokens": [256],
+	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,
 	"log_metrics": true


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
