### PR TITLE
Faster in-memory weight transfer for transformers-neuronx

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -141,7 +141,7 @@ class TransformersNeuronXService(object):
                 n_positions=self.n_positions,
                 unroll=self.unroll)
         model.load_state_dict_low_memory(self.model.state_dict())
-        return model.load_state_dict_low_memory(self.model.state_dict())
+        return model
 
     def load_model(self, model_type):
         self.model = self.load_hf_model()

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -81,11 +81,6 @@ class TransformersNeuronXService(object):
         self.download_dir = os.path.join(path, folder)
         return self.download_dir
 
-    def convert_model(self, load_path):
-        self.model = self.load_hf_model()
-        logging.info(f"Saving INF2 model to {load_path} ...")
-        save_pretrained_split(self.model, load_path)
-
     def get_load_path(self, model_type):
         if self.download_dir:
             load_path = self.download_dir
@@ -101,7 +96,9 @@ class TransformersNeuronXService(object):
             revision=self.revision,
             low_cpu_mem_usage=True)
 
-    def load_inf2_model(self, model_type, load_path):
+    def load_inf2_model_from_disk(self, model_type, load_path):
+        logging.info(f"Saving INF2 model to {load_path} ...")
+        save_pretrained_split(self.model, load_path)
         if self.load_in_8bit:
             neuron_config = NeuronConfig()
             neuron_config.quant = QuantizationConfig(quant_dtype='s8',
@@ -122,10 +119,39 @@ class TransformersNeuronXService(object):
             n_positions=self.n_positions,
             unroll=self.unroll)
 
+    def load_inf2_model_from_memory(self, model_type):
+        if self.load_in_8bit:
+            neuron_config = NeuronConfig()
+            neuron_config.quant = QuantizationConfig(quant_dtype='s8',
+                                                     dequant_dtype=self.amp)
+            model = MODEL_TYPE_TO_MODEL[model_type](
+                self.model.config,
+                batch_size=self.batch_size,
+                amp=self.amp,
+                tp_degree=self.tensor_parallel_degree,
+                n_positions=self.n_positions,
+                neuron_config=neuron_config,
+                unroll=self.unroll)
+        else:
+            model = MODEL_TYPE_TO_MODEL[model_type](
+                self.model.config,
+                batch_size=self.batch_size,
+                amp=self.amp,
+                tp_degree=self.tensor_parallel_degree,
+                n_positions=self.n_positions,
+                unroll=self.unroll)
+        model.load_state_dict_low_memory(self.model.state_dict())
+        return model.load_state_dict_low_memory(self.model.state_dict())
+
     def load_model(self, model_type):
+        self.model = self.load_hf_model()
         load_path = self.get_load_path(model_type)
-        self.convert_model(load_path)
-        self.model = self.load_inf2_model(model_type, load_path)
+        try:
+            logging.info("Trying to transfer weights in-memory")
+            self.model = self.load_inf2_model_from_memory(model_type)
+        except Exception as exc:
+            logging.info(f"Falling back to disk transfer due to {str(exc)}")
+            self.model = self.load_inf2_model_from_disk(model_type, load_path)
         logging.info(f"LLM sharding and compiling Started ...")
         start = time.time()
         # TODO: workaround on Neuron Compiler bug for SM


### PR DESCRIPTION
## Overview ##

This PR improves the latency of transferring model weights from the HF representation to the INF2 representation by doing it in-memory as opposed to using the disk as a buffer.  For OPT-66B on inf2.48xl, this improves the latency of weight transfer from 840s to 5s. 

## Description ## 

Splitting the model into small pieces on the disk and then loading it, reduces CPU memory requirements. However, this operation demands high IOPS from the disk. Typical EBS volumes used by EC2 (gp3) and SageMaker (gp2) do not provide high IOPS by default. This leads to EBS throttling, which manifests as a massive latency to transfer model weights (upto 1400 secs).

However, Large Language Models are typically used with large instances with large CPU memory. As a result, for instances like inf2.24xl, inf2.48xl, trn1.32xl, loading from disk is wasteful in terms of instance hours. Direct in-memory transfer is much faster (<5s) in these cases.

This PR modifies the load_model code path to first try in-memory loading and then fall back to disk loading in the event of an overflow.

## Testing ##
Tested in EC2 on inf2.48xl and inf2.24xl with OPT-66B and OPT-13B