### PR TITLE
[serving] Adds more built-in logging options

### DIFF
--- a/serving/build.gradle
+++ b/serving/build.gradle
@@ -122,8 +122,10 @@ startScripts {
                 'fi\n' +
                 'if [ -f "/opt/ml/.sagemaker_infra/endpoint-metadata.json" ]; then\n' +
                 '    export JAVA_OPTS="$JAVA_OPTS -XX:-UseContainerSupport"\n' +
-                'fi\n' +
-                'DEFAULT_JVM_OPTS="-Dlog4j.configurationFile=${APP_HOME}/conf/log4j2.xml"\n')
+                '    DEFAULT_JVM_OPTS="${DEFAULT_JVM_OPTS:--Dlog4j.configurationFile=${APP_HOME}/conf/log4j2-plain.xml}"\n' +
+                'else\n' +
+                '    DEFAULT_JVM_OPTS="${DEFAULT_JVM_OPTS:--Dlog4j.configurationFile=${APP_HOME}/conf/log4j2.xml}"\n' +
+                'fi\n')
         text = text.replaceAll('CLASSPATH=\\$APP_HOME/lib/.*', 'CLASSPATH=\\$APP_HOME/lib/*')
         unixScript.text = text
     }

--- a/serving/src/main/conf/log4j2-console.xml
+++ b/serving/src/main/conf/log4j2-console.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %c{1} - %msg%n"/>
+        </Console>
+        <RollingFile
+                name="application"
+                fileName="${env:MODEL_SERVER_HOME}/logs/serving.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/serving.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss} %c{1} - %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+        <RollingFile
+                name="access"
+                fileName="${env:MODEL_SERVER_HOME}/logs/access.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/access.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+        <RollingFile
+                name="server_metric"
+                fileName="${env:MODEL_SERVER_HOME}/logs/server_metric.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/server_metric.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+        <RollingFile
+                name="model_metric"
+                fileName="${env:MODEL_SERVER_HOME}/logs/model_metric.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/model_metric.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="application"/>
+        </Root>
+        <Logger name="ai.djl" level="${sys:ai.djl.logging.level:-info}" additivity="false"
+                includeLocation="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="application"/>
+        </Logger>
+        <Logger name="ACCESS_LOG" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="access"/>
+        </Logger>
+        <Logger name="server_metric" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="server_metric"/>
+        </Logger>
+        <Logger name="model_metric" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="model_metric"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/serving/src/main/conf/log4j2-plain.xml
+++ b/serving/src/main/conf/log4j2-plain.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %c{1} - %msg%n"/>
+        </Console>
+        <RollingFile
+                name="application"
+                fileName="${env:MODEL_SERVER_HOME}/logs/serving.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/serving.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss} %c{1} - %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+        <RollingFile
+                name="access"
+                fileName="${env:MODEL_SERVER_HOME}/logs/access.log"
+                filePattern="${env:MODEL_SERVER_HOME}/logs/access.%d{dd-MMM}.log.gz"
+                ignoreExceptions="false">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="application"/>
+        </Root>
+        <Logger name="ai.djl" level="${sys:ai.djl.logging.level:-info}" additivity="false"
+                includeLocation="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="application"/>
+        </Logger>
+        <Logger name="ACCESS_LOG" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="access"/>
+        </Logger>
+        <Logger name="server_metric" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="model_metric" level="info" additivity="false" includeLocation="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
1. disable color highlight with log4j-plain.xml
2. enable log server and model metrics to console

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
