### PR TITLE
Revert "Change rolling batch generations order (#1046)"

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -132,7 +132,7 @@ class LmiDistRollingBatch(RollingBatch):
             if self.cache:
                 decode_generations, decode_next_batch = self.model.generate_token(
                     self.cache)
-                decode_generations.extend(generations)
+                generations.extend(decode_generations)
 
                 # concatenate with the existing batch of the model
                 if prefill_next_batch is None:
@@ -141,7 +141,7 @@ class LmiDistRollingBatch(RollingBatch):
                     self.cache = prefill_next_batch
                 else:
                     self.cache = self.model.batch_type.concatenate(
-                        [decode_next_batch, prefill_next_batch])
+                        [prefill_next_batch, decode_next_batch])
             else:
                 self.cache = prefill_next_batch
         else:


### PR DESCRIPTION
This reverts commit 7f9b9a8cb0e141f7b147fd265550184e552571ee.

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
