### PR TITLE
Fix neuron cores auto-scaling

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -178,7 +178,7 @@ class Connection {
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);
         }
         if ("nc".equals(device.getDeviceType())) {
-            String visibleCores = getNeuronVisibleCores(deviceId, tensorParallelDegree);
+            String visibleCores = getNeuronVisibleCores(workerId, tensorParallelDegree);
             // TODO: re-map logic device once neuron fixed bug
             pyEnv.addEnv("NEURON_RT_VISIBLE_CORES", visibleCores);
             logger.info("Set NEURON_RT_VISIBLE_CORES={}", visibleCores);
@@ -220,11 +220,10 @@ class Connection {
         return sb.toString();
     }
 
-    private static String getNeuronVisibleCores(int deviceId, int tensorParallelDegree) {
-        if (tensorParallelDegree > 0) {
-            return deviceId + "-" + (deviceId + tensorParallelDegree - 1);
-        }
-        return String.valueOf(deviceId);
+    private static String getNeuronVisibleCores(int workerId, int tensorParallelDegree) {
+        int start = workerId * tensorParallelDegree;
+        int end = start + tensorParallelDegree - 1;
+        return start + "-" + end;
     }
 
     void connect() throws InterruptedException {


### PR DESCRIPTION
When trying to use 2 workers with for each one neuron core on inf2.xlarge with tensor_parallel_degree = 1, I can see the same core (nc0) is required by the 2 workers with:

Set NEURON_RT_VISIBLE_CORES=0

Causing an error as the same core is requested by the second worker.

The provided code should fix that.