### PR TITLE
Fixes API responses

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeWorkflowResponse.java
@@ -32,7 +32,7 @@ public class DescribeWorkflowResponse {
 
     private String workflowName;
     private String version;
-    private List<DescribeWorkerPoolConfig> wpcs;
+    private List<Model> models;
 
     /**
      * Constructs a new {@code DescribeWorkflowResponse} instance.
@@ -42,7 +42,7 @@ public class DescribeWorkflowResponse {
     public DescribeWorkflowResponse(ai.djl.serving.workflow.Workflow workflow) {
         this.workflowName = workflow.getName();
         this.version = workflow.getVersion();
-        wpcs = new ArrayList<>();
+        models = new ArrayList<>();
 
         ModelManager manager = ModelManager.getInstance();
         WorkLoadManager wlm = manager.getWorkLoadManager();
@@ -53,8 +53,8 @@ public class DescribeWorkflowResponse {
             int activeWorker = 0;
             int targetWorker = 0;
 
-            DescribeWorkerPoolConfig m = new DescribeWorkerPoolConfig();
-            wpcs.add(m);
+            Model m = new Model();
+            models.add(m);
             WorkerPool<Input, Output> pool = wlm.getWorkerPool(wpc);
             if (pool != null) {
                 pool.cleanup();
@@ -117,12 +117,12 @@ public class DescribeWorkflowResponse {
      *
      * @return a list of models
      */
-    public List<DescribeWorkerPoolConfig> getWpcs() {
-        return wpcs;
+    public List<Model> getModels() {
+        return models;
     }
 
     /** A class represents model information. */
-    public static final class DescribeWorkerPoolConfig {
+    public static final class Model {
 
         private String modelName;
         private String modelUrl;

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -38,6 +38,7 @@ import ai.djl.util.Utils;
 import ai.djl.util.ZipUtils;
 import ai.djl.util.cuda.CudaUtils;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
@@ -586,7 +587,6 @@ public class ModelServerTest {
                         + " workers:4");
     }
 
-    @SuppressWarnings("unchecked")
     private void testListModels(Channel channel) throws InterruptedException {
         request(
                 channel,
@@ -601,12 +601,12 @@ public class ModelServerTest {
         }
 
         // Test pure JSON works
-        Map<String, Object> rawResult = JsonUtils.GSON.fromJson(result, Map.class);
-        List<Object> rawModels = (List<Object>) rawResult.get("models");
+        JsonObject rawResult = JsonUtils.GSON.fromJson(result, JsonObject.class);
+        JsonArray rawModels = rawResult.get("models").getAsJsonArray();
         Set<String> modelProperties =
                 new HashSet<>(Arrays.asList("modelName", "version", "modelUrl", "status"));
-        for (Object rrawModel : rawModels) {
-            Map<String, Object> rawModel = (Map<String, Object>) rrawModel;
+        for (JsonElement rrawModel : rawModels) {
+            JsonObject rawModel = rrawModel.getAsJsonObject();
             assertTrue(modelProperties.containsAll(rawModel.keySet()));
         }
 
@@ -618,7 +618,6 @@ public class ModelServerTest {
         Assert.assertEquals(resp.getNextPageToken(), "2");
     }
 
-    @SuppressWarnings("unchecked")
     private void testListWorkflows(Channel channel) throws InterruptedException {
         request(
                 channel,
@@ -632,12 +631,12 @@ public class ModelServerTest {
         }
 
         // Test pure JSON works
-        Map<String, Object> rawResult = JsonUtils.GSON.fromJson(result, Map.class);
-        assertTrue(rawResult.containsKey("nextPageToken"));
-        List<Object> rawWorkflows = (List<Object>) rawResult.get("workflows");
+        JsonObject rawResult = JsonUtils.GSON.fromJson(result, JsonObject.class);
+        assertTrue(rawResult.has("nextPageToken"));
+        JsonArray rawWorkflows = rawResult.get("workflows").getAsJsonArray();
         Set<String> workflowProperties = new HashSet<>(Arrays.asList("workflowName", "version"));
-        for (Object rrawWorkflow : rawWorkflows) {
-            Map<String, Object> rawWorkflow = (Map<String, Object>) rrawWorkflow;
+        for (JsonElement rrawWorkflow : rawWorkflows) {
+            JsonObject rawWorkflow = rrawWorkflow.getAsJsonObject();
             assertTrue(workflowProperties.containsAll(rawWorkflow.keySet()));
         }
     }
@@ -653,7 +652,6 @@ public class ModelServerTest {
         assertEquals(resp.get("platform").getAsString(), "mxnet_mxnet");
     }
 
-    @SuppressWarnings("unchecked")
     private void testDescribeModel(Channel channel) throws InterruptedException {
         request(
                 channel,
@@ -691,11 +689,10 @@ public class ModelServerTest {
         assertNotNull(worker.getStatus());
 
         // Test pure JSON works
-        List<Object> rawResult = (List<Object>) JsonUtils.GSON.fromJson(result, List.class);
-        List<Object> rawModels =
-                (List<Object>) ((Map<String, Object>) rawResult.get(0)).get("models");
-        Map<String, Object> rawModel = (Map<String, Object>) rawModels.get(0);
-        assertEquals(rawModel.get("modelName"), "mlp_2");
+        JsonArray rawResult = JsonUtils.GSON.fromJson(result, JsonArray.class);
+        JsonArray rawModels = rawResult.get(0).getAsJsonObject().get("models").getAsJsonArray();
+        JsonObject rawModel = rawModels.get(0).getAsJsonObject();
+        assertEquals(rawModel.get("modelName").getAsString(), "mlp_2");
     }
 
     private void testUnregisterModel(Channel channel) throws InterruptedException {


### PR DESCRIPTION
This is an update to fix the changes to the workflow response from https://github.com/deepjavalibrary/djl-serving/pull/1022. Before, we had no test that checks the response components decided by the names of Java response object properties (workflows, models, etc.). This adds some new JSON testing to help ensure that these are not accidentally changed, fixing this issue and hopefully avoiding future breakages.
