### PR TITLE
[ci] Use smaller instance for inf2 bloom test

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           rm -rf models
           python3 llm/prepare.py transformers_neuronx bloom-7b1
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-6 \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-2 \
           serve
           curl http://127.0.0.1:8080/models
           python3 llm/client.py transformers_neuronx bloom-7b1

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -298,7 +298,7 @@ transformers_neuronx_model_spec = {
     },
     "bloom-7b1": {
         "worker": 1,
-        "seq_length": [128, 256],
+        "seq_length": [128],
         "batch_size": [4]
     },
     "gpt-j-6b": {

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -321,7 +321,7 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 8,
         "option.n_positions": 512,
         "option.dtype": "fp16",
-        "option.model_loading_timeout": 720
+        "option.model_loading_timeout": 900
     },
     "open-llama-7b": {
         "option.model_id": "s3://djl-llm/open-llama-7b/",


### PR DESCRIPTION
## Description ##

Fix inf2 bloom test to single worker for timeout issues.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
