### PR TITLE
[fix] update tp for dynamic llama2 test back to 4

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -499,7 +499,7 @@ ds_smoothquant_model_list = {
     },
     "llama2-13b-dynamic-int8": {
         "option.model_id": "TheBloke/Llama-2-13B-fp16",
-        "option.tensor_parallel_degree": 2,
+        "option.tensor_parallel_degree": 4,
         "option.quantize": "dynamic_int8",
     },
     "llama2-13b-smoothquant": {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fixing CI failure due to a tensor parallel degree change on the llama2 dq test

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
