### PR TITLE
Removes quick abort of python reader threads

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -257,7 +257,7 @@ class PyProcess {
         @SuppressWarnings("PMD.UseTryWithResources")
         public void run() {
             try (Scanner scanner = new Scanner(is, StandardCharsets.UTF_8)) {
-                while (isRunning.get() && scanner.hasNext()) {
+                while (scanner.hasNext()) {
                     String result = scanner.nextLine();
                     if (result == null) {
                         logger.warn("Got EOF: {}", getName());


### PR DESCRIPTION
This is a PR for a bit of discussion. To give context, every time the Python engine spins up a PyProcess it also spins up two reader threads (stdout and stderr) that will read the output of the process and echo it back to the main stdout.

Before, we would shortcut the end of the reader threads by indicating that the ReaderThread should shut down and it cutting off checking for future or current output. The result of this is that the Python process output may be cut off. This is an especially concerning problem if the python process crashes and it cuts off the python error and stack trace. Running with and without this change can already show, even in just the gradle tests, several instances of messages being cut off. More customers may also be having issues understanding their Python errors due to this.

After this, it will wait for the ReaderThreads to read all input and stop on their own. In the integration tests, it seems to work fine and all readerthreads stop without issues. The concern is whether this change may make it so that ReaderThreads are not closed as promptly or whether there exists cases that they may not close at all. @frankfliu, it would be nice if you could weigh in. I am not sure if there was a specific reason it was added.

As a hybrid approach, we could also add some mechanism to ensure ReaderThreads are killed. Maybe a 30 second delay? If there isn't an issue with ReaderThreads not stopping though, we should avoid creating a then unnecessary mechanism (and add a followup PR that can do some code cleanup)