### PR TITLE
[fix] add fast loading to partition test

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -310,6 +310,8 @@ class DeepSpeedService(object):
 
     def get_model(self, model_id_or_path, loading_method, **kwargs):
         if loading_method == 'from_config':
+            if 'low_cpu_mem_usage' in kwargs:
+                kwargs.pop('low_cpu_mem_usage')
             return self.get_model_from_config(model_id_or_path, **kwargs)
         elif loading_method == 'pretrained':
             return self.get_model_pretrained(model_id_or_path, **kwargs)

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -62,6 +62,7 @@ if $is_partition; then
     ${model_path:+-v ${model_path}/test:/opt/ml/input/data/training} \
     -v ${PWD}/logs:/opt/djl/logs \
     -v ~/.aws:/root/.aws \
+    -v ~/sagemaker_infra/:/opt/ml/.sagemaker_infra/:ro \
     ${env_file} \
     -e TEST_TELEMETRY_COLLECTION='true' \
     ${runtime:+--runtime="${runtime}"} \


### PR DESCRIPTION
Add fast loading for partition testing.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
