### PR TITLE
add Neuron RollingBatch implementation

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception
+from djl_python.transformers_neuronx_scheduler.optimum_neuron_scheduler import NeuronGenerator
+
+
+class NeuronRollingBatch(RollingBatch):
+
+    def __init__(self, model, tokenizer, batch_size, n_postions, **kwargs):
+        """
+        Initializes the NeuronRollingBatch.
+        :param model: the Neuron HuggingFace model
+        :param batch_size: the maximum batch size required by model
+        :param tokenizer: the tokenizer used by model
+        """
+        super().__init__(-1, **kwargs)
+        self.scheduler = NeuronGenerator(model, tokenizer, batch_size,
+                                         n_postions)
+
+    def reset(self):
+        self.scheduler.clear()
+        super().reset()
+
+    @stop_on_any_exception
+    def inference(self, input_data, parameters):
+        batch_size = len(input_data)
+        new_requests = self.get_new_requests(input_data, parameters,
+                                             batch_size)
+        if len(new_requests) > 0:
+            generations = self.scheduler.prefill(new_requests)
+        else:
+            generations = self.scheduler.decode()
+        generation_dict = {
+            generation.request_id: generation
+            for generation in generations
+        }
+        req_ids = []
+        for request in self.pending_requests:
+            generation = generation_dict.get(request.id, None)
+            if generation:
+                is_last_token = generation.generated_text is not None
+                if not is_last_token:
+                    req_ids.append(request.id)
+
+                request.set_next_token("" if generation.token_is_special else
+                                       generation.token_text,
+                                       self.output_formatter,
+                                       last_token=is_last_token)
+            else:
+                request.set_next_token("",
+                                       self.output_formatter,
+                                       last_token=False)
+                req_ids.append(request.id)
+
+        # filter the requests that are stopped.
+        self.scheduler.filter(req_ids)
+        return self.postprocess_results(batch_size)
+
+    def preprocess_requests(self, requests):
+        raise NotImplementedError("Not implemented for Neuron rolling batcher")

