### PR TITLE
Clarify error message with unsupported quantization algorithm, since …

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -63,7 +63,7 @@ class LmiDistRollingBatch(RollingBatch):
                 f"Can't set both dtype: {dtype} and quantize: {quantize}")
         if quantize is not None and quantize not in QUANTIZATION_SUPPORT_ALGO:
             raise ValueError(
-                f"Invalid value for quantize: {quantize}. Valid values are: {QUANTIZATION_SUPPORT_ALGO}"
+                f"Invalid value for quantize: {quantize}. Valid values when using option rolling_batch=lmi-dist are: {QUANTIZATION_SUPPORT_ALGO}"
             )
         if quantize is None and dtype == "int8":
             quantize = "bitsandbytes"


### PR DESCRIPTION
…DeepSpeed and lmi-dist have different quantization algorithms supported

## Description ##


Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
