### PR TITLE
[feat] fail continuous test if python is not formatted in CI

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       # Enable gradle cache: https://github.com/actions/cache/blob/master/examples.md#java---gradle
       - uses: actions/cache@v3
         with:
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install DJLServing dependencies
         shell: bash
         run: |

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -17,6 +17,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            format: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
@@ -27,9 +30,9 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: install Python Dependencies
-        run: pip3 install numpy
+        run: pip3 install numpy yapf
       # Enable gradle cache: https://github.com/actions/cache/blob/master/examples.md#java---gradle
       - uses: actions/cache@v3
         with:
@@ -37,6 +40,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Test repo formatting
+        if: ${{ matrix.format }}
+        run: ./gradlew verifyPython
       - name: Build with Gradle
         run: ./gradlew --refresh-dependencies build :jacoco:testCodeCoverageReport
       - name: Upload test results

--- a/build.gradle
+++ b/build.gradle
@@ -121,12 +121,3 @@ configure(javaProjects()) {
         }
     }
 }
-
-apply from: file("${rootProject.projectDir}/tools/gradle/publish.gradle")
-tasks.register('formatPython') {
-    doFirst {
-        exec {
-            commandLine "bash", "-c", "find . -name '*.py' -not -path '*/.gradle/*' -not -path '*/build/*' -print0 | xargs -0 yapf --in-place"
-        }
-    }
-}

--- a/engines/python/build.gradle
+++ b/engines/python/build.gradle
@@ -33,11 +33,13 @@ sourceSets {
     main.resources.srcDirs "setup"
 }
 
+apply from: file("${rootProject.projectDir}/tools/gradle/python-formatter.gradle")
+
 processResources {
     doFirst {
 	    stripPackageVersion()
     	def versionLine = new StringBuilder()
-    	versionLine.append("__version__ = '${djl_version}'")
+    	versionLine.append("\n__version__ = '${djl_version}'\n")
     	file("setup/djl_python/__init__.py").append(versionLine)
     }
 

--- a/engines/python/setup/setup.py
+++ b/engines/python/setup/setup.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     test_requirements = [
         'numpy', 'requests', 'Pillow', 'transformers', 'torch', 'einops',
-        'accelerate', 'sentencepiece', 'protobuf'
+        'accelerate', 'sentencepiece', 'protobuf', 'yapf'
     ]
 
     setup(name='djl_python',

--- a/tools/gradle/python-formatter.gradle
+++ b/tools/gradle/python-formatter.gradle
@@ -1,0 +1,34 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+}
+
+apply plugin: PythonFormatterPlugin
+
+class PythonFormatterPlugin implements Plugin<Project> {
+    void apply(Project project) {
+        project.task('formatPython') {
+            doLast {
+                 project.exec {
+                    commandLine "bash", "-c", "find . -name '*.py' -not -path '*/.gradle/*' -not -path '*/build/*' -print0 | xargs -0 yapf --in-place"
+                }
+            }
+        }
+
+        project.task('verifyPython') {
+            doFirst {
+                try {
+                    project.exec {
+                        commandLine "bash", "-c", "find . -name '*.py' -not -path '*/.gradle/*' -not -path '*/build/*' -print0 | xargs -0 yapf -d"
+                    }
+                } catch (Exception e) {
+                    throw new GradleException("Repo is improperly formatted, please run ./gradlew formatPython, and recommit", e)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

PR looks to add a test in the continuous workflow, so that when the build test is done on the ubuntu image we will also test to see if running ./gradlew formatPython changes any files. If it does then we fail with an error informing the PR author to run the command and recommit to pass the pipeline.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