--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import copy
+from enum import Enum
+from typing import List, Optional
+
+import torch
+import logging
+from transformers import PreTrainedTokenizerBase
+from transformers.generation import GenerationConfig
+
+from djl_python.rolling_batch.rolling_batch import Request
+from djl_python.transformers_neuronx_scheduler.token_selector import TokenSelector
+from djl_python.transformers_neuronx_scheduler.utils import Generation, FinishReason, GeneratedText
+
+
+class Slot:
+    """Represents a slot in a static batch"""
+
+    class State(Enum):
+        EMPTY = 0
+        PAUSE = 1
+        READY = 2
+
+    def __init__(self, id: int):
+        self._id = id
+        self.clear()
+
+    def clear(self):
+        """Clear the slot and mark it as available."""
+        self._state = Slot.State.EMPTY
+        self._request_id = None
+        self._inputs = ""
+        self._generation_config = None
+        self._tokens = []
+        self._selector = None
+        self._generated_tokens = 0
+        self._next_token_text = ""
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def state(self) -> "Slot.State":
+        return self._state
+
+    @property
+    def request_id(self) -> int:
+        return self._request_id
+
+    @property
+    def inputs(self) -> str:
+        return self._inputs
+
+    @property
+    def generation_config(self) -> GenerationConfig:
+        return self._generation_config
+
+    @property
+    def generated_tokens(self) -> torch.LongTensor:
+        return self._generated_tokens
+
+    def assign(self, request: Request, generation_config: GenerationConfig):
+        """Assign a request to a slot.
+
+        Args:
+            request (`Request`):
+                The request to be assigned. Contains the inputs and tokens selection parameters.
+            generation_config (`transformers.GenerationConfig`):
+                The base generation config (might be modified by the request generation parameters).
+        """
+        self._state = Slot.State.READY
+        self._request_id = request.id
+        self._inputs = request.input_text
+        self._generation_config = copy.deepcopy(generation_config)
+        # Update generation config with token chooser parameters
+        param = request.parameters
+        self._generation_config.temperature = param.get("temperature", 0.9)
+        self._generation_config.top_k = param.get("top_k", 0)
+        self._generation_config.top_p = param.get("top_p", 1.0)
+        self._generation_config.typical_p = param.get("typical_p", 1.0)
+        self._generation_config.do_sample = param.get("do_sample", False)
+        self._generation_config.repetition_penalty = param.get(
+            "repetition_penalty", 1.0)
+        # TODO: seed, watermark
+        self._generation_config.max_new_tokens = param.get(
+            "max_new_tokens", 30)
+        # TODO: stop_sequences, ignore_eos_token
+
+    def reset(self, input_ids, selector):
+        """Reset the slot for the next generation.
+
+        Args:
+            input_ids: (`torch.LongTensor`):
+                The new input_ids to use to generate the next token.
+            selector: (`optimum.neuron.generation.TokenSelector`):
+                An object implementing the updated token selection logic.
+        """
+        self._tokens = input_ids
+        self._selector = selector
+
+    def pause(self):
+        """Mark the current slot as paused for generation.
+
+        Note that the KV cache for this slot will still be filled.
+        """
+        self._state = Slot.State.PAUSE
+
+    def resume(self):
+        """Mark the slot as ready for generation."""
+        self._state = Slot.State.READY
+
+    def append(self, next_token: int, next_token_text: str):
+        """Append a new generated token to this slot
+
+        The new token is added to the list of generated tokens, which impacts
+        directly the generated_text and stopped property.
+
+        The new token is however not added immediately to the slot inputs: it will
+        be added later on when it has effectively been used to produce the next token.
+
+        Args:
+            next_token (`int`):
+                The newly generated token.
+            next_token_test (`str`):
+                The corresponding decoded text.
+        """
+        self._tokens = torch.cat(
+            [self._tokens, torch.LongTensor([next_token])])
+        self._generated_tokens += 1
+        # Now that a new token has been generated, we can append the previous one to the inputs
+        self._inputs += self._next_token_text
+        self._next_token_text = next_token_text
+
+    def select(self, input_ids: torch.LongTensor,
+               logits: torch.Tensor) -> torch.LongTensor:
+        """Select the next token from the candidate logits.
+
+        Args:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                The sequence used as a prompt for the generation (not used in all generation modes).
+            logits (`torch.Tensor` of shape `(batch_size, sequence_length)`):
+                The logits corresponding to the generated tokens.
+
+        Return:
+            `torch.LongTensor`: A scalar torch.LongTensor` containing the selected token.
+        """
+        return self._selector.select(input_ids, logits)[0]
+
+    @property
+    def stopped(self) -> bool:
+        return self._selector.stopping_criteria(self._tokens, None)
+
+    @property
+    def generated_text(self) -> str:
+        return self._inputs + self._next_token_text
+
+    @property
+    def next_token(self) -> int:
+        return None if len(self._tokens) == 0 else self._tokens[-1]
+
+    @property
+    def max_token(self) -> int:
+        return self._generation_config.max_length
+
+
+class NeuronGenerator:
+    """A Generator for Neuron models."""
+
+    def __init__(self, model, tokenizer: PreTrainedTokenizerBase, batch_size,
+                 n_positions):
+        self.model = model
+        # Specify padding options for decoder-only architecture
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        tokenizer.padding_side = "left"
+        self.tokenizer = tokenizer
+        self.special_tokens = [
+            self.tokenizer.eos_token_id, self.tokenizer.pad_token_id
+        ]
+        self.slots = [Slot(i) for i in range(batch_size)]
+        self.batch_size = batch_size
+        self.n_positions = n_positions
+
+    def prefill(self, new_requests: List[Request]):
+        """Prefill new requests.
+
+        Return:
+            A list of `Generation` for each request and a `CachedBatch` containing all pending requests.
+        """
+        slots = {state: [] for state in Slot.State}
+        for slot in self.slots:
+            slots[slot.state].append(slot)
+        active_slots = slots[Slot.State.READY]
+        empty_slots = slots[Slot.State.EMPTY]
+        if len(empty_slots) < len(new_requests):
+            raise ValueError(
+                f"Cannot prefill {len(new_requests)} new request(s) with only {len(empty_slots)} empty slots."
+                f"Please align the number of concurrent requests with the static batch size: {self.batch_size}."
+            )
+        # Assign each request to an empty slot
+        logging.debug(
+            f"Prefilling {len(new_requests)} new request(s) with {len(empty_slots)} empty slot(s)"
+        )
+        for request in new_requests:
+            slot = empty_slots.pop()
+            slot.assign(request, self.model.generation_config)
+            logging.debug(
+                f"Request {slot.request_id} assigned to slot {slot.id}")
+        # Reconstruct the full inputs (without padding)
+        inputs = [slot.inputs for slot in self.slots]
+        # Tokenize with padding
+        padded_inputs = self.tokenizer(inputs,
+                                       return_tensors="pt",
+                                       padding=True)
+        #  If needed truncate sequences to fit into the static dimensions
+        seq_length = min(padded_inputs.input_ids.shape[-1], self.n_positions)
+        input_ids = padded_inputs.input_ids[:, :seq_length]
+        # Each slot must be reset with the padded inputs
+        for i, slot in enumerate(self.slots):
+            if slot.state != slot.state.EMPTY:
+                slot_input_ids = input_ids[i:i + 1, :]
+                # Padded input ids are also required to set logits processors and stopping criterias
+                selector = TokenSelector.create(slot_input_ids,
+                                                slot.generation_config,
+                                                self.model, self.n_positions)
+                slot_input_ids = slot_input_ids.squeeze().type(torch.int64)
+                slot.reset(slot_input_ids, selector)
+        # Clear KV cache
+        self.model.reset_generation()
+        # Pause previously active slots during generation.
+        # Their KV cache will be prefilled but new tokens will be ignored, as they
+        # have already been generated and sent back in the last decode.
+        for slot in active_slots:
+            slot.pause()
+        generation = self._generate_token(input_ids)
+        # Reactivate previously active slots for the next decode.
+        for slot in active_slots:
+            slot.resume()
+        logging.debug("Model ready for decoding")
+        return generation
+
+    def decode(self) -> List[Generation]:
+        """Decode the specified prefilled requests.
+
+        Args:
+            batches (`List[CachedBatch]`):
+                A list of previous batches containing the prefilled requests.
+
+        Return:
+            A list of `Generation` for each request and a `CachedBatch` containing all pending requests.
+        """
+        # Construct input_ids from tokens generated by the last decode or prefill requests
+        empty = True
+        input_ids = torch.full([self.batch_size, 1],
+                               fill_value=self.tokenizer.eos_token_id,
+                               dtype=torch.int64)
+        for i, slot in enumerate(self.slots):
+            if slot.state != Slot.State.EMPTY:
+                input_ids[i, 0] = slot.next_token
+                empty = False
+        if empty:
+            raise ValueError(
+                "Unable to decode tokens for non-prefilled batches (probably due to a previous failure)"
+            )
+        return self._generate_token(input_ids, attention_mask=None)
+
+    def _generate_token(
+            self,
+            input_ids: torch.LongTensor,
+            attention_mask: Optional[torch.LongTensor] = None
+    ) -> List[Generation]:
+        model_inputs = self.model.prepare_inputs_for_generation(
+            input_ids, attention_mask)
+        outputs = self.model(
+            **model_inputs,
+            return_dict=True,
+        )
+        generations = []
+        request_ids = []
+        for i, slot in enumerate(self.slots):
+            if slot.state != Slot.State.READY:
+                continue
+            request_id = slot.request_id
+            request_ids.append(request_id)
+            next_token_logits = outputs.logits[i:i + 1, -1, :]
+            slot_input_ids = input_ids[i:i + 1, :]
+            next_token = slot.select(slot_input_ids, next_token_logits)
+            next_token_text = self.tokenizer.decode(next_token)
+            if not slot.generated_text.endswith(
+                    " ") and not next_token_text.startswith(" "):
+                # Some tokenizers do not prepend spaces automatically when decoding a single token
+                contextual_text = self.tokenizer.decode(
+                    [slot.next_token, next_token])
+                if contextual_text[:-len(next_token_text)].endswith(" "):
+                    next_token_text = " " + next_token_text
+            slot.append(next_token, next_token_text)
+            generated_text = None
+            finish_reason = None
+            if next_token == self.tokenizer.eos_token_id:
+                finish_reason = FinishReason.FINISH_REASON_EOS_TOKEN
+            elif slot.stopped:
+                finish_reason = FinishReason.FINISH_REASON_STOP_SEQUENCE
+            if finish_reason is not None:
+                # We must include the generated text for each finished sequence in the response
+                generated_text = GeneratedText(
+                    text=slot.generated_text,
+                    generated_tokens=slot.generated_tokens,
+                    finish_reason=finish_reason,
+                    seed=0)
+                logging.debug(
+                    f"Finished generating tokens for request {request_id}")
+                # mark the slot as available
+                slot.clear()
+            generations.append(
+                Generation(
+                    request_id=request_id,
+                    prefill_tokens=None,
+                    token_id=next_token,
+                    token_logprob=None,
+                    token_text=next_token_text,
+                    token_is_special=(next_token in [self.special_tokens]),
+                    generated_text=generated_text,
+                ))
+        return generations
+
+    def filter(self, request_ids: List[int]):
+        """Remove requests that are not listed from the specified batch
+
+        Args:
+            batch_id (`int`):
+                The id of a cached batch.
+            request_ids(`List[int]`):
+                The list of requests that must be kept.
+
+        Return:
+            A `CachedBatch` containing the pending requests.
+        """
+        self._clear(request_ids)
+
+    def clear(self):
+        """Remove all requests from the generator"""
+        return self._clear([])
+
+    def _clear(self, request_ids: List):
+        for slot in self.slots:
+            if slot.state != Slot.State.EMPTY and slot.request_id not in request_ids:
+                logging.debug(f"Removing request {slot.request_id}")
+                slot.clear()

