### PR TITLE
Adds adapter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ node_modules/
 # dir
 tests/integration/models/
 engines/python/setup/djl_python/tests/resources*
+
+#Python
+__pycache__
+*.egg-info/
+*.pt

--- a/engines/python/.gitignore
+++ b/engines/python/.gitignore
@@ -1,3 +1,0 @@
-__pycache__
-*.egg-info/
-*.pt

--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -217,6 +217,48 @@ public class PyEngineTest {
         }
     }
 
+    @Test
+    public void testAdaptEchoModel() throws TranslateException, IOException, ModelException {
+        // Echo model doesn't support initialize
+        Criteria<Input, Output> criteria =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optModelPath(Paths.get("src/test/resources/adaptecho"))
+                        .optEngine("Python")
+                        .build();
+        try (ZooModel<Input, Output> model = criteria.loadModel();
+                Predictor<Input, Output> predictor = model.newPredictor()) {
+            Input input = new Input();
+            input.add("input");
+            input.add("adapter", "ad");
+            Output output = predictor.predict(input);
+            Assert.assertEquals(output.getData().getAsString(), "dynadinput");
+        }
+    }
+
+    @Test
+    public void testBatchAdaptEchoModel() throws TranslateException, IOException, ModelException {
+        // Echo model doesn't support initialize
+        Criteria<Input, Output> criteria =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optModelPath(Paths.get("src/test/resources/adaptecho"))
+                        .optEngine("Python")
+                        .build();
+        try (ZooModel<Input, Output> model = criteria.loadModel();
+                Predictor<Input, Output> predictor = model.newPredictor()) {
+            Input in0 = new Input();
+            in0.add("input");
+            in0.add("adapter", "ad0");
+            Input in1 = new Input();
+            in1.add("input");
+            in1.add("adapter", "ad1");
+            List<Output> outputs = predictor.batchPredict(Arrays.asList(in0, in1));
+            Assert.assertEquals(outputs.get(0).getData().getAsString(), "dynad0input");
+            Assert.assertEquals(outputs.get(1).getData().getAsString(), "dynad1input");
+        }
+    }
+
     @Test(expectedExceptions = EngineException.class, expectedExceptionsMessageRegExp = "OOM")
     public void testLoadModelOom()
             throws TranslateException, IOException, ModelException, InterruptedException {

--- a/engines/python/src/test/resources/adaptecho/model.py
+++ b/engines/python/src/test/resources/adaptecho/model.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+"""
+Test Python model example.
+"""
+
+import logging
+import sys
+import time
+
+from djl_python import Input
+from djl_python import Output
+
+adapters = dict()
+
+
+def register_adapter(inputs: Input):
+    global adapters
+    name = inputs.get_properties()["name"]
+    adapters[name] = True
+    return Output().add("Successfully registered adapter")
+
+
+def unregister_adapter(inputs: Input):
+    global adapters
+    name = inputs.get_properties()["name"]
+    del adapters[name]
+    return Output().add("Successfully unregistered adapter")
+
+
+def handle(inputs: Input):
+    """
+    Default handler function
+    """
+
+    if inputs.is_empty():
+        return
+
+    outputs = Output()
+
+    for i, input in enumerate(inputs.get_batches()):
+        data = input.get_as_string()
+        if input.contains_key("adapter"):
+            adapter = input.get_as_string("adapter")
+            if adapter in adapters:
+                # Registered adapter
+                out = adapter + data
+            else:
+                # Dynamic adapter
+                out = "dyn" + adapter + data
+        else:
+            out = data
+        outputs.add(out, key="data", batch_index=i)
+
+    return outputs

--- a/engines/python/src/test/resources/adaptecho/model.py
+++ b/engines/python/src/test/resources/adaptecho/model.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
 # except in compliance with the License. A copy of the License is located at

--- a/engines/python/src/test/resources/adaptecho/serving.properties
+++ b/engines/python/src/test/resources/adaptecho/serving.properties
@@ -1,0 +1,4 @@
+option.pythonExecutable=python3
+option.entryPoint=model.py
+option.handler=handle
+retry_threshold=0

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -380,7 +380,6 @@ public class ModelServer {
             URI uri = WorkflowDefinition.toWorkflowUri(modelUrl);
             if (uri != null) {
                 workflow = WorkflowDefinition.parse(modelName, uri).toWorkflow();
-                workflow.prepare(modelManager.getWorkLoadManager());
             } else {
                 if (modelName == null) {
                     modelName = ModelInfo.inferModelNameFromUrl(modelUrl);
@@ -401,7 +400,6 @@ public class ModelServer {
                                 -1,
                                 -1);
                 workflow = new Workflow(modelInfo);
-                workflow.prepare(modelManager.getWorkLoadManager());
             }
             CompletableFuture<Void> f =
                     modelManager

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -380,6 +380,7 @@ public class ModelServer {
             URI uri = WorkflowDefinition.toWorkflowUri(modelUrl);
             if (uri != null) {
                 workflow = WorkflowDefinition.parse(modelName, uri).toWorkflow();
+                workflow.prepare(modelManager.getWorkLoadManager());
             } else {
                 if (modelName == null) {
                     modelName = ModelInfo.inferModelNameFromUrl(modelUrl);
@@ -400,6 +401,7 @@ public class ModelServer {
                                 -1,
                                 -1);
                 workflow = new Workflow(modelInfo);
+                workflow.prepare(modelManager.getWorkLoadManager());
             }
             CompletableFuture<Void> f =
                     modelManager

--- a/serving/src/main/java/ai/djl/serving/ServerInitializer.java
+++ b/serving/src/main/java/ai/djl/serving/ServerInitializer.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.serving;
 
+import ai.djl.serving.http.AdapterManagementRequestHandler;
 import ai.djl.serving.http.ConfigurableHttpRequestHandler;
 import ai.djl.serving.http.InferenceRequestHandler;
 import ai.djl.serving.http.InvalidRequestHandler;
@@ -68,6 +69,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
             case MANAGEMENT:
                 pipeline.addLast(new ConfigurableHttpRequestHandler(pluginManager));
                 pipeline.addLast("management", new ManagementRequestHandler());
+                pipeline.addLast("management-adapter", new AdapterManagementRequestHandler());
                 break;
             case INFERENCE:
                 pipeline.addLast("inference", new InferenceRequestHandler());
@@ -77,6 +79,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
                 pipeline.addLast("inference", new InferenceRequestHandler());
                 pipeline.addLast(new ConfigurableHttpRequestHandler(pluginManager));
                 pipeline.addLast("management", new ManagementRequestHandler());
+                pipeline.addLast("management-adapter", new AdapterManagementRequestHandler());
                 break;
         }
         pipeline.addLast("badRequest", new InvalidRequestHandler());

--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http;
+
+import ai.djl.ModelException;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.serving.http.list.ListAdaptersResponse;
+import ai.djl.serving.http.list.ListPagination;
+import ai.djl.serving.models.ModelManager;
+import ai.djl.serving.util.NettyUtils;
+import ai.djl.serving.wlm.Adapter;
+import ai.djl.serving.wlm.ModelInfo;
+import ai.djl.serving.wlm.WorkerPool;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** A class handling inbound HTTP requests to the management API for adapters. */
+public class AdapterManagementRequestHandler extends HttpRequestHandler {
+    private static final Pattern ADAPTERS_PATTERN =
+            Pattern.compile("^/models/.+/adapters([/?][^/]*)?");
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean acceptInboundMessage(Object msg) throws Exception {
+        if (super.acceptInboundMessage(msg)) {
+            FullHttpRequest req = (FullHttpRequest) msg;
+            String uri = req.uri();
+            return ADAPTERS_PATTERN.matcher(uri).matches();
+        }
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void handleRequest(
+            ChannelHandlerContext ctx,
+            FullHttpRequest req,
+            QueryStringDecoder decoder,
+            String[] segments)
+            throws ModelException {
+        HttpMethod method = req.method();
+        String modelName = segments[2];
+
+        if (segments.length < 5) {
+            if (HttpMethod.GET.equals(method)) {
+                handleListAdapters(ctx, modelName, decoder);
+                return;
+            } else if (HttpMethod.POST.equals(method)) {
+                handleRegisterAdapter(ctx, modelName, decoder);
+                return;
+            } else {
+                throw new MethodNotAllowedException();
+            }
+        }
+
+        String adapterName = segments[4];
+        if (HttpMethod.GET.equals(method)) {
+            handleDescribeAdapter(ctx, modelName, adapterName);
+        } else if (HttpMethod.DELETE.equals(method)) {
+            handleUnregisterAdapter(ctx, modelName, adapterName);
+        } else {
+            throw new MethodNotAllowedException();
+        }
+    }
+
+    private void handleListAdapters(
+            ChannelHandlerContext ctx, String modelName, QueryStringDecoder decoder) {
+        WorkerPool<Input, Output> wp =
+                ModelManager.getInstance().getWorkLoadManager().getWorkerPoolById(modelName);
+        if (wp == null) {
+            throw new BadRequestException("The model " + modelName + " was not found");
+        }
+        ModelInfo<Input, Output> modelInfo = getModelInfo(wp);
+
+        ListAdaptersResponse list = new ListAdaptersResponse();
+        List<String> keys = new ArrayList<>(modelInfo.getAdapters().keySet());
+        ListPagination pagination = new ListPagination(decoder, keys.size());
+        if (pagination.getLast() < keys.size()) {
+            list.setNextPageToken(String.valueOf(pagination.getLast()));
+        }
+
+        for (int i = pagination.getPageToken(); i < pagination.getLast(); ++i) {
+            String adapterName = keys.get(i);
+            Adapter adapter = modelInfo.getAdapter(adapterName);
+            list.addAdapter(adapter.getName(), adapter.getUrl().toString());
+        }
+
+        NettyUtils.sendJsonResponse(ctx, list);
+    }
+
+    private void handleRegisterAdapter(
+            ChannelHandlerContext ctx, String modelName, QueryStringDecoder decoder) {
+
+        String adapterName = NettyUtils.getRequiredParameter(decoder, "name");
+        URI uri = URI.create(NettyUtils.getRequiredParameter(decoder, "url"));
+
+        WorkerPool<Input, Output> wp =
+                ModelManager.getInstance().getWorkLoadManager().getWorkerPoolById(modelName);
+        if (wp == null) {
+            throw new BadRequestException("The model " + modelName + " was not found");
+        }
+        Adapter adapter = Adapter.newInstance(wp, adapterName, uri);
+        adapter.register(wp);
+
+        String msg = "Adapter " + adapterName + " registered";
+        NettyUtils.sendJsonResponse(ctx, new StatusResponse(msg));
+    }
+
+    private void handleDescribeAdapter(
+            ChannelHandlerContext ctx, String modelName, String adapterName) {
+        WorkerPool<Input, Output> wp =
+                ModelManager.getInstance().getWorkLoadManager().getWorkerPoolById(modelName);
+        if (wp == null) {
+            throw new BadRequestException("The model " + modelName + " was not found");
+        }
+        ModelInfo<Input, Output> modelInfo = getModelInfo(wp);
+        Adapter adapter = modelInfo.getAdapter(adapterName);
+
+        if (adapter == null) {
+            throw new BadRequestException("The adapter " + adapterName + " was not found");
+        }
+
+        DescribeAdapterResponse adapterResponse = new DescribeAdapterResponse(adapter);
+        NettyUtils.sendJsonResponse(ctx, adapterResponse);
+    }
+
+    private void handleUnregisterAdapter(
+            ChannelHandlerContext ctx, String modelName, String adapterName) {
+
+        WorkerPool<Input, Output> wp =
+                ModelManager.getInstance().getWorkLoadManager().getWorkerPoolById(modelName);
+        if (wp == null) {
+            throw new BadRequestException("The model " + modelName + " was not found");
+        }
+        Adapter.unregister(wp, adapterName);
+
+        String msg = "Adapter " + adapterName + " registered";
+        NettyUtils.sendJsonResponse(ctx, new StatusResponse(msg));
+    }
+
+    private ModelInfo<Input, Output> getModelInfo(WorkerPool<Input, Output> wp) {
+        if (!(wp.getWpc() instanceof ModelInfo)) {
+            String modelName = wp.getWpc().getId();
+            throw new BadRequestException("The worker " + modelName + " is not a model");
+        }
+        return (ModelInfo<Input, Output>) wp.getWpc();
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.QueryStringDecoder;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -101,7 +100,7 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
         for (int i = pagination.getPageToken(); i < pagination.getLast(); ++i) {
             String adapterName = keys.get(i);
             Adapter adapter = modelInfo.getAdapter(adapterName);
-            list.addAdapter(adapter.getName(), adapter.getUrl().toString());
+            list.addAdapter(adapter.getName(), adapter.getSrc());
         }
 
         NettyUtils.sendJsonResponse(ctx, list);
@@ -111,14 +110,14 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
             ChannelHandlerContext ctx, String modelName, QueryStringDecoder decoder) {
 
         String adapterName = NettyUtils.getRequiredParameter(decoder, "name");
-        URI uri = URI.create(NettyUtils.getRequiredParameter(decoder, "url"));
+        String src = NettyUtils.getRequiredParameter(decoder, "src");
 
         WorkerPool<Input, Output> wp =
                 ModelManager.getInstance().getWorkLoadManager().getWorkerPoolById(modelName);
         if (wp == null) {
             throw new BadRequestException("The model " + modelName + " was not found");
         }
-        Adapter adapter = Adapter.newInstance(wp, adapterName, uri);
+        Adapter adapter = Adapter.newInstance(wp, adapterName, src);
         adapter.register(wp);
 
         String msg = "Adapter " + adapterName + " registered";

--- a/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
@@ -17,7 +17,7 @@ import ai.djl.serving.wlm.Adapter;
 /** A class that holds information about adapter status. */
 public class DescribeAdapterResponse {
     private String name;
-    private String url;
+    private String src;
 
     /**
      * Constructs a {@link DescribeAdapterResponse}.
@@ -26,7 +26,7 @@ public class DescribeAdapterResponse {
      */
     public DescribeAdapterResponse(Adapter adapter) {
         this.name = adapter.getName();
-        this.url = adapter.getUrl().toString();
+        this.src = adapter.getSrc();
     }
 
     /**
@@ -39,11 +39,11 @@ public class DescribeAdapterResponse {
     }
 
     /**
-     * Returns the adapter url.
+     * Returns the adapter src.
      *
-     * @return the adapter url
+     * @return the adapter src
      */
-    public String getUrl() {
-        return url;
+    public String getSrc() {
+        return src;
     }
 }

--- a/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http;
+
+import ai.djl.serving.wlm.Adapter;
+
+/** A class that holds information about adapter status. */
+public class DescribeAdapterResponse {
+    private String name;
+    private String url;
+
+    /**
+     * Constructs a {@link DescribeAdapterResponse}.
+     *
+     * @param adapter the adapter to describe
+     */
+    public DescribeAdapterResponse(Adapter adapter) {
+        this.name = adapter.getName();
+        this.url = adapter.getUrl().toString();
+    }
+
+    /**
+     * Returns the adapter name.
+     *
+     * @return the adapter name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the adapter url.
+     *
+     * @return the adapter url
+     */
+    public String getUrl() {
+        return url;
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/ManagementRequestHandler.java
@@ -195,7 +195,6 @@ public class ManagementRequestHandler extends HttpRequestHandler {
         if (uri != null) {
             try {
                 workflow = WorkflowDefinition.parse(req.getModelName(), uri).toWorkflow();
-                workflow.prepare(modelManager.getWorkLoadManager());
             } catch (IOException | BadWorkflowException e) {
                 NettyUtils.sendError(ctx, e.getCause());
                 return;
@@ -217,7 +216,6 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                             req.getMinWorkers(),
                             req.getMaxWorkers());
             workflow = new Workflow(modelInfo);
-            workflow.prepare(modelManager.getWorkLoadManager());
         }
         CompletableFuture<Void> f =
                 modelManager
@@ -256,7 +254,6 @@ public class ManagementRequestHandler extends HttpRequestHandler {
 
             URI uri = URI.create(workflowUrl);
             Workflow workflow = WorkflowDefinition.parse(null, uri).toWorkflow();
-            workflow.prepare(modelManager.getWorkLoadManager());
             String workflowName = workflow.getName();
 
             CompletableFuture<Void> f =

--- a/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
@@ -59,20 +59,20 @@ public class ListAdaptersResponse {
      * Adds the adapter to the list.
      *
      * @param name the adapter name
-     * @param url the adapter url
+     * @param src the adapter source
      */
-    public void addAdapter(String name, String url) {
-        adapters.add(new AdapterItem(name, url));
+    public void addAdapter(String name, String src) {
+        adapters.add(new AdapterItem(name, src));
     }
 
     /** A class that holds the adapter response. */
     public static final class AdapterItem {
         private String name;
-        private String url;
+        private String src;
 
-        private AdapterItem(String name, String url) {
+        private AdapterItem(String name, String src) {
             this.name = name;
-            this.url = url;
+            this.src = src;
         }
 
         /**
@@ -85,12 +85,12 @@ public class ListAdaptersResponse {
         }
 
         /**
-         * Returns the adapter url.
+         * Returns the adapter src.
          *
-         * @return the adapter url
+         * @return the adapter src
          */
-        public String getUrl() {
-            return url;
+        public String getSrc() {
+            return src;
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http.list;
+
+import ai.djl.serving.http.list.ListAdaptersResponse.AdapterItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** A class that holds information about the current registered adapters. */
+public class ListAdaptersResponse {
+
+    private String nextPageToken;
+    private List<AdapterItem> adapters;
+
+    /** Constructs a new {@code ListModelsResponse} instance. */
+    public ListAdaptersResponse() {
+        adapters = new ArrayList<>();
+    }
+
+    /**
+     * Returns the next page token.
+     *
+     * @return the next page token
+     */
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+
+    /**
+     * Sets the next page token.
+     *
+     * @param nextPageToken the next page token
+     */
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+
+    /**
+     * Returns a list of adapters.
+     *
+     * @return a list of adapters
+     */
+    public List<AdapterItem> getAdapters() {
+        return adapters;
+    }
+
+    /**
+     * Adds the adapter to the list.
+     *
+     * @param name the adapter name
+     * @param url the adapter url
+     */
+    public void addAdapter(String name, String url) {
+        adapters.add(new AdapterItem(name, url));
+    }
+
+    /** A class that holds the adapter response. */
+    public static final class AdapterItem {
+        private String name;
+        private String url;
+
+        private AdapterItem(String name, String url) {
+            this.name = name;
+            this.url = url;
+        }
+
+        /**
+         * Returns the adapter name.
+         *
+         * @return the adapter name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns the adapter url.
+         *
+         * @return the adapter url
+         */
+        public String getUrl() {
+            return url;
+        }
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/list/ListModelsResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListModelsResponse.java
@@ -10,7 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.serving.http;
+package ai.djl.serving.http.list;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/serving/src/main/java/ai/djl/serving/http/list/ListPagination.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListPagination.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http.list;
+
+import ai.djl.serving.util.NettyUtils;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+/** A pagination helper for items in the list responses. */
+public final class ListPagination {
+
+    private int pageToken;
+    private int last;
+
+    /**
+     * Constructs a new {@link ListPagination}.
+     *
+     * @param decoder the query with the pagination data
+     * @param keysSize the number of items to paginate over
+     */
+    public ListPagination(QueryStringDecoder decoder, int keysSize) {
+        int limit = NettyUtils.getIntParameter(decoder, "limit", 100);
+        pageToken = NettyUtils.getIntParameter(decoder, "next_page_token", 0);
+        if (limit > 100 || limit < 0) {
+            limit = 100;
+        }
+        if (pageToken < 0) {
+            pageToken = 0;
+        }
+
+        last = pageToken + limit;
+        if (last > keysSize) {
+            last = keysSize;
+        }
+    }
+
+    /**
+     * Returns the current page token.
+     *
+     * @return the current page token
+     */
+    public int getPageToken() {
+        return pageToken;
+    }
+
+    /**
+     * Returns the last item in the pagination.
+     *
+     * @return the last item in the pagination
+     */
+    public int getLast() {
+        return last;
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/http/list/ListWorkflowsResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListWorkflowsResponse.java
@@ -10,7 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.serving.http;
+package ai.djl.serving.http.list;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/serving/src/main/java/ai/djl/serving/http/list/package-info.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/serving/src/main/java/ai/djl/serving/http/list/package-info.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/** Contains classes that handles REST API list responses. */
+package ai.djl.serving.http.list;

--- a/serving/src/main/java/ai/djl/serving/models/Endpoint.java
+++ b/serving/src/main/java/ai/djl/serving/models/Endpoint.java
@@ -133,7 +133,7 @@ public class Endpoint {
     /** Closes the {@code Endpoint}. */
     public void close() {
         for (Workflow workflow : workflows) {
-            workflow.stop();
+            workflow.close();
         }
     }
 }

--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -157,6 +157,7 @@ public final class ModelManager {
                             throw new CompletionException(e);
                         }
                     }
+                    workflow.prepare(wlm);
                     return null;
                 });
     }

--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -180,7 +180,7 @@ public final class ModelManager {
             // unregister all versions
             for (Workflow workflow : endpoint.getWorkflows()) {
                 candidateWpcsToUnregister.addAll(workflow.getWpcs());
-                workflow.stop();
+                workflow.close();
             }
             startupWorkflows.remove(workflowName);
             endpoint.getWorkflows().clear();
@@ -192,7 +192,7 @@ public final class ModelManager {
                 return false;
             }
             candidateWpcsToUnregister.addAll(workflow.getWpcs());
-            workflow.stop();
+            workflow.close();
             startupWorkflows.remove(workflowName);
             logger.info("Model {}/{} unregistered.", workflowName, version);
         }

--- a/serving/src/main/java/ai/djl/serving/util/NettyUtils.java
+++ b/serving/src/main/java/ai/djl/serving/util/NettyUtils.java
@@ -426,6 +426,24 @@ public final class NettyUtils {
      *
      * @param decoder the {@code QueryStringDecoder} parsed from uri
      * @param key the parameter key
+     * @return the parameter's value
+     */
+    public static String getRequiredParameter(QueryStringDecoder decoder, String key) {
+        List<String> param = decoder.parameters().get(key);
+        if (param != null && !param.isEmpty()) {
+            String ret = param.get(0);
+            if (!ret.isEmpty()) {
+                return ret;
+            }
+        }
+        throw new BadRequestException("The parameter " + key + " is required");
+    }
+
+    /**
+     * Reads the parameter's value for the key from the uri.
+     *
+     * @param decoder the {@code QueryStringDecoder} parsed from uri
+     * @param key the parameter key
      * @param def the default value
      * @return the parameter's value
      */

--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -18,6 +18,7 @@ import ai.djl.serving.wlm.WorkLoadManager;
 import ai.djl.serving.wlm.WorkerPoolConfig;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 import ai.djl.serving.workflow.WorkflowExpression.Item.ItemType;
+import ai.djl.serving.workflow.function.AdapterWorkflowFunction;
 import ai.djl.serving.workflow.function.EnsembleMerge;
 import ai.djl.serving.workflow.function.FunctionsApply;
 import ai.djl.serving.workflow.function.IdentityWF;
@@ -40,7 +41,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** A flow of executing {@link ai.djl.Model}s and custom functions. */
-public class Workflow {
+public class Workflow implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(Workflow.class);
 
@@ -54,6 +55,7 @@ public class Workflow {
         BUILT_INS.put(IdentityWF.NAME, IdentityWF::new);
         BUILT_INS.put(EnsembleMerge.NAME, EnsembleMerge::new);
         BUILT_INS.put(FunctionsApply.NAME, FunctionsApply::new);
+        BUILT_INS.put(AdapterWorkflowFunction.NAME, AdapterWorkflowFunction::new);
     }
 
     String name;
@@ -62,6 +64,7 @@ public class Workflow {
     Map<String, WorkflowExpression> expressions;
     Map<String, WorkflowFunction> funcs;
     Map<String, Map<String, Object>> configs;
+    private boolean prepared;
 
     /**
      * Constructs a workflow containing only a single workerPoolConfig.
@@ -125,6 +128,24 @@ public class Workflow {
     }
 
     /**
+     * Prepares this workflow for use.
+     *
+     * <p>This is idempotent and can be safely re-called if this is already prepared. It should
+     * re-call to ensure preparedness.
+     *
+     * @param wlm the wlm to prepare with
+     */
+    public void prepare(WorkLoadManager wlm) {
+        if (prepared) {
+            return;
+        }
+        prepared = true;
+        for (WorkflowFunction f : funcs.values()) {
+            f.prepare(wlm, configs);
+        }
+    }
+
+    /**
      * Executes a workflow with an input.
      *
      * @param wlm the wlm to run the workflow with
@@ -133,6 +154,7 @@ public class Workflow {
      */
     public CompletableFuture<Output> execute(WorkLoadManager wlm, Input input) {
         logger.trace("Beginning execution of workflow: {}", name);
+        prepare(wlm);
         WorkflowExecutor ex = new WorkflowExecutor(wlm, input);
         return ex.execute(OUT)
                 .thenApply(
@@ -194,10 +216,14 @@ public class Workflow {
         return name;
     }
 
-    /** Stops the workflow and unloads all the wpcs in the workflow. */
-    public void stop() {
+    /** {@inheritDoc} */
+    @Override
+    public void close() {
         for (WorkerPoolConfig<Input, Output> wpc : getWpcs()) {
             wpc.close();
+        }
+        for (WorkflowFunction f : funcs.values()) {
+            f.close();
         }
     }
 
@@ -311,6 +337,7 @@ public class Workflow {
             if (BUILT_INS.containsKey(name)) {
                 // Built-in WorkflowFunctions should be one for each workflow
                 WorkflowFunction f = BUILT_INS.get(name).get();
+                f.prepare(wlm, configs);
                 funcs.put(name, f);
                 return f;
             }

--- a/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
@@ -62,16 +62,17 @@ public class AdapterWorkflowFunction extends WorkflowFunction {
         this.adapters = new ConcurrentHashMap<>();
 
         // Add adapters from configurations
-        for (Map.Entry<String, Object> entry : configs.get("adapters").entrySet()) {
-            String ref = entry.getKey();
-            Map<String, Object> config = (Map<String, Object>) entry.getValue();
-            String modelName = (String) config.get("model");
-            String adapterName = (String) config.get("name");
-            String src = (String) config.get("src");
+        if (configs != null && configs.containsKey("adapters")) {
+            for (Map.Entry<String, Object> entry : configs.get("adapters").entrySet()) {
+                Map<String, Object> config = (Map<String, Object>) entry.getValue();
+                String modelName = (String) config.get("model");
+                String adapterName = entry.getKey();
+                String src = (String) config.get("src");
 
-            WorkerPool<?, ?> wp = wlm.getWorkerPoolById(modelName);
-            Adapter adapter = Adapter.newInstance(wp, adapterName, src);
-            adapters.put(ref, new AdapterReference(modelName, adapter));
+                WorkerPool<?, ?> wp = wlm.getWorkerPoolById(modelName);
+                Adapter adapter = Adapter.newInstance(wp, adapterName, src);
+                adapters.put(adapterName, new AdapterReference(modelName, adapter));
+            }
         }
 
         // Register adapters

--- a/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.workflow.function;
+
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.serving.wlm.Adapter;
+import ai.djl.serving.wlm.WorkLoadManager;
+import ai.djl.serving.wlm.WorkerPool;
+import ai.djl.serving.workflow.Workflow.WorkflowArgument;
+import ai.djl.serving.workflow.Workflow.WorkflowExecutor;
+import ai.djl.serving.workflow.WorkflowExpression;
+import ai.djl.serving.workflow.WorkflowExpression.Item;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Workflow function "adapter" applies an adapted model to an input.
+ *
+ * <p>To use this workflow function, you must pre-specify the adapted functions in the configs. In
+ * the configs, create an object "adapters" with keys as reference names and values as objects. The
+ * adapter reference objects should have three properties:
+ *
+ * <ul>
+ *   <li>model - the model name
+ *   <li>name - the adapter name
+ *   <li>url - the adapter url
+ * </ul>
+ *
+ * <p>To call this workflow function, it requires two arguments. The first is the adapter config
+ * reference name (determining the model and adapter to use). The second argument is the input.
+ *
+ * <p>To see an example of this workflow function, see the <a
+ * href="https://github.com/deepjavalibrary/djl-serving/tree/master/serving/src/test/resources/adapterWorkflows/w1/workflow.json">test
+ * example</a>.
+ */
+public class AdapterWorkflowFunction extends WorkflowFunction {
+
+    public static final String NAME = "adapter";
+
+    private WorkLoadManager wlm;
+    private Map<String, AdapterReference> adapters;
+
+    /** {@inheritDoc} */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void prepare(WorkLoadManager wlm, Map<String, Map<String, Object>> configs) {
+        this.wlm = wlm;
+        this.adapters = new ConcurrentHashMap<>();
+
+        // Add adapters from configurations
+        for (Map.Entry<String, Object> entry : configs.get("adapters").entrySet()) {
+            String ref = entry.getKey();
+            Map<String, Object> config = (Map<String, Object>) entry.getValue();
+            String modelName = (String) config.get("model");
+            String adapterName = (String) config.get("name");
+            URI url = URI.create((String) config.get("url"));
+
+            WorkerPool<?, ?> wp = wlm.getWorkerPoolById(modelName);
+            Adapter adapter = Adapter.newInstance(wp, adapterName, url);
+            adapters.put(ref, new AdapterReference(modelName, adapter));
+        }
+
+        // Register adapters
+        for (AdapterReference adapter : adapters.values()) {
+            adapter.adapter.register(wlm.getWorkerPoolById(adapter.modelName));
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() {
+        for (AdapterReference adapter : adapters.values()) {
+            WorkerPool<Input, Output> wp = wlm.getWorkerPoolById(adapter.modelName);
+            if (wp != null) {
+                Adapter.unregister(wp, adapter.adapter.getName());
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CompletableFuture<Item> run(WorkflowExecutor executor, List<WorkflowArgument> args) {
+        if (args.size() != 2) {
+            throw new IllegalArgumentException(
+                    "The adapter workflow function should have two args, but has " + args.size());
+        }
+        String adapterReference = args.get(0).getItem().getString();
+
+        if (!adapters.containsKey(adapterReference)) {
+            throw new IllegalArgumentException(
+                    "The adapter function was called with unknown adapter " + adapterReference);
+        }
+        AdapterReference adapter = adapters.get(adapterReference);
+
+        return args.get(1)
+                .evaluate()
+                .thenComposeAsync(
+                        evaluatedArg -> {
+                            Input input = evaluatedArg.getInput();
+                            input.add("adapter", adapter.adapter.getName());
+                            return executor.executeExpression(
+                                    new WorkflowExpression(
+                                            new Item(adapter.modelName), new Item(input)));
+                        });
+    }
+
+    private static final class AdapterReference {
+
+        private String modelName;
+        private Adapter adapter;
+
+        private AdapterReference(String modelName, Adapter adapter) {
+            this.modelName = modelName;
+            this.adapter = adapter;
+        }
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
@@ -22,7 +22,6 @@ import ai.djl.serving.workflow.Workflow.WorkflowExecutor;
 import ai.djl.serving.workflow.WorkflowExpression;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -68,10 +67,10 @@ public class AdapterWorkflowFunction extends WorkflowFunction {
             Map<String, Object> config = (Map<String, Object>) entry.getValue();
             String modelName = (String) config.get("model");
             String adapterName = (String) config.get("name");
-            URI url = URI.create((String) config.get("url"));
+            String src = (String) config.get("src");
 
             WorkerPool<?, ?> wp = wlm.getWorkerPoolById(modelName);
-            Adapter adapter = Adapter.newInstance(wp, adapterName, url);
+            Adapter adapter = Adapter.newInstance(wp, adapterName, src);
             adapters.put(ref, new AdapterReference(modelName, adapter));
         }
 

--- a/serving/src/main/java/ai/djl/serving/workflow/function/WorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/WorkflowFunction.java
@@ -12,11 +12,13 @@
  */
 package ai.djl.serving.workflow.function;
 
+import ai.djl.serving.wlm.WorkLoadManager;
 import ai.djl.serving.workflow.Workflow;
 import ai.djl.serving.workflow.WorkflowExpression.Item;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -25,7 +27,7 @@ import java.util.stream.Collectors;
  *
  * @see #run(Workflow.WorkflowExecutor, List)
  */
-public abstract class WorkflowFunction {
+public abstract class WorkflowFunction implements AutoCloseable {
 
     /**
      * The lambda function that is run.
@@ -57,4 +59,16 @@ public abstract class WorkflowFunction {
                                         .map(CompletableFuture::join)
                                         .collect(Collectors.toList()));
     }
+
+    /**
+     * Prepares this {@link WorkflowFunction}.
+     *
+     * @param wlm the wlm
+     * @param configs the workflow configs
+     */
+    public void prepare(WorkLoadManager wlm, Map<String, Map<String, Object>> configs) {}
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() {}
 }

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -810,7 +810,7 @@ public class ModelServerTest {
         // Test Missing Adapter before registering
         testAdapterMissing();
 
-        url = "/models/adaptecho/adapters?name=" + "adaptable" + "&url=" + "url";
+        url = "/models/adaptecho/adapters?name=" + "adaptable" + "&src=" + "src";
         request(channel, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url));
         assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
     }
@@ -893,7 +893,7 @@ public class ModelServerTest {
         DescribeAdapterResponse resp =
                 JsonUtils.GSON.fromJson(result, DescribeAdapterResponse.class);
         assertEquals(resp.getName(), "adaptable");
-        assertEquals(resp.getUrl(), "url");
+        assertEquals(resp.getSrc(), "src");
     }
 
     private void testAdapterScale(Channel channel) throws InterruptedException {

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -22,14 +22,16 @@ import ai.djl.engine.Engine;
 import ai.djl.modality.Classifications.Classification;
 import ai.djl.repository.MRL;
 import ai.djl.repository.Repository;
+import ai.djl.serving.http.DescribeAdapterResponse;
 import ai.djl.serving.http.DescribeWorkflowResponse;
 import ai.djl.serving.http.DescribeWorkflowResponse.Model;
 import ai.djl.serving.http.ErrorResponse;
-import ai.djl.serving.http.ListModelsResponse;
-import ai.djl.serving.http.ListWorkflowsResponse;
-import ai.djl.serving.http.ListWorkflowsResponse.WorkflowItem;
 import ai.djl.serving.http.ServerStartupException;
 import ai.djl.serving.http.StatusResponse;
+import ai.djl.serving.http.list.ListAdaptersResponse;
+import ai.djl.serving.http.list.ListModelsResponse;
+import ai.djl.serving.http.list.ListWorkflowsResponse;
+import ai.djl.serving.http.list.ListWorkflowsResponse.WorkflowItem;
 import ai.djl.serving.models.ModelManager;
 import ai.djl.serving.util.ConfigManager;
 import ai.djl.serving.util.Connector;
@@ -234,6 +236,15 @@ public class ModelServerTest {
 
             testPredictionsInvalidRequestSize(channel);
 
+            // adapter API
+            testAdapterRegister(channel);
+            testAdapterPredict(channel);
+            testAdapterInvoke(channel);
+            testAdapterList(channel);
+            testAdapterDescribe(channel);
+            testAdapterScale(channel);
+            testAdapterUnregister(channel);
+
             // plugin tests
             testStaticHtmlRequest();
 
@@ -273,6 +284,27 @@ public class ModelServerTest {
 
             testPredictions(channel, new String[] {"/predictions/m"});
             testPredictionsWorkflows(channel);
+
+            channel.close().sync();
+
+            ConfigManagerTest.testSsl();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testAdapterWorkflows()
+            throws ServerStartupException, GeneralSecurityException, ParseException, IOException,
+                    InterruptedException, ReflectiveOperationException {
+        ModelServer server =
+                initTestServer("src/test/resources/adapterWorkflows/config.properties");
+        try {
+            assertTrue(server.isRunning());
+            Channel channel = initTestChannel();
+
+            testAdapterWorkflowPredict(channel, "adapter1", "a1");
+            testAdapterWorkflowPredict(channel, "adapter2", "a2");
 
             channel.close().sync();
 
@@ -767,6 +799,126 @@ public class ModelServerTest {
         // wait for 1st response
         f.sync();
         Assert.assertTrue(latch.await(2, TimeUnit.MINUTES));
+    }
+
+    private void testAdapterRegister(Channel channel) throws InterruptedException {
+        String url = URLEncoder.encode("file:src/test/resources/adaptecho", StandardCharsets.UTF_8);
+        url = "/models?model_name=adaptecho&url=" + url;
+        request(channel, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url));
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
+
+        // Test Missing Adapter before registering
+        testAdapterMissing();
+
+        url = "/models/adaptecho/adapters?name=" + "adaptable" + "&url=" + "url";
+        request(channel, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url));
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
+    }
+
+    private void testAdapterMissing() throws InterruptedException {
+        Channel channel = connect(Connector.ConnectorType.INFERENCE);
+        assertNotNull(channel);
+
+        String url = "/predictions/adaptecho?adapter=adaptable";
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);
+        req.content().writeBytes("testPredictAdapter".getBytes(StandardCharsets.UTF_8));
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+        request(channel, req);
+        channel.closeFuture().sync();
+        channel.close().sync();
+
+        if (!System.getProperty("os.name").startsWith("Win")) {
+            assertEquals(httpStatus.code(), 503);
+        }
+    }
+
+    private void testAdapterPredict(Channel channel) throws InterruptedException {
+        String url = "/predictions/adaptecho?adapter=adaptable";
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);
+        req.content().writeBytes("testPredictAdapter".getBytes(StandardCharsets.UTF_8));
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+        request(channel, req);
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
+        assertEquals(result, "adaptabletestPredictAdapter");
+    }
+
+    private void testAdapterWorkflowPredict(Channel channel, String workflow, String adapter)
+            throws InterruptedException {
+        String url = "/predictions/" + workflow;
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);
+        req.content().writeBytes("testAWP".getBytes(StandardCharsets.UTF_8));
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+        request(channel, req);
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
+        assertEquals(result, adapter + "testAWP");
+    }
+
+    private void testAdapterInvoke(Channel channel) throws InterruptedException {
+        String url = "/invocations?model_name=adaptecho&adapter=adaptable";
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);
+        req.content().writeBytes("testInvokeAdapter".getBytes(StandardCharsets.UTF_8));
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+        request(channel, req);
+
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
+        assertEquals(result, "adaptabletestInvokeAdapter");
+    }
+
+    private void testAdapterList(Channel channel) throws InterruptedException {
+        request(
+                channel,
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1, HttpMethod.GET, "/models/adaptecho/adapters"));
+
+        ListAdaptersResponse resp = JsonUtils.GSON.fromJson(result, ListAdaptersResponse.class);
+        assertTrue(resp.getAdapters().stream().anyMatch(a -> "adaptable".equals(a.getName())));
+    }
+
+    private void testAdapterDescribe(Channel channel) throws InterruptedException {
+        request(
+                channel,
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.GET,
+                        "/models/adaptecho/adapters/adaptable"));
+
+        DescribeAdapterResponse resp =
+                JsonUtils.GSON.fromJson(result, DescribeAdapterResponse.class);
+        assertEquals(resp.getName(), "adaptable");
+        assertEquals(resp.getUrl(), "url");
+    }
+
+    private void testAdapterScale(Channel channel) throws InterruptedException {
+        request(
+                channel,
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.PUT,
+                        "/models/adaptecho?min_worker=4&max_worker=4"));
+
+        StatusResponse resp = JsonUtils.GSON.fromJson(result, StatusResponse.class);
+        assertEquals(
+                resp.getStatus(),
+                "Workflow \"adaptecho\" worker scaled. New Worker configuration min workers:4 max"
+                        + " workers:4");
+
+        // Runs prediction after scaling
+        // Has 3/4 chance to hit a worker that was scaled
+        testAdapterPredict(channel);
+    }
+
+    private void testAdapterUnregister(Channel channel) throws InterruptedException {
+        String url = "/models/adaptecho/adapters/adaptable";
+        request(channel, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.DELETE, url));
+        assertEquals(httpStatus.code(), HttpResponseStatus.OK.code());
     }
 
     private void testDescribeApi(Channel channel) throws InterruptedException {

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -38,12 +38,6 @@ public class WorkflowTest {
     /** A standard input for multiple tests with a zero image. */
     private Input zeroInput;
 
-    public static void main(String[] args) throws BadWorkflowException, IOException {
-        WorkflowTest t = new WorkflowTest();
-        t.beforeAll();
-        t.testCriteria();
-    }
-
     @BeforeSuite
     public void beforeAll() throws IOException {
         ConfigManager.init(new Arguments(new CommandLine.Builder().build()));
@@ -102,6 +96,7 @@ public class WorkflowTest {
             throws IOException, BadWorkflowException {
         Workflow workflow = WorkflowDefinition.parse(workflowFile).toWorkflow();
         WorkLoadManager wlm = new WorkLoadManager();
+        workflow.prepare(wlm);
         for (WorkerPoolConfig<Input, Output> wpc : workflow.getWpcs()) {
             wpc.setMaxWorkers(1);
             wlm.registerWorkerPool(wpc).initWorkers("-1");

--- a/serving/src/test/java/ai/djl/serving/WorkflowTest.java
+++ b/serving/src/test/java/ai/djl/serving/WorkflowTest.java
@@ -38,6 +38,12 @@ public class WorkflowTest {
     /** A standard input for multiple tests with a zero image. */
     private Input zeroInput;
 
+    public static void main(String[] args) throws BadWorkflowException, IOException {
+        WorkflowTest t = new WorkflowTest();
+        t.beforeAll();
+        t.testCriteria();
+    }
+
     @BeforeSuite
     public void beforeAll() throws IOException {
         ConfigManager.init(new Arguments(new CommandLine.Builder().build()));
@@ -102,7 +108,7 @@ public class WorkflowTest {
         }
 
         Output output = workflow.execute(wlm, input).join();
-        workflow.stop();
+        workflow.close();
         wlm.close();
         Assert.assertNotNull(output.getData());
         return output;

--- a/serving/src/test/resources/adaptecho
+++ b/serving/src/test/resources/adaptecho
@@ -1,0 +1,1 @@
+../../../../engines/python/src/test/resources/adaptecho

--- a/serving/src/test/resources/adapterWorkflows/config.properties
+++ b/serving/src/test/resources/adapterWorkflows/config.properties
@@ -1,0 +1,5 @@
+# debug=true
+inference_address=https://127.0.0.1:8443
+management_address=https://127.0.0.1:8443
+model_store=build/models
+load_models=src/test/resources/adapterWorkflows/w1,src/test/resources/adapterWorkflows/w2

--- a/serving/src/test/resources/adapterWorkflows/w1/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w1/workflow.json
@@ -1,0 +1,19 @@
+{
+  "name": "adapter1",
+  "version": "0.1",
+  "models": {
+    "m": "src/test/resources/adaptecho"
+  },
+  "configs": {
+    "adapters": {
+      "a": {
+        "model": "m",
+        "name": "a1",
+        "url": "url1"
+      }
+    }
+  },
+  "workflow": {
+    "out": ["adapter", "a", "in"]
+  }
+}

--- a/serving/src/test/resources/adapterWorkflows/w1/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w1/workflow.json
@@ -9,7 +9,7 @@
       "a": {
         "model": "m",
         "name": "a1",
-        "url": "url1"
+        "src": "url1"
       }
     }
   },

--- a/serving/src/test/resources/adapterWorkflows/w1/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w1/workflow.json
@@ -6,14 +6,13 @@
   },
   "configs": {
     "adapters": {
-      "a": {
+      "a1": {
         "model": "m",
-        "name": "a1",
         "src": "url1"
       }
     }
   },
   "workflow": {
-    "out": ["adapter", "a", "in"]
+    "out": ["adapter", "a1", "in"]
   }
 }

--- a/serving/src/test/resources/adapterWorkflows/w2/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w2/workflow.json
@@ -6,14 +6,13 @@
   },
   "configs": {
     "adapters": {
-      "a": {
+      "a2": {
         "model": "m",
-        "name": "a2",
         "src": "url2"
       }
     }
   },
   "workflow": {
-    "out": ["adapter", "a", "in"]
+    "out": ["adapter", "a2", "in"]
   }
 }

--- a/serving/src/test/resources/adapterWorkflows/w2/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w2/workflow.json
@@ -9,7 +9,7 @@
       "a": {
         "model": "m",
         "name": "a2",
-        "url": "url2"
+        "src": "url2"
       }
     }
   },

--- a/serving/src/test/resources/adapterWorkflows/w2/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w2/workflow.json
@@ -1,0 +1,19 @@
+{
+  "name": "adapter2",
+  "version": "0.1",
+  "models": {
+    "m": "src/test/resources/adaptecho"
+  },
+  "configs": {
+    "adapters": {
+      "a": {
+        "model": "m",
+        "name": "a2",
+        "url": "url2"
+      }
+    }
+  },
+  "workflow": {
+    "out": ["adapter", "a", "in"]
+  }
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.inference.Predictor;
+import ai.djl.serving.wlm.WorkerPoolConfig.ThreadConfig;
+import ai.djl.serving.wlm.util.WorkerJob;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An adapter is a modification producing a variation of a model that can be used during prediction.
+ */
+public abstract class Adapter {
+
+    protected String name;
+    protected URI url;
+
+    /**
+     * Constructs an {@link Adapter}.
+     *
+     * @param name the adapter name
+     * @param url the adapter url
+     */
+    protected Adapter(String name, URI url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    /**
+     * Constructs a new {@link Adapter}.
+     *
+     * <p>After registration, you should call {@link #register(WorkerPool)}. This doesn't affect the
+     * worker pool itself.
+     *
+     * @param wp the worker pool for the new adapter
+     * @param name the adapter name
+     * @param url the adapter url
+     * @return the new adapter
+     */
+    public static Adapter newInstance(WorkerPool<?, ?> wp, String name, URI url) {
+        if (!(wp.getWpc() instanceof ModelInfo)) {
+            String modelName = wp.getWpc().getId();
+            throw new IllegalArgumentException("The worker " + modelName + " is not a model");
+        }
+        ModelInfo<?, ?> modelInfo = (ModelInfo<?, ?>) wp.getWpc();
+        String engineName = modelInfo.getEngineName();
+        if ("Python".equals(engineName)) {
+            return new PyAdapter(name, url);
+        } else {
+            throw new IllegalArgumentException(
+                    "Adapters are only currently supported for Python models");
+        }
+    }
+
+    /**
+     * Unregisters an adapter in a worker pool.
+     *
+     * <p>This unregisters it in the wpc for new threads and all existing threads.
+     *
+     * @param wp the worker pool to remove the adapter from
+     * @param adapterName the adapter name
+     * @param <I> the input type
+     * @param <O> the output type
+     */
+    public static <I, O> void unregister(WorkerPool<I, O> wp, String adapterName) {
+        ModelInfo<I, O> wpc = (ModelInfo<I, O>) wp.getWpc();
+        Adapter adapter = wpc.unregisterAdapter(adapterName);
+        for (WorkerGroup<I, O> wg : wp.getWorkerGroups().values()) {
+            for (WorkerThread<I, O> t : wg.getWorkers()) {
+                t.addConfigJob(adapter.unregisterJob(wpc, t.getThreadType()));
+            }
+        }
+    }
+
+    /**
+     * Returns the adapter name.
+     *
+     * @return the adapter name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the adapter url.
+     *
+     * @return the adapter url
+     */
+    public URI getUrl() {
+        return url;
+    }
+
+    /**
+     * Registers this adapter in a worker pool.
+     *
+     * <p>This registers it in the wpc for new threads and all existing threads.
+     *
+     * @param wp the worker pool to register this adapter in
+     * @param <I> the input type
+     * @param <O> the output type
+     */
+    public <I, O> void register(WorkerPool<I, O> wp) {
+        ModelInfo<I, O> wpc = (ModelInfo<I, O>) wp.getWpc();
+        wpc.registerAdapter(this);
+        for (WorkerGroup<I, O> wg : wp.getWorkerGroups().values()) {
+            for (WorkerThread<I, O> t : wg.getWorkers()) {
+                t.addConfigJob(registerJob(wpc, t.getThreadType()));
+            }
+        }
+    }
+
+    /**
+     * Creates a {@link WorkerJob} to register this adapter in a {@link WorkerThread}.
+     *
+     * @param wpc the worker pool of the thread
+     * @param threadConfig the thread config to register
+     * @param <I> the input type
+     * @param <O> the output type
+     * @return the registration job
+     */
+    public <I, O> WorkerJob<I, O> registerJob(
+            WorkerPoolConfig<I, O> wpc, ThreadConfig<I, O> threadConfig) {
+        ModelInfo<I, O>.ModelThread t = (ModelInfo<I, O>.ModelThread) threadConfig;
+        Job<I, O> job =
+                new Job<>(
+                        wpc,
+                        null,
+                        in -> {
+                            registerPredictor(t.getPredictor());
+                            return null;
+                        });
+        return new WorkerJob<>(job, new CompletableFuture<>());
+    }
+
+    /**
+     * Creates a {@link WorkerJob} to unregister this adapter from a {@link WorkerThread}.
+     *
+     * @param wpc the worker pool of the thread
+     * @param threadConfig the thread config to unregister
+     * @param <I> the input type
+     * @param <O> the output type
+     * @return the unregistration job
+     */
+    public <I, O> WorkerJob<I, O> unregisterJob(
+            WorkerPoolConfig<I, O> wpc, ThreadConfig<I, O> threadConfig) {
+        ModelInfo<I, O>.ModelThread t = (ModelInfo<I, O>.ModelThread) threadConfig;
+        Job<I, O> job =
+                new Job<>(
+                        wpc,
+                        null,
+                        in -> {
+                            unregisterPredictor(t.getPredictor());
+                            return null;
+                        });
+        return new WorkerJob<>(job, new CompletableFuture<>());
+    }
+
+    protected abstract void registerPredictor(Predictor<?, ?> predictor);
+
+    protected abstract void unregisterPredictor(Predictor<?, ?> predictor);
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -16,7 +16,6 @@ import ai.djl.inference.Predictor;
 import ai.djl.serving.wlm.WorkerPoolConfig.ThreadConfig;
 import ai.djl.serving.wlm.util.WorkerJob;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,17 +24,17 @@ import java.util.concurrent.CompletableFuture;
 public abstract class Adapter {
 
     protected String name;
-    protected URI url;
+    protected String src;
 
     /**
      * Constructs an {@link Adapter}.
      *
      * @param name the adapter name
-     * @param url the adapter url
+     * @param src the adapter source
      */
-    protected Adapter(String name, URI url) {
+    protected Adapter(String name, String src) {
         this.name = name;
-        this.url = url;
+        this.src = src;
     }
 
     /**
@@ -46,10 +45,10 @@ public abstract class Adapter {
      *
      * @param wp the worker pool for the new adapter
      * @param name the adapter name
-     * @param url the adapter url
+     * @param src the adapter source
      * @return the new adapter
      */
-    public static Adapter newInstance(WorkerPool<?, ?> wp, String name, URI url) {
+    public static Adapter newInstance(WorkerPool<?, ?> wp, String name, String src) {
         if (!(wp.getWpc() instanceof ModelInfo)) {
             String modelName = wp.getWpc().getId();
             throw new IllegalArgumentException("The worker " + modelName + " is not a model");
@@ -57,7 +56,7 @@ public abstract class Adapter {
         ModelInfo<?, ?> modelInfo = (ModelInfo<?, ?>) wp.getWpc();
         String engineName = modelInfo.getEngineName();
         if ("Python".equals(engineName)) {
-            return new PyAdapter(name, url);
+            return new PyAdapter(name, src);
         } else {
             throw new IllegalArgumentException(
                     "Adapters are only currently supported for Python models");
@@ -94,12 +93,12 @@ public abstract class Adapter {
     }
 
     /**
-     * Returns the adapter url.
+     * Returns the adapter src.
      *
-     * @return the adapter url
+     * @return the adapter src
      */
-    public URI getUrl() {
-        return url;
+    public String getSrc() {
+        return src;
     }
 
     /**

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -54,8 +54,8 @@ public abstract class Adapter {
             throw new IllegalArgumentException("The worker " + modelName + " is not a model");
         }
         ModelInfo<?, ?> modelInfo = (ModelInfo<?, ?>) wp.getWpc();
-        String engineName = modelInfo.getEngineName();
-        if ("Python".equals(engineName)) {
+        // TODO Replace usage of class name with creating adapters by Engine.newPatch(name ,src)
+        if ("PyEngine".equals(modelInfo.getEngine().getClass().getSimpleName())) {
             return new PyAdapter(name, src);
         } else {
             throw new IllegalArgumentException(
@@ -76,6 +76,7 @@ public abstract class Adapter {
     public static <I, O> void unregister(WorkerPool<I, O> wp, String adapterName) {
         ModelInfo<I, O> wpc = (ModelInfo<I, O>) wp.getWpc();
         Adapter adapter = wpc.unregisterAdapter(adapterName);
+        // TODO Support worker adapter scheduling rather than register/unregister on all workers
         for (WorkerGroup<I, O> wg : wp.getWorkerGroups().values()) {
             for (WorkerThread<I, O> t : wg.getWorkers()) {
                 t.addConfigJob(adapter.unregisterJob(wpc, t.getThreadType()));

--- a/wlm/src/main/java/ai/djl/serving/wlm/Job.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Job.java
@@ -12,12 +12,22 @@
  */
 package ai.djl.serving.wlm;
 
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.translate.TranslateException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /** A class represents an inference job. */
 public class Job<I, O> {
 
     private WorkerPoolConfig<I, O> workerPoolConfig;
     private I input;
+    private O output;
     private long begin;
+    private JobFunction<I, O> runner;
 
     /**
      * Constructs a new {@code Job} instance.
@@ -30,6 +40,51 @@ public class Job<I, O> {
         this.input = input;
 
         begin = System.nanoTime();
+    }
+
+    /**
+     * Constructs a new {@code Job} instance.
+     *
+     * @param wpc the model to run the job
+     * @param input the input data
+     * @param runner the function to run on worker
+     */
+    public Job(WorkerPoolConfig<I, O> wpc, I input, JobFunction<I, O> runner) {
+        this(wpc, input);
+        this.runner = runner;
+    }
+
+    /**
+     * Runs a {@link JobFunction} on a batch of jobs and sets the result in their output.
+     *
+     * @param jobs the jobs to run and update
+     * @param f the function to run
+     * @param <I> the input type
+     * @param <O> the output type
+     * @throws TranslateException if the jobs fail to run
+     */
+    public static <I, O> void runAll(List<Job<I, O>> jobs, JobFunction<I, O> f)
+            throws TranslateException {
+        List<O> out = f.apply(jobs.stream().map(Job::getInput).collect(Collectors.toList()));
+        if (out != null) {
+            for (int i = 0; i < out.size(); i++) {
+                jobs.get(i).setOutput(out.get(i));
+            }
+        }
+    }
+
+    /**
+     * Sets a {@link Job} output to a failure.
+     *
+     * @param job the job to set the output on
+     * @param code the failure code
+     * @param message the failure message
+     */
+    public static void setFailOutput(Job<Input, Output> job, int code, String message) {
+        Output output = new Output();
+        output.setCode(code);
+        output.setMessage(message);
+        job.setOutput(output);
     }
 
     /**
@@ -51,11 +106,38 @@ public class Job<I, O> {
     }
 
     /**
+     * Returns the output data.
+     *
+     * @return the output data
+     */
+    public O getOutput() {
+        return output;
+    }
+
+    /**
+     * Sets the output of the job.
+     *
+     * @param output the job output
+     */
+    public void setOutput(O output) {
+        this.output = output;
+    }
+
+    /**
      * Returns the wait time of this job.
      *
      * @return the wait time of this job in mirco seconds
      */
     public long getWaitingMicroSeconds() {
         return (System.nanoTime() - begin) / 1000;
+    }
+
+    /**
+     * Returns the task to run for the job.
+     *
+     * @return the task to run for the job
+     */
+    public Optional<JobFunction<I, O>> getRunner() {
+        return Optional.ofNullable(runner);
     }
 }

--- a/wlm/src/main/java/ai/djl/serving/wlm/JobFunction.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/JobFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.translate.TranslateException;
+
+import java.util.List;
+
+/**
+ * A function describing the action to take in a {@link Job}.
+ *
+ * @param <I> the job input type
+ * @param <O> the job output type
+ */
+@FunctionalInterface
+public interface JobFunction<I, O> {
+
+    /**
+     * Applies this function.
+     *
+     * @param inputs the batch of inputs to run
+     * @return the batch of results
+     * @throws TranslateException if it fails to run
+     */
+    List<O> apply(List<I> inputs) throws TranslateException;
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -49,6 +49,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -80,6 +81,8 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
     private String translatorFactory;
     private String translator;
 
+    private boolean dynamicAdapters;
+
     transient Path modelDir;
     private transient String artifactName;
     transient Path downloadS3Dir;
@@ -91,6 +94,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
     private transient Class<O> outputClass;
     private transient Criteria<I, O> criteria;
     private transient Map<Device, ZooModel<I, O>> models;
+    private transient Map<String, Adapter> adapters;
 
     /**
      * Constructs a new {@code ModelInfo} instance.
@@ -103,6 +107,8 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         this.modelUrl = modelUrl;
         this.inputClass = (Class<I>) Input.class;
         this.outputClass = (Class<O>) Output.class;
+
+        adapters = new ConcurrentHashMap<>();
     }
 
     /**
@@ -118,6 +124,8 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         this.criteria = criteria;
         inputClass = criteria.getInputClass();
         outputClass = criteria.getOutputClass();
+
+        adapters = new ConcurrentHashMap<>();
     }
 
     /**
@@ -164,6 +172,8 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         this.batchSize = batchSize;
         this.minWorkers = Math.min(minWorkers, maxWorkers);
         this.maxWorkers = maxWorkers;
+
+        adapters = new ConcurrentHashMap<>();
     }
 
     /**
@@ -234,6 +244,9 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
             }
 
             ZooModel<I, O> m = builder.build().loadModel();
+            if (engineName == null) {
+                engineName = m.getNDManager().getEngine().getEngineName();
+            }
             models.put(device, m);
             status = Status.READY;
         } finally {
@@ -270,7 +283,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
 
     /** {@inheritDoc} */
     @Override
-    public ThreadType<I, O> newThread(Device device) {
+    public ThreadConfig<I, O> newThread(Device device) {
         return new ModelThread(device);
     }
 
@@ -412,6 +425,9 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
     /** {@inheritDoc} */
     @Override
     public void initialize() throws IOException, ModelException {
+        if (adapters == null) {
+            adapters = new ConcurrentHashMap<>();
+        }
         downloadModel();
         loadServingProperties();
         downloadS3();
@@ -430,6 +446,62 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                 arguments.put(key, prop.getProperty(key));
             }
         }
+    }
+
+    /**
+     * Adds an adapter to this {@link ModelInfo}.
+     *
+     * @param adapter the adapter to add
+     */
+    public void registerAdapter(Adapter adapter) {
+        synchronized (this) {
+            if (adapters.containsKey(adapter.getName())) {
+                throw new IllegalArgumentException(
+                        "The adapter "
+                                + adapter.getName()
+                                + " already exists. If you want to replace it, please unregistering"
+                                + " before registering a new adapter with the same name.");
+            }
+            adapters.put(adapter.getName(), adapter);
+        }
+    }
+
+    /**
+     * Removes an adapter from this {@link ModelInfo}.
+     *
+     * @param name the adapter to remove
+     * @return the removed adapter
+     */
+    public Adapter unregisterAdapter(String name) {
+        synchronized (this) {
+            // TODO: Remove from current workers
+            if (!adapters.containsKey(name)) {
+                throw new IllegalArgumentException(
+                        "The adapter "
+                                + name
+                                + " was not found and therefore can't be unregistered");
+            }
+            return adapters.remove(name);
+        }
+    }
+
+    /**
+     * Returns the adapters for this model.
+     *
+     * @return the adapters for this model
+     */
+    public Map<String, Adapter> getAdapters() {
+        return adapters;
+    }
+
+    /**
+     * Returns an adapter on this {@link ModelInfo}.
+     *
+     * @param name the adapter name to get
+     * @return the adapter
+     */
+    public Adapter getAdapter(String name) {
+        return adapters.get(name);
     }
 
     /** {@inheritDoc} */
@@ -872,7 +944,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         return Integer.parseInt(value);
     }
 
-    protected class ModelThread extends ThreadType<I, O> {
+    protected class ModelThread extends ThreadConfig<I, O> {
 
         private Predictor<I, O> predictor;
         ZooModel<I, O> model;
@@ -891,12 +963,53 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                 metrics.setOnLimit((m, s) -> MODEL_METRIC.info("{}-{}", id, m.percentile(s, 50)));
                 predictor.setMetrics(metrics);
             }
+
+            synchronized (this) {
+                for (Map.Entry<String, Adapter> adapter : adapters.entrySet()) {
+                    configJobs.add(adapter.getValue().registerJob(ModelInfo.this, this).getJob());
+                    configJobs.add(
+                            new Job<>(
+                                    ModelInfo.this,
+                                    null,
+                                    in -> {
+                                        adapter.getValue().registerPredictor(predictor);
+                                        return null;
+                                    }));
+                }
+            }
         }
 
-        /** {@inheritDoc} */
         @Override
-        public List<O> run(List<I> input) throws TranslateException {
-            return predictor.batchPredict(input);
+        @SuppressWarnings("unchecked")
+        public void run(List<Job<I, O>> jobs) throws TranslateException {
+            List<Job<I, O>> validJobs = new ArrayList<>(jobs.size());
+            for (Job<I, O> job : jobs) {
+                if (job.getInput() instanceof Input) {
+                    Input i = (Input) job.getInput();
+                    if (i.getContent().contains("adapter")) {
+                        String adapter = i.getAsString("adapter");
+                        if (!dynamicAdapters && !adapters.containsKey(adapter)) {
+                            String failMessage =
+                                    "The adapter " + adapter + " has not been registered";
+                            Job.setFailOutput((Job<Input, Output>) job, 503, failMessage);
+                            continue;
+                        }
+                    }
+                }
+                validJobs.add(job);
+            }
+            if (!validJobs.isEmpty()) {
+                Job.runAll(validJobs, js -> predictor.batchPredict(js));
+            }
+        }
+
+        /**
+         * Returns the predictor.
+         *
+         * @return the predictor
+         */
+        public Predictor<I, O> getPredictor() {
+            return predictor;
         }
 
         /** {@inheritDoc} */

--- a/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
@@ -17,8 +17,6 @@ import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.translate.TranslateException;
 
-import java.net.URI;
-
 /** An overload of {@link Adapter} for the python engine. */
 public class PyAdapter extends Adapter {
 
@@ -26,10 +24,10 @@ public class PyAdapter extends Adapter {
      * Constructs an {@link Adapter}.
      *
      * @param name the adapter name
-     * @param url the adapter url
+     * @param src the adapter src
      */
-    protected PyAdapter(String name, URI url) {
-        super(name, url);
+    protected PyAdapter(String name, String src) {
+        super(name, src);
     }
 
     @SuppressWarnings("unchecked")
@@ -39,7 +37,7 @@ public class PyAdapter extends Adapter {
         Input input = new Input();
         input.addProperty("handler", "register_adapter");
         input.addProperty("name", name);
-        input.addProperty("url", url.toString());
+        input.addProperty("src", src);
         try {
             p.predict(input);
         } catch (TranslateException e) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.inference.Predictor;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.translate.TranslateException;
+
+import java.net.URI;
+
+/** An overload of {@link Adapter} for the python engine. */
+public class PyAdapter extends Adapter {
+
+    /**
+     * Constructs an {@link Adapter}.
+     *
+     * @param name the adapter name
+     * @param url the adapter url
+     */
+    protected PyAdapter(String name, URI url) {
+        super(name, url);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void registerPredictor(Predictor<?, ?> predictor) {
+        Predictor<Input, Output> p = (Predictor<Input, Output>) predictor;
+        Input input = new Input();
+        input.addProperty("handler", "register_adapter");
+        input.addProperty("name", name);
+        input.addProperty("url", url.toString());
+        try {
+            p.predict(input);
+        } catch (TranslateException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void unregisterPredictor(Predictor<?, ?> predictor) {
+        Predictor<Input, Output> p = (Predictor<Input, Output>) predictor;
+        Input input = new Input();
+        input.addProperty("handler", "unregister_adapter");
+        input.addProperty("name", name);
+        try {
+            p.predict(input);
+        } catch (TranslateException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -155,6 +156,24 @@ public class WorkLoadManager {
 
     /**
      * Returns the {@link WorkerPool} for a wpc.
+     *
+     * @param <I> the wpc class
+     * @param <O> the wpc class
+     * @param id the wpc id
+     * @return the {@link WorkerPool}
+     */
+    @SuppressWarnings("unchecked")
+    public <I, O> WorkerPool<I, O> getWorkerPoolById(String id) {
+        for (Entry<WorkerPoolConfig<?, ?>, WorkerPool<?, ?>> wp : workerPools.entrySet()) {
+            if (id.equals(wp.getKey().getId())) {
+                return (WorkerPool<I, O>) wp.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the {@link WorkerPool} for a model.
      *
      * @param <I> the wpc input class
      * @param <O> the wpc output class

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkerPool.java
@@ -251,8 +251,11 @@ public class WorkerPool<I, O> {
         if (activeThreads < minWorkers) {
             // scale up the fixed pool
             logger.info(
-                    "scale up {} workers ({} - {})",
+                    "scaling up min workers by {} (from {} to {}) workers. Total range is min {} to"
+                            + " max {}",
                     minWorkers - activeThreads,
+                    activeThreads,
+                    minWorkers,
                     minWorkers,
                     group.getMaxWorkers());
             group.addThreads(minWorkers - activeThreads, true);


### PR DESCRIPTION
This PR serves to add adapter support. It is supported with two different customer experiences which can be seen in the ModelServerTest file. The first is through the new adapter management API and adding an adapter query parameter to prediction calls. The second is by creating a workflow with the AdapterWorkflowFunction.

Both are testing using the adaptecho model. It is a simple python echo model that prepends the adapter contents. It can be used as a simple example of how the adapter should function for a model handler. Note the usage of additional functions register_adapter and unregister_adapter alongside the main handler.

Then, there is a new Adapter abstract class. It only has a PyAdapter implementation for now. In the future, this should depend on the Patch from DJL and will require an addition Engine.loadAdapter(name, url) function to create the engine specific patches. This is left as a future improvement. For now, it has functionality to both register and unregister the adapter through the predictor. It also has helpers to integrate the registration and unregistration flows alongside both the API and workflow approach.

After that, those Adapters are stored in the ModelInfo. It adds a new concept of configJobs that are run on worker threads. The ModelInfo will create config jobs to register all adapters on thread creation and to register new adapters on existing workers.

To support the API approach, the main changes are through the new AdapterManagementRequestHandler. They are all testing in the ModelServerTest.

To support the workflow approach, it begins by making both workflows and workflow functions contain both a prepare and close function. Preparing the AdapterWorkflowFunction will register it and closing it will unregister it. The test features two workflows with a shared model (adaptecho) that are loaded together.

Another miscellaneous improvement to mention is the change to Job. Job has two new arguments. The first is a Job runner that determines what will run. It can either take the default behavior of executing the predictor through the ThreadConfig or contain custom behavior (register and unregister). The second change is that Output is stored in the job rather than returned directly. This helps deal with some job runners that may be successful for part of the batch but fail with other parts. It also cleans up the logic with respect to grouping bu job runner. The JobFunction is also a new functional interface to handle exceptions.
