### PR TITLE
Worker type

### DIFF
--- a/benchmark/src/main/java/ai/djl/benchmark/WlmBenchmark.java
+++ b/benchmark/src/main/java/ai/djl/benchmark/WlmBenchmark.java
@@ -73,10 +73,12 @@ public class WlmBenchmark extends AbstractBenchmark {
         ModelInfo<Void, float[]> modelInfo =
                 new ModelInfo<>("model", arguments.getModelUrl(), criteria);
 
-        WorkerPool<Void, float[]> wp = wlm.registerModel(modelInfo);
         int workersPerDevice = numOfWorkers / devices.length;
+        modelInfo.setMinWorkers(workersPerDevice);
+        modelInfo.setMaxWorkers(workersPerDevice);
+        WorkerPool<Void, float[]> wp = wlm.registerWorkerPool(modelInfo);
         for (String deviceName : devices) {
-            wp.initWorkers(deviceName, workersPerDevice, workersPerDevice);
+            wp.initWorkers(deviceName);
         }
 
         // Measure memory before worker kickoff

--- a/serving/docs/architecture.md
+++ b/serving/docs/architecture.md
@@ -3,16 +3,68 @@
 DJL serving is built on top of [Deep Java Library](https://djl.ai). You can visit the
 [DJL github repository](https://github.com/deepjavalibrary/djl) to learn more. For module, dependency and class overview refer to [generated diagrams](https://sourcespy.com/github/deepjavalibrarydjlserving/).
 
-DJL Serving uses a [Netty](https://netty.io/) frontend on top of backend worker thread pools.
-The frontend uses a single Netty setup with multiple [HttpRequestHandler](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/HttpRequestHandler.html)s.
+DJL Serving exists in roughly four layers:
+
+1. Frontend - A [Netty](https://netty.io/) HTTP client that accepts and manages incoming requests
+2. Workflows - A system for combining multiple models and glue code together into execution plans
+3. WorkLoadManager (WLM) - A worker thread management system supporting batching and routing.
+
+There is also the model store, specified in the [configuration](configuration.md), that specifies the models to be loaded on startup in the ModelManager.
+
+![Architecture Diagram](https://resources.djl.ai/images/djl-serving/architecture-02.png)
+
+
+## Frontend
+
+![Frontend Diagram](https://resources.djl.ai/images/djl-serving/frontend-01.png)
+
+DJL Serving uses a [Netty](https://netty.io/) frontend to handle the incoming requests.
+It has a single Netty setup with multiple [HttpRequestHandler](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/HttpRequestHandler.html)s.
 Different request handlers will provide support for the [inference API](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/InferenceRequestHandler.html), [Management API](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/http/ManagementRequestHandler.html), or other APIs available from various plugins.
+
+Those request handlers can then communicate with other layers of the DJL stack.
+Mainly, this is through the ModelManager which manages the various endpoints.
+Each endpoint can have multiple versions that each correspond to a Workflow.
+The inference API will call various workflows (assigned round-robin to the workflows in an endpoint).
+The management API can be used to CRUD the various endpoints and workflows in them.
+
+## Workflows
+
+The workflow system is used to support various use cases involving multiple levels of models and glue code.
+It is configured using a `workflow.json` file where you can describe the workflow pipeline and the models involved.
+More details about workflows can be found in the [workflows guide](workflows.md).
+
+Within the workflow, the main purpose is to call various models.
+This is done through the WorkLoadManager.
+Creating and removing the workflow will add and remove the respective models from the WLM.
+The same model in multiple workflows will correspond to a single model in the WLM.
+
+## WorkLoadManager
+
+![WorkLoadManager Diagram](https://resources.djl.ai/images/djl-serving/wlm-01.png)
 
 The backend is based around the [WorkLoadManager](../../wlm/README.md) module.
 The WLM takes care of multiple worker threads for each model along with the batching and request routing to them.
 It is also available separately and can be utilized through the WLM module (`ai.djl.serving:wlm`).
+This may be useful if you want the DJL Serving worker scaling support, but not the HTTP frontend.
+
+For each model, there is a worker pool corresponding to it's full support.
+Each worker pool has a job queue to manage the incoming requests.
+It also has a worker pool config describing the task (model) it runs.
+
+The worker pool can then contain multiple worker groups.
+The groups correspond to the support for the model on a particular device.
+So, the same model can have worker groups for both CPU and GPU or on multiple GPUs by creating multiple worker groups.
+
+Finally, each worker group can contain the individual worker threads.
+This allows for multiple threads on the same device (typically CPU) for the same model.
+The number of workers in a worker group can be automatically scaled with a minimum and maximum value.
+A constant number of workers can be set by having the same minimum and maximum workers.
 
 Within each worker thread inside the WLM, there is a DJL Predictor.
 Depending on what Engine the Predictor is, it can run various models such as those from PyTorch, Tensorflow, XGBoost, or any of the other engines supported by DJL.
 Notably, there is also a [Python Engine](../../engines/python/README.md) which can be used to run models, preprocessing, and postprocessing defined in a python script.
 
-![Architecture Diagram](https://resources.djl.ai/images/djl-serving/architecture.png)
+When using the Python engine, the DJL Python Predictor (PyPredictor) contains a python process.
+This means that each worker thread (in each worker group in each worker pool) has it's own process.
+The process can be used and closed through the PyPredictor.

--- a/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/WorkflowDefinition.java
@@ -17,6 +17,7 @@ import ai.djl.modality.Output;
 import ai.djl.repository.FilenameUtils;
 import ai.djl.serving.util.MutableClassLoader;
 import ai.djl.serving.wlm.ModelInfo;
+import ai.djl.serving.wlm.WorkerPoolConfig;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 import ai.djl.serving.workflow.function.WorkflowFunction;
 import ai.djl.util.ClassLoaderUtils;
@@ -233,7 +234,9 @@ public class WorkflowDefinition {
             }
         }
 
-        return new Workflow(name, version, models, expressions, configs, loadedFunctions);
+        Map<String, WorkerPoolConfig<Input, Output>> wpcs = new ConcurrentHashMap<>(models);
+        wpcs.putAll(models);
+        return new Workflow(name, version, wpcs, expressions, configs, loadedFunctions);
     }
 
     private static final class ModelDefinitionDeserializer

--- a/serving/src/main/puml/frontend.puml
+++ b/serving/src/main/puml/frontend.puml
@@ -1,0 +1,39 @@
+@startuml
+skinparam componentStyle uml1
+package "DJL Serving - single process" {
+
+  frame ModelManager as mm {
+    frame "Endpoints" {
+      frame "Endpoint mlp" {
+        [Workflow 0] as w0
+      }
+    }
+  }
+
+  frame Netty {
+      package REST_API [
+          /resnet18
+          ..
+          /resnet18/v1
+          ..
+          /resnet18/v2
+          --
+          /BERT
+          ===
+          Management API
+      ]
+
+    package HttpRequestHandlers [
+        InferenceRequestHandler
+        ManagementRequestHandler
+        KServeRequestHandler
+        ...
+    ]
+    HTTP -r-> REST_API
+  }
+
+  REST_API -r-> HttpRequestHandlers
+  HttpRequestHandlers -r-> w0
+
+}
+@enduml

--- a/serving/src/main/puml/wlm.puml
+++ b/serving/src/main/puml/wlm.puml
@@ -1,0 +1,50 @@
+@startuml
+skinparam componentStyle uml1
+
+package "DJL Serving WorkLoad Manager" as wlm {
+  frame "Worker pool (mlp)" as wp_mlp {
+
+    queue "Job queue\nauto batch" as jq_mlp
+
+    frame "WorkerGroup (CPU)" as wg_mlp {
+
+      [Predictor WorkerThread 1]
+      [Predictor WorkerThread 2]
+      [Predictor WorkerThread 3]
+      [Predictor WorkerThread 4]
+    }
+  }
+
+  frame "Worker pool (resnet18_v1)" as wp_resnet {
+
+    queue "Job queue\nauto batch" as jq_resnet
+
+    frame "WorkerGroup (GPU0)" as wg0 {
+      [Predictor WorkerThread] as wt0
+    }
+  }
+
+  frame "Worker pool (llama)" as wp_llama {
+    queue "Job queue\nauto batch" as jq_llama
+
+    frame "WorkerGroup (GPU1)" as wg1 {
+      [Predictor WorkerThread] as wt1
+    }
+    frame "WorkerGroup (GPU2)" as wg2 {
+      [Predictor WorkerThread] as wt2
+    }
+    wg1-[hidden]down-wg2
+  }
+  wp_mlp-[hidden]down-wp_resnet
+  wp_resnet-[hidden]down-wp_llama
+}
+
+frame "Python Workers" {
+    [Worker llama GPU1] as py1
+    [Worker llama GPU2] as py2
+    py1-[hidden]down-py2
+}
+
+wt1 -> py1
+wt2 -> py2
+@enduml

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -23,6 +23,7 @@ import ai.djl.modality.Classifications.Classification;
 import ai.djl.repository.MRL;
 import ai.djl.repository.Repository;
 import ai.djl.serving.http.DescribeWorkflowResponse;
+import ai.djl.serving.http.DescribeWorkflowResponse.DescribeWorkerPoolConfig;
 import ai.djl.serving.http.ErrorResponse;
 import ai.djl.serving.http.ListModelsResponse;
 import ai.djl.serving.http.ListWorkflowsResponse;
@@ -476,7 +477,7 @@ public class ModelServerTest {
         Type type = new TypeToken<DescribeWorkflowResponse[]>() {}.getType();
         DescribeWorkflowResponse[] resp = JsonUtils.GSON.fromJson(result, type);
         DescribeWorkflowResponse wf = resp[0];
-        DescribeWorkflowResponse.Model model = wf.getModels().get(0);
+        DescribeWorkerPoolConfig model = wf.getWpcs().get(0);
         assertEquals(model.getQueueSize(), 10);
         DescribeWorkflowResponse.Group group = model.getWorkGroups().get(0);
 
@@ -638,8 +639,8 @@ public class ModelServerTest {
         assertEquals(wf.getWorkflowName(), "mlp_2");
         assertNull(wf.getVersion());
 
-        List<DescribeWorkflowResponse.Model> models = wf.getModels();
-        DescribeWorkflowResponse.Model model = models.get(0);
+        List<DescribeWorkerPoolConfig> models = wf.getWpcs();
+        DescribeWorkerPoolConfig model = models.get(0);
         assertEquals(model.getModelName(), "mlp_2");
         assertNotNull(model.getModelUrl());
         assertEquals(model.getBatchSize(), 1);

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -15,8 +15,8 @@ package ai.djl.serving;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.serving.util.ConfigManager;
-import ai.djl.serving.wlm.ModelInfo;
 import ai.djl.serving.wlm.WorkLoadManager;
+import ai.djl.serving.wlm.WorkerPoolConfig;
 import ai.djl.serving.workflow.BadWorkflowException;
 import ai.djl.serving.workflow.Workflow;
 import ai.djl.serving.workflow.WorkflowDefinition;
@@ -78,12 +78,12 @@ public class WorkflowTest {
     public void testLocalPerf() throws IOException, BadWorkflowException {
         Path workflowFile = Paths.get("src/test/resources/workflows/localPerf.json");
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
-        ModelInfo<Input, Output> m = workflow.getModels().iterator().next();
+        WorkerPoolConfig<Input, Output> wpc = workflow.getWpcs().iterator().next();
 
-        Assert.assertEquals(m.getQueueSize(), 102);
-        Assert.assertEquals(m.getMaxIdleSeconds(), 62);
-        Assert.assertEquals(m.getMaxBatchDelayMillis(), 302);
-        Assert.assertEquals(m.getBatchSize(), 3);
+        Assert.assertEquals(wpc.getQueueSize(), 102);
+        Assert.assertEquals(wpc.getMaxIdleSeconds(), 62);
+        Assert.assertEquals(wpc.getMaxBatchDelayMillis(), 302);
+        Assert.assertEquals(wpc.getBatchSize(), 3);
     }
 
     @Test
@@ -96,9 +96,9 @@ public class WorkflowTest {
             throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         WorkLoadManager wlm = new WorkLoadManager();
-        for (ModelInfo<Input, Output> model : workflow.getModels()) {
-            model.setMaxWorkers(1);
-            wlm.registerModel(model).initWorkers("-1");
+        for (WorkerPoolConfig<Input, Output> wpc : workflow.getWpcs()) {
+            wpc.setMaxWorkers(1);
+            wlm.registerWorkerPool(wpc).initWorkers("-1");
         }
 
         Output output = workflow.execute(wlm, input).join();

--- a/wlm/src/main/java/ai/djl/serving/wlm/BatchAggregator.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/BatchAggregator.java
@@ -44,13 +44,14 @@ abstract class BatchAggregator<I, O> {
     /**
      * Constructs a new {@code BbatchAggregator} instance.
      *
-     * @param model the model to use.
+     * @param wpc the workerPoolConfig to use.
      * @param jobQueue the job queue for polling data from.
      */
-    public BatchAggregator(ModelInfo<I, O> model, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
-        this.dimension = new Dimension("Model", model.getId());
-        this.batchSize = model.getBatchSize();
-        this.maxBatchDelayMicros = model.getMaxBatchDelayMillis() * 1000L;
+    public BatchAggregator(
+            WorkerPoolConfig<I, O> wpc, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
+        this.dimension = new Dimension("Model", wpc.getId());
+        this.batchSize = wpc.getBatchSize();
+        this.maxBatchDelayMicros = wpc.getMaxBatchDelayMillis() * 1000L;
         this.jobQueue = jobQueue;
         wjs = new ArrayList<>();
     }

--- a/wlm/src/main/java/ai/djl/serving/wlm/Job.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Job.java
@@ -15,30 +15,30 @@ package ai.djl.serving.wlm;
 /** A class represents an inference job. */
 public class Job<I, O> {
 
-    private ModelInfo<I, O> modelInfo;
+    private WorkerPoolConfig<I, O> workerPoolConfig;
     private I input;
     private long begin;
 
     /**
      * Constructs a new {@code Job} instance.
      *
-     * @param modelInfo the model to run the job
+     * @param wpc the model to run the job
      * @param input the input data
      */
-    public Job(ModelInfo<I, O> modelInfo, I input) {
-        this.modelInfo = modelInfo;
+    public Job(WorkerPoolConfig<I, O> wpc, I input) {
+        this.workerPoolConfig = wpc;
         this.input = input;
 
         begin = System.nanoTime();
     }
 
     /**
-     * Returns the model that associated with this job.
+     * Returns the worker pool config that is associated with this job.
      *
-     * @return the model that associated with this job
+     * @return the worker pool config that is associated with this job
      */
-    public ModelInfo<I, O> getModel() {
-        return modelInfo;
+    public WorkerPoolConfig<I, O> getWpc() {
+        return workerPoolConfig;
     }
 
     /**

--- a/wlm/src/main/java/ai/djl/serving/wlm/PermanentBatchAggregator.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PermanentBatchAggregator.java
@@ -34,12 +34,12 @@ public class PermanentBatchAggregator<I, O> extends BatchAggregator<I, O> {
     /**
      * Constructs a {@code PermanentBatchAggregator} instance.
      *
-     * @param model the model to use.
+     * @param wpc the workerPoolConfig to use.
      * @param jobQueue the job queue for polling data from.
      */
     public PermanentBatchAggregator(
-            ModelInfo<I, O> model, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
-        super(model, jobQueue);
+            WorkerPoolConfig<I, O> wpc, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
+        super(wpc, jobQueue);
     }
 
     /** {@inheritDoc} */

--- a/wlm/src/main/java/ai/djl/serving/wlm/TemporaryBatchAggregator.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/TemporaryBatchAggregator.java
@@ -37,14 +37,14 @@ public class TemporaryBatchAggregator<I, O> extends BatchAggregator<I, O> {
     /**
      * a batch aggregator that terminates after a maximum idle time.
      *
-     * @param model the model to run for.
+     * @param wpc the workerPoolConfig to run for.
      * @param jobQueue reference to external job queue for polling.
      */
     public TemporaryBatchAggregator(
-            ModelInfo<I, O> model, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
-        super(model, jobQueue);
+            WorkerPoolConfig<I, O> wpc, LinkedBlockingDeque<WorkerJob<I, O>> jobQueue) {
+        super(wpc, jobQueue);
         this.idleSince = System.currentTimeMillis();
-        this.maxIdleSeconds = model.getMaxIdleSeconds();
+        this.maxIdleSeconds = wpc.getMaxIdleSeconds();
     }
 
     /** {@inheritDoc} */

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerGroup.java
@@ -31,11 +31,11 @@ public class WorkerGroup<I, O> {
         this.workerPool = workerPool;
         this.device = device;
         workers = new CopyOnWriteArrayList<>();
-        ModelInfo<I, O> model = workerPool.getModel();
+        WorkerPoolConfig<I, O> wpc = workerPool.getWpc();
 
-        // Default workers from model, may be overridden by configureWorkers on init or scale
-        minWorkers = model.getMinWorkers(device);
-        maxWorkers = model.getMaxWorkers(device);
+        // Default workers from worker type, may be overridden by configureWorkers on init or scale
+        minWorkers = wpc.getMinWorkers(device);
+        maxWorkers = wpc.getMaxWorkers(device);
         minWorkers = Math.min(minWorkers, maxWorkers);
     }
 
@@ -91,11 +91,11 @@ public class WorkerGroup<I, O> {
     }
 
     void addThreads(int count, boolean permanent) {
-        ModelInfo<I, O> model = workerPool.getModel();
+        WorkerPoolConfig<I, O> wpc = workerPool.getWpc();
         ExecutorService threadPool = workerPool.getThreadPool();
         for (int i = 0; i < count; ++i) {
             WorkerThread<I, O> thread =
-                    WorkerThread.builder(model)
+                    WorkerThread.builder(wpc)
                             .setDevice(device)
                             .setJobQueue(workerPool.getJobQueue())
                             .optFixPoolThread(permanent)

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPoolConfig.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPoolConfig.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.Device;
+import ai.djl.ModelException;
+import ai.djl.repository.zoo.ModelNotFoundException;
+import ai.djl.translate.TranslateException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link WorkerPoolConfig} represents a task that could be run in the {@link WorkLoadManager}.
+ *
+ * <p>Each {@link WorkerThread} (also {@link WorkerPool} and {@link WorkerGroup}) focuses on
+ * executing a single worker type. They contain the configuration for the thread, any persistent
+ * data, and the code to run on the thread.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ */
+public abstract class WorkerPoolConfig<I, O> {
+
+    protected transient String id;
+    protected String version;
+    protected String modelUrl;
+    protected int queueSize;
+    protected int batchSize;
+    protected int maxBatchDelayMillis;
+    protected int maxIdleSeconds;
+    protected Integer minWorkers; // Integer so it becomes null when parsed from JSON
+    protected Integer maxWorkers; // Integer so it becomes null when parsed from JSON
+
+    /**
+     * Loads the worker type to the specified device.
+     *
+     * @param device the device to load worker type on
+     * @throws IOException if failed to read worker type file
+     * @throws ModelException if failed to load the specified model
+     */
+    public abstract void load(Device device) throws ModelException, IOException;
+
+    /**
+     * Starts a new {@link WorkerThread} for this {@link WorkerPoolConfig}.
+     *
+     * @param device the device to run on
+     * @return the new {@link ThreadType}
+     */
+    public abstract ThreadType<I, O> newThread(Device device);
+
+    /**
+     * Initialize the worker.
+     *
+     * @throws IOException if failed to download worker
+     * @throws ModelNotFoundException if model not found
+     */
+    public abstract void initialize() throws IOException, ModelException;
+
+    /** Close all loaded workers. */
+    public abstract void close();
+
+    /**
+     * Returns the default device for this model if device is null.
+     *
+     * @param deviceName the device to use if it is not null
+     * @return a non-null device
+     */
+    public Device withDefaultDevice(String deviceName) {
+        return Device.fromName(deviceName);
+    }
+
+    /**
+     * Returns the worker type loading status.
+     *
+     * @return the worker type loading status
+     */
+    public abstract Status getStatus();
+
+    /**
+     * Returns if the worker type can be load parallel on multiple devices.
+     *
+     * @return if the worker type can be load parallel on multiple devices
+     */
+    public abstract boolean isParallelLoading();
+
+    /**
+     * Returns the devices the worker type will be loaded on at startup.
+     *
+     * @return the devices the worker type will be loaded on at startup
+     */
+    public abstract String[] getLoadOnDevices();
+
+    /**
+     * Sets the worker type ID.
+     *
+     * @param id the worker type ID
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the worker type ID.
+     *
+     * @return the worker type ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the worker type version.
+     *
+     * @return the worker type version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Returns the worker type url.
+     *
+     * @return the worker type url
+     */
+    public String getModelUrl() {
+        return modelUrl;
+    }
+
+    /**
+     * Sets the configured max idle time in seconds of workers.
+     *
+     * @param maxIdleSeconds the configured max idle time in seconds of workers
+     */
+    public void setMaxIdleSeconds(int maxIdleSeconds) {
+        this.maxIdleSeconds = maxIdleSeconds;
+    }
+
+    /**
+     * Returns the configured max idle time in seconds of workers.
+     *
+     * @return the max idle time in seconds
+     */
+    public int getMaxIdleSeconds() {
+        return maxIdleSeconds;
+    }
+
+    /**
+     * Sets the configured batch size.
+     *
+     * @param batchSize the configured batch size
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Returns the configured batch size.
+     *
+     * @return the configured batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Sets the maximum delay in milliseconds to aggregate a batch.
+     *
+     * @param maxBatchDelayMillis the maximum delay in milliseconds to aggregate a batch
+     */
+    public void setMaxBatchDelayMillis(int maxBatchDelayMillis) {
+        this.maxBatchDelayMillis = maxBatchDelayMillis;
+    }
+
+    /**
+     * Returns the maximum delay in milliseconds to aggregate a batch.
+     *
+     * @return the maximum delay in milliseconds to aggregate a batch
+     */
+    public int getMaxBatchDelayMillis() {
+        return maxBatchDelayMillis;
+    }
+
+    /**
+     * Sets the configured size of the workers queue.
+     *
+     * @param queueSize the configured size of the workers queue
+     */
+    public void setQueueSize(int queueSize) {
+        this.queueSize = queueSize;
+    }
+
+    /**
+     * Returns the configured size of the workers queue.
+     *
+     * @return requested size of the workers queue.
+     */
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    /**
+     * Sets the starting number of min workers.
+     *
+     * @param minWorkers Sets the starting number of min workers
+     */
+    public void setMinWorkers(int minWorkers) {
+        if (maxWorkers != null && maxWorkers < minWorkers) {
+            throw new IllegalArgumentException(
+                    "The max workers for a model or worker can't be smaller than the min workers");
+        }
+
+        this.minWorkers = minWorkers;
+    }
+
+    /**
+     * Returns the minimum number of workers.
+     *
+     * @param device the device to get the min workers for
+     * @return the minimum number of workers
+     */
+    public int getMinWorkers(Device device) {
+        return minWorkers;
+    }
+
+    /**
+     * Sets the starting number of max workers.
+     *
+     * @param maxWorkers Sets the starting number of max workers
+     */
+    public void setMaxWorkers(int maxWorkers) {
+        if (minWorkers != null && maxWorkers < minWorkers) {
+            throw new IllegalArgumentException(
+                    "The max workers for a model or worker can't be smaller than the min workers");
+        }
+        if (maxWorkers == 0) {
+            throw new IllegalArgumentException("Models must have a maxWorkers greater than 0");
+        }
+
+        this.maxWorkers = maxWorkers;
+    }
+
+    /**
+     * Returns the maximum number of workers.
+     *
+     * @param device the device to get the max workers for
+     * @return the maximum number of workers
+     */
+    public int getMaxWorkers(Device device) {
+        return maxWorkers;
+    }
+
+    /**
+     * Sets the starting minimum and maximum number of workers.
+     *
+     * @param minWorkers the new minimum number of workers
+     * @param maxWorkers the new maximum number of workers
+     */
+    public void setMinMaxWorkers(int minWorkers, int maxWorkers) {
+        if (maxWorkers < minWorkers) {
+            throw new IllegalArgumentException(
+                    "The max workers for a model or worker can't be smaller than the min workers");
+        }
+        if (minWorkers == 0) {
+            throw new IllegalArgumentException(
+                    "Having a minWorkers of 0 is not currently supported");
+        }
+        if (maxWorkers == 0) {
+            throw new IllegalArgumentException("Models must have a maxWorkers greater than 0");
+        }
+
+        this.minWorkers = minWorkers;
+        this.maxWorkers = maxWorkers;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WorkerPoolConfig)) {
+            return false;
+        }
+        WorkerPoolConfig<?, ?> wpc = (WorkerPoolConfig<?, ?>) o;
+        return id.equals(wpc.id) && Objects.equals(version, wpc.version);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        if (version != null) {
+            return id + ':' + version + " (" + getStatus() + ')';
+        }
+        return id + " (" + getStatus() + ')';
+    }
+
+    /** An enum represents state of a worker type. */
+    public enum Status {
+        PENDING,
+        READY,
+        FAILED
+    }
+
+    protected abstract static class ThreadType<I, O> {
+        Device device;
+
+        protected ThreadType(Device device) {
+            this.device = device;
+        }
+
+        /**
+         * Runs the work on the {@link WorkerThread}.
+         *
+         * @param input the work input
+         * @return the computed output
+         * @throws TranslateException if it failed to compute
+         */
+        public abstract List<O> run(List<I> input) throws TranslateException;
+
+        /** Closes the thread type and frees any resources. */
+        public abstract void close();
+    }
+}

--- a/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/WorkLoadManagerTest.java
@@ -38,7 +38,7 @@ public class WorkLoadManagerTest {
                         .optModelUrls(modelUrl)
                         .build();
         ModelInfo<Input, Output> modelInfo = new ModelInfo<>("model", modelUrl, criteria);
-        wlm.registerModel(modelInfo).initWorkers(null, 1, 2);
+        wlm.registerWorkerPool(modelInfo).initWorkers(null);
         Input input = new Input();
         URL url = new URL("https://resources.djl.ai/images/0.png");
         try (InputStream is = url.openStream()) {


### PR DESCRIPTION
This is a decent change I wanted to get some early feedback on. It still needs a
bit of clean up, and I am not quite happy with the name of "workerType" (let me
know if anyone has any better ideas).

The basic idea is that I replaced the `ModelInfo` inside of the WLM with an
abstraction called `WorkerType`. The WorkerType corresponds to a WorkerPool and
determines what data is saved and work is done within a `WorkerThread`. The main
WorkerType is still the ModelInfo which extends it. I also added a
LambdaWorkerType that can be used for other processing. Unlike a
WorkflowFunction, it runs in a dedicated worker thread rather than on the common
CompleteableFuture pool.

I think this also helps clean up the abstractions a bit. Within the ModelInfo,
it essentially removed all of the pieces which are more about interacting with
DJL Serving and the WLM more than deep learning. It should also help define
clearer boundaries for when we add expansions and other pieces to the model such
as adapters. I'll also update the architecture section after this (which
probably needed an update regardless).