--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/token_selector.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/token_selector.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import logging
+from typing import Optional
+import torch
+from transformers.generation import (
+    GenerationConfig,
+    GenerationMixin,
+    LogitsProcessorList,
+    StoppingCriteriaList,
+    TopKLogitsWarper,
+)
+from transformers.generation.utils import GenerationMode
+from transformers.generation import LogitsWarper
+
+
+class FastTopKLogitsWarper(LogitsWarper):
+    r"""Returns [batch_size, top_k] scores and indices instead of [batch_size, vocab_size] scores."""
+
+    def __init__(self, top_k: int):
+        self.top_k = top_k
+
+    def __call__(self, input_ids: torch.LongTensor,
+                 scores: torch.FloatTensor) -> torch.FloatTensor:
+        top_k = min(self.top_k, scores.size(-1))  # Safety check
+        # Remove all tokens with a probability less than the last token of the top-k
+        return torch.topk(scores, top_k)
+
+
+class TokenSelector:
+    """Implements the token selection logic corresponding to a generation configuration.
+
+    This class combines and uses the logits processors and stopping criterias implemented in
+    the transformers library.
+
+    The algorithm to select these objects is heavily inspired by the transformers `GenerationMixin.generate()`
+    method, but the actual token selection methods are specific.
+
+    The reason why this class does not inherit from `GenerationMixin` is because it does not
+    include the code to produce the tokens logits.
+    Separating the production of the tokens logits from the tokens selection allows this class
+    to be used with different generation paradigms, either synchronously using a single `TokenSelector` in
+    `GenerationMixin.generate()` or asynchronously using multiple `TokenSelector` inside an inference endpoint.
+
+    The constructor of this class should not be called directly: instances should be obtained by
+    calling `TokenSelector.create()`.
+    """
+
+    def __init__(
+        self,
+        mode: GenerationMode,
+        logits_processor: LogitsProcessorList,
+        stopping_criteria: StoppingCriteriaList,
+        eos_token_id: int,
+        pad_token_id: int,
+        logits_warper: Optional[LogitsProcessorList] = None,
+    ):
+        self.mode = mode
+        self.logits_processor = logits_processor
+        self.stopping_criteria = stopping_criteria
+        self.eos_token_id = eos_token_id
+        self.pad_token_id = pad_token_id
+        self.logits_warper = logits_warper
+        if self.mode == GenerationMode.SAMPLE:
+            assert len(self.logits_warper) > 0
+            last_warper = self.logits_warper[-1]
+            self.fast_topk = isinstance(last_warper, TopKLogitsWarper)
+            if self.fast_topk:
+                # Replace the last warping operation by a faster alternative
+                self.logits_warper[-1] = FastTopKLogitsWarper(
+                    last_warper.top_k)
+
+    @classmethod
+    def create(cls, input_ids: torch.Tensor,
+               generation_config: GenerationConfig, model: GenerationMixin,
+               max_seq_length: int) -> "TokenSelector":
+        r"""Creates the `TokenSelector` for a specific generation configuration.
+
+        Args:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                The sequence used as a prompt for the generation.
+            generation_config (`~transformers.generation.GenerationConfig`, *optional*):
+                The generation configuration to parametrize the token selection.
+            model (`~transformers.generation.GenerationMixin`):
+                The model provides the internal helpers allowing to select the logits processors and stopping criterias.
+            max_seq_length (`int`):
+                The maximum number of input + generated tokens for this model. It depends on the model compilation parameters.
+        Return:
+            `torch.LongTensor`: A `torch.LongTensor` containing the selected tokens.
+        """
+        generation_config.validate()
+
+        unsupported_generation_flags = [
+            "output_attentions",
+            "output_hidden_states",
+            "output_scores",
+            "return_dict_in_generate",
+        ]
+        for flag in unsupported_generation_flags:
+            if getattr(generation_config, flag, False):
+                raise ValueError("{flag} is not supported for generation.")
+
+        if generation_config.max_new_tokens is not None:
+            logging.warning(
+                f"Both `max_new_tokens` (={generation_config.max_new_tokens}) and `max_length`(="
+                f"{generation_config.max_length}) seem to have been set. `max_new_tokens` will take precedence. "
+                "Please refer to the documentation for more information. "
+                "(https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)"
+            )
+            generation_config.max_length = generation_config.max_new_tokens + input_ids.shape[
+                -1]
+
+        min_length = generation_config.min_length
+        if min_length > max_seq_length:
+            raise ValueError(
+                f"The minimum generation length ({min_length}) exceeds the model maximum sequence length ({max_seq_length})"
+            )
+        max_length = generation_config.max_length
+        if max_length > max_seq_length:
+            logging.warning(
+                f"Adjusting the maximum generation length ({max_length}) to the model maximum sequence length ({max_seq_length})"
+            )
+            generation_config.max_length = max_seq_length
+
+        # Instantiate transformers library processors and criterias
+        logits_processor = model._get_logits_processor(
+            generation_config,
+            input_ids_seq_length=input_ids.shape[-1],
+            encoder_input_ids=input_ids,
+            prefix_allowed_tokens_fn=None,
+            logits_processor=LogitsProcessorList(),
+        )
+        stopping_criteria = model._get_stopping_criteria(
+            generation_config, stopping_criteria=StoppingCriteriaList())
+
+        # The generation requires special tokens
+        eos_token_id = generation_config.eos_token_id
+        # This is not supposed to happen for any of the models we support
+        assert eos_token_id is not None and not isinstance(eos_token_id, list)
+        if generation_config.pad_token_id is None:
+            logging.warning(
+                f"Setting `pad_token_id` to `eos_token_id`:{eos_token_id} for open-end generation."
+            )
+            generation_config.pad_token_id = eos_token_id
+
+        generation_mode = model._get_generation_mode(generation_config, None)
+        if generation_mode not in [
+                GenerationMode.GREEDY_SEARCH, GenerationMode.SAMPLE
+        ]:
+            raise ValueError("Unsupported generation mode")
+
+        logits_warper = None
+        if generation_mode == GenerationMode.SAMPLE:
+            logits_warper = model._get_logits_warper(generation_config)
+
+        return cls(
+            mode=generation_mode,
+            logits_processor=logits_processor,
+            stopping_criteria=stopping_criteria,
+            logits_warper=logits_warper,
+            eos_token_id=eos_token_id,
+            pad_token_id=generation_config.pad_token_id,
+        )
+
+    def select(self, input_ids: torch.LongTensor,
+               logits: torch.Tensor) -> torch.LongTensor:
+        """Select the next tokens from the candidate logits.
+
+        Args:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                The sequence used as a prompt for the generation (not used in all generation modes).
+            logits (`torch.Tensor` of shape `(batch_size, sequence_length)`):
+                The logits corresponding to the generated tokens.
+
+        Return:
+            `torch.LongTensor`: A `torch.LongTensor` containing the selected tokens.
+        """
+        scores = self.logits_processor(input_ids, logits)
+        if self.mode == GenerationMode.SAMPLE:
+            return self._sample(scores)
+        else:
+            return torch.argmax(scores, dim=-1)
+
+    def _sample(self, scores: torch.Tensor) -> torch.LongTensor:
+        if self.fast_topk:
+            # Get [batch_size, top_k] scores and indices instead of [batch_size, vocab_size] scores
+            scores, next_token_indices = self.logits_warper(None, scores)
+        else:
+            scores = self.logits_warper(None, scores)
+
+        # sample
+        probs = torch.nn.functional.softmax(scores, dim=-1)
+        next_tokens = torch.multinomial(probs, num_samples=1)
+        if self.fast_topk:
+            # Convert the topk relative tokens to actual vocabulary tokens
+            next_tokens = torch.gather(next_token_indices, 1, next_tokens)
+        return next_tokens.squeeze(1)

