### PR TITLE
[RollingBatch] add active requests and pending requests for skip tokens

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -120,8 +120,9 @@ class LmiDistRollingBatch(RollingBatch):
         new_requests = self.get_new_requests(input_data, parameters,
                                              batch_size)
         new_batch = self.preprocess_requests(new_requests)
-        self._prefill_and_decode(new_batch)
-        return self.postprocess_results(batch_size)
+        if new_batch or self.cache:
+            self._prefill_and_decode(new_batch)
+        return self.postprocess_results()
 
     def _prefill_and_decode(self, new_batch):
         # prefill step
@@ -154,7 +155,7 @@ class LmiDistRollingBatch(RollingBatch):
         }
 
         req_ids = []
-        for request in self.pending_requests:
+        for request in self.active_requests:
             generation = generation_dict[request.id]
             is_last_token = generation.generated_text is not None
             if not is_last_token:

--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -45,7 +45,7 @@ class NeuronRollingBatch(RollingBatch):
             for generation in generations
         }
         req_ids = []
-        for request in self.pending_requests:
+        for request in self.active_requests:
             generation = generation_dict.get(request.id, None)
             if generation:
                 is_last_token = generation.generated_text is not None
@@ -64,7 +64,7 @@ class NeuronRollingBatch(RollingBatch):
 
         # filter the requests that are stopped.
         self.scheduler.filter(req_ids)
-        return self.postprocess_results(batch_size)
+        return self.postprocess_results()
 
     def preprocess_requests(self, requests):
         raise NotImplementedError("Not implemented for Neuron rolling batcher")

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -87,7 +87,7 @@ class VLLMRollingBatch(RollingBatch):
         # step 2: send result back
         finished_id = []
         for (key, cache), request in zip(self.request_cache.items(),
-                                         self.pending_requests):
+                                         self.active_requests):
             request.set_next_token(cache["text"][cache["curr_length"]:],
                                    self.output_formatter, cache["finished"])
             cache["curr_length"] = len(cache["text"])
@@ -97,7 +97,7 @@ class VLLMRollingBatch(RollingBatch):
         for key in finished_id:
             self.request_cache.pop(key)
 
-        return self.postprocess_results(batch_size)
+        return self.postprocess_results()
 
     def preprocess_requests(self, requests):
         raise NotImplementedError("Not implemented for vLLM rolling batcher")


### PR DESCRIPTION
## Description ##

This PR introduced a new concept called `active_requests`. It means the active serving requests with scheduler. In the meantime, the old `pending_requests` will be used to preseve requests that before the skip tokens. The pseudo process looks like below:

```
Step 1: requests enter into pending requests.

If waiting tokens not meeting:
    return [] and just run step
if waiting tokens met:
   merge all requests
   return all pending requests
```

### Test

All 3 GPU engines passed

```
python run.py TheBloke/Llama-2-13B-Chat-fp16 -rb scheduler
```

```
python run.py TheBloke/Llama-2-13B-Chat-fp16 -rb vllm
```

```
torchrun --standalone --nnodes=1 --nproc-per-node=4  run.py TheBloke/Llama-2-13B-Chat-fp16 -rb lmi-dist
```

Inferentia testing

```
        properties = {
            "tensor_parallel_degree": 2,
            "trust_remote_code": "true",
            # "waiting_tokens": 1,
            "batch_size": 4,
            "dtype":"fp16",
            "n_positions": 512,
            "engine": "Python"
        }
    if args.rollingbatch == "lmi-dist":
        dist.init_process_group("nccl")
        properties["engine"] = "MPI"
    batcher = init_rolling_batch(args.rollingbatch, args.model_id, properties)
    simulator(batcher, "The president of United States is", {
        "max_new_tokens": 256,
        "do_sample": True
    }, [1, 1, 1, 1], 1)
```

```
python3 run.py facebook/opt-1.3b -rb neuron
```