### PR TITLE
[python] Remove generation_dict in lmi_dist_rolling_batch

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -143,14 +143,9 @@ class LmiDistRollingBatch(RollingBatch):
             if next_batch is not None:
                 self.cache[next_batch.batch_id] = next_batch
 
-        generation_dict = {
-            generation.request_id: generation
-            for generation in generations
-        }
-
         req_ids = []
         for request in self.active_requests:
-            generation = generation_dict.get(request.id, None)
+            generation = generations.get(request.id, None)
             if generation:
                 is_last_token = generation.generated_text is not None
                 if not is_last_token:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