--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/utils.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/utils.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+from enum import Enum
+from typing import Optional
+
+
+class FinishReason(str, Enum):
+
+    FINISH_REASON_LENGTH = 0
+    FINISH_REASON_EOS_TOKEN = 1
+    FINISH_REASON_STOP_SEQUENCE = 2
+
+    # number of generated tokens == `max_new_tokens`
+    Length = "length"
+    # the model generated its end of sequence token
+    EndOfSequenceToken = "eos_token"
+    # the model generated a text included in `stop_sequences`
+    StopSequence = "stop_sequence"
+
+
+class Generation(object):
+
+    def __init__(self, request_id, prefill_tokens, token_id, token_logprob,
+                 token_text, token_is_special, generated_text) -> None:
+        self.request_id = request_id
+        self.prefill_tokens = prefill_tokens
+        self.token_id = token_id
+        self.token_logprob = token_logprob
+        self.token_text = token_text
+        self.token_is_special = token_is_special
+        self.generated_text = generated_text
+
+
+class GeneratedText(object):
+
+    def __init__(self, text: str, generated_tokens: int,
+                 finish_reason: FinishReason, seed: Optional[int]):
+        self.text = text
+        self.generated_tokens = generated_tokens
+        self.finish_reason = finish_reason
+        self.seed = seed

