### PR TITLE
[INF2] don't install linux headers

### DIFF
--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -14,7 +14,7 @@ echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc
 curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 
 # https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#inf2-packages
-apt-get update -y && apt-get install -y linux-headers-$(uname -r) && apt-get install -y aws-neuronx-dkms=2.12.* \
+apt-get update -y && apt-get install -y aws-neuronx-dkms=2.12.* \
     aws-neuronx-collectives=2.16.* \
     aws-neuronx-runtime-lib=2.16.* \
     aws-neuronx-tools=2.13.*


### PR DESCRIPTION
## Description ##

Remove linux headers installation. The cross system header mismatch cause building bugs
