### PR TITLE
Simplify handling of min/max workers

### DIFF
--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -116,20 +116,11 @@ public final class ModelManager {
                             if (model.isParallelLoading()) {
                                 pool = Executors.newFixedThreadPool(devices.length);
                             }
-                            int minWorkers = model.getMinWorkers();
-                            int maxWorkers = model.getMaxWorkers();
                             for (String deviceName : devices) {
                                 if (pool != null) {
-                                    futures.add(
-                                            pool.submit(
-                                                    () ->
-                                                            initWorkers(
-                                                                    model,
-                                                                    deviceName,
-                                                                    minWorkers,
-                                                                    maxWorkers)));
+                                    futures.add(pool.submit(() -> initWorkers(model, deviceName)));
                                 } else {
-                                    initWorkers(model, deviceName, minWorkers, maxWorkers);
+                                    initWorkers(model, deviceName);
                                 }
                             }
                             if (pool != null) {
@@ -205,14 +196,11 @@ public final class ModelManager {
      *
      * @param model the model to scale workers for
      * @param deviceName the device for the model
-     * @param minWorkers the min workers, -1 for auto-scale
-     * @param maxWorkers the max workers, -1 for auto-scale
-     * @see WorkerPool#initWorkers(String, int, int)
+     * @see WorkerPool#initWorkers(String)
      */
-    public void initWorkers(
-            ModelInfo<Input, Output> model, String deviceName, int minWorkers, int maxWorkers) {
+    public void initWorkers(ModelInfo<Input, Output> model, String deviceName) {
         Thread.currentThread().setContextClassLoader(MutableClassLoader.getInstance());
-        wlm.getWorkerPool(model).initWorkers(deviceName, minWorkers, maxWorkers);
+        wlm.getWorkerPool(model).initWorkers(deviceName);
     }
 
     /**

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -97,7 +97,8 @@ public class WorkflowTest {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         WorkLoadManager wlm = new WorkLoadManager();
         for (ModelInfo<Input, Output> model : workflow.getModels()) {
-            wlm.registerModel(model).initWorkers("-1", -1, 1);
+            model.setMaxWorkers(1);
+            wlm.registerModel(model).initWorkers("-1");
         }
 
         Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -468,6 +468,10 @@ public final class ModelInfo<I, O> {
             throw new IllegalArgumentException(
                     "The max workers for a model can't be smaller than the min workers");
         }
+        if (minWorkers == 0) {
+            throw new IllegalArgumentException(
+                    "Having a minWorkers of 0 is not currently supported");
+        }
 
         this.minWorkers = minWorkers;
     }
@@ -496,6 +500,9 @@ public final class ModelInfo<I, O> {
             throw new IllegalArgumentException(
                     "The max workers for a model can't be smaller than the min workers");
         }
+        if (maxWorkers == 0) {
+            throw new IllegalArgumentException("Models must have a maxWorkers greater than 0");
+        }
 
         this.maxWorkers = maxWorkers;
     }
@@ -510,6 +517,13 @@ public final class ModelInfo<I, O> {
         if (maxWorkers < minWorkers) {
             throw new IllegalArgumentException(
                     "The max workers for a model can't be smaller than the min workers");
+        }
+        if (minWorkers == 0) {
+            throw new IllegalArgumentException(
+                    "Having a minWorkers of 0 is not currently supported");
+        }
+        if (maxWorkers == 0) {
+            throw new IllegalArgumentException("Models must have a maxWorkers greater than 0");
         }
 
         this.minWorkers = minWorkers;

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
@@ -13,8 +13,6 @@
 package ai.djl.serving.wlm;
 
 import ai.djl.Device;
-import ai.djl.Model;
-import ai.djl.serving.wlm.util.WlmConfigManager;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -33,10 +31,11 @@ public class WorkerGroup<I, O> {
         this.workerPool = workerPool;
         this.device = device;
         workers = new CopyOnWriteArrayList<>();
-        WlmConfigManager config = WlmConfigManager.getInstance();
-        Model model = workerPool.getModel().getModel(device);
-        minWorkers = config.getDefaultMinWorkers(model);
-        maxWorkers = config.getDefaultMaxWorkers(model);
+        ModelInfo<I, O> model = workerPool.getModel();
+
+        // Default workers from model, may be overridden by configureWorkers on init or scale
+        minWorkers = model.getMinWorkers(device);
+        maxWorkers = model.getMaxWorkers(device);
         minWorkers = Math.min(minWorkers, maxWorkers);
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
@@ -174,8 +174,17 @@ public class WorkerPool<I, O> {
      * Initializes new worker capacities for this model.
      *
      * @param deviceName the device for the model, null for default devices
-     * @param minWorkers minimum amount of workers.
-     * @param maxWorkers maximum amount of workers.
+     */
+    public void initWorkers(String deviceName) {
+        initWorkers(deviceName, -1, -1);
+    }
+
+    /**
+     * Initializes new worker capacities for this model.
+     *
+     * @param deviceName the device for the model, null for default devices
+     * @param minWorkers minimum amount of workers (-1 for model default).
+     * @param maxWorkers maximum amount of workers (-1 for model default).
      */
     public void initWorkers(String deviceName, int minWorkers, int maxWorkers) {
         Device device;


### PR DESCRIPTION
This unifies the handling of min/max workers into the two pieces of WorkerGroup and ModelInfo. The source becomes clearly sourced from modelInfo unless a default is passed during a WorkerGroup creation through a scaling call. Before, there were more layers of passed in data and defaults in ways that were difficult to track.