--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -164,7 +164,7 @@ public class PyModel extends BaseModel {
                     entryPoint = "djl_python.fastertransformer";
                 } else if ("nc".equals(manager.getDevice().getDeviceType())
                         && pyEnv.getTensorParallelDegree() > 0) {
-                    entryPoint = "djl_python.transformers-neuronx";
+                    entryPoint = "djl_python.transformers_neuronx";
                 } else if (pyEnv.getInitParameters().containsKey("model_id")) {
                     entryPoint = "djl_python.huggingface";
                 } else {

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -633,7 +633,7 @@ def build_transformers_neuronx_handler_model(model):
         )
     options = transformers_neuronx_handler_list[model]
     options["engine"] = "Python"
-    options["option.entryPoint"] = "djl_python.transformers-neuronx"
+    options["option.entryPoint"] = "djl_python.transformers_neuronx"
     write_model_artifacts(options)
 
 


### PR DESCRIPTION
## Description ##

Support rolling batch using inefficient mechanism. Inspired from Optimum Neuron repo: https://github.com/huggingface/optimum-neuron/tree/main/text-generation-inference/server/text_generation_server

[BREAKING Change]: we are renaming transformers-neuronx.py to transformers_neuronx.py for better importing and regulate the python file naming.

## Test

Simulator testing with rolling batch

