### PR TITLE
When doing smoothquant calibration, pass tokenizer through in deepspe…

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -398,16 +398,24 @@ class DeepSpeedService(object):
         else:
             self.ds_config["dtype"] = model.dtype
         self.ds_config['replace_state_dict'] = state_dict_mmap
-        self.model = deepspeed.init_inference(model, self.ds_config)
 
-        if self.enable_streaming:
-            return
         # Optimization for text-generation batch processing
         if self.task == "text-generation":
             self.tokenizer.padding_side = "left"
             if not self.tokenizer.pad_token:
                 self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        # If doing smoothquant calibration, set tokenizer
+        smoothing_config = self.ds_config.get("smoothing", {})
+        if smoothing_config.get("calibrate", False):
+            smoothing_config["tokenizer"] = self.tokenizer
+
+        self.model = deepspeed.init_inference(model, self.ds_config)
+
+        # Don't create a "pipeline" if we're streaming or text-generation task, since those don't use a pipeline
+        if self.enable_streaming or self.task == "text-generation":
             return
+
         self.pipeline = pipeline(task=self.task,
                                  model=self.model.module,
                                  tokenizer=self.tokenizer,


### PR DESCRIPTION
…ed config

## Description ##
The tokenizer is needed for SmoothQuant calibration.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
