### PR TITLE
[python] Make rolling batch output not escape unicode characters

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -23,7 +23,7 @@ def _json_output_formatter(token_texts: list, first_token: bool,
     :return: formatted output
     """
     json_encoded_str = f"{{\"generated_text\": \"" if first_token else ""
-    text = json.dumps(''.join(token_texts))
+    text = json.dumps(''.join(token_texts), ensure_ascii=False)
     json_encoded_str = f"{json_encoded_str}{text[1:-1]}"
     if last_token:
         json_encoded_str = f"{json_encoded_str}\"}}"
@@ -39,7 +39,7 @@ def _jsonlines_output_formatter(token_texts: list, first_token: bool,
     :return: formatted output
     """
     token_texts = {"outputs": token_texts}
-    json_encoded_str = json.dumps(token_texts) + "\n"
+    json_encoded_str = json.dumps(token_texts, ensure_ascii=False) + "\n"
     return json_encoded_str
 
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Make rolling batch output not escape unicode characters. This will make output not have unicode characters escaped like: `\u201c`, `\u0080`, `\u0099`