```
python3 run.py facebook/opt-1.3b -rb neuron
```

```
        properties = {
            "tensor_parallel_degree": 2,
            "trust_remote_code": "true",
            "batch_size": 4,
            "dtype":"fp16",
            "n_positions": 512,
            "engine": "Python"
        }
    if args.rollingbatch == "lmi-dist":
        dist.init_process_group("nccl")
        properties["engine"] = "MPI"
    batcher = init_rolling_batch(args.rollingbatch, args.model_id, properties)
    simulator(batcher, "The president of United States is", {
        "max_new_tokens": 256,
        "do_sample": True
    }, [1, 2, 1], [200, 100, 20])
```
and with result

```
Finish one request: {"generated_text": " a mentally unstable, amoral woman.  She's been in office for less than a week and will outlast everyone in office.  She's making a mockery of the office of the presidency.\n>The only reason that Hillary is a better candidate is because people like you are worried about the e-penis on Hillary's forehead.   Says the Trump supporter.</s>"}

Finish one request: {"generated_text": " worthless.\nBut what if he starts a world war 3?</s>"}

Finish one request: {"generated_text": " one of the most powerful men on the planet... ,,,.</s>"}

Finish one request: {"generated_text": " not an example.\nGG History Beans\"\n\nNobody\nMy!\" Actually doesn What\nMy\n\nWhat Came- This is...__ PE??\nPA m R E A M\nM R A EE ONE!XENUT'?PH O W BJ BILL FU FORNI.S.OP.ONE.ERONE?F, F UPL.It.No.- AShip World. Of Map. Same. World.  For Opp.   Just saw this.  I think.    (our shared. This.\nCon.  The future.   To We'll. CO.  See the Shef.  World:  U.  We Are. That's.   Did  The Elvis.  S.   O' Hear  3 Years in fore! Cor Nare    Choose.   It's  In- We're. : U.\nLoad in History:  F.   O.   U.   We's   Oh.    Look.   Insert \"Look: It.  Pick Up!  I amians  You.     More  I) Non-  Hey! Ife  Bit How the "}

```