### PR TITLE
[docker] disable TORCH_CUDNN_V8_API_DISABLED for PyTorch 2.0.1

### DIFF
--- a/serving/docker/pytorch-cu118.Dockerfile
+++ b/serving/docker/pytorch-cu118.Dockerfile
@@ -34,6 +34,8 @@ ENV PYTORCH_LIBRARY_PATH=/usr/local/lib/python3.9/dist-packages/torch/lib
 ENV PYTORCH_PRECXX11=true
 ENV PYTORCH_VERSION=${torch_version}
 ENV PYTORCH_FLAVOR=cu118-precxx11
+# TODO: remove TORCH_CUDNN_V8_API_DISABLED once PyTorch bug is fixed
+ENV TORCH_CUDNN_V8_API_DISABLED=1
 ENV JAVA_OPTS="-Xmx1g -Xms1g -XX:+ExitOnOutOfMemoryError -Dai.djl.default_engine=PyTorch"
 ENV PYTORCH_KERNEL_CACHE_PATH=/tmp
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
