### PR TITLE
Cleans tensorParallelDegree with MultiDevice

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -13,6 +13,7 @@
 package ai.djl.python.engine;
 
 import ai.djl.Device;
+import ai.djl.Device.MultiDevice;
 import ai.djl.Model;
 import ai.djl.engine.EngineException;
 import ai.djl.inference.streaming.ChunkedBytesSupplier;
@@ -123,7 +124,11 @@ class Connection {
     static String[] getPythonStartCmd(PyEnv pyEnv, Model model, int workerId, int port) {
         Device device = model.getNDManager().getDevice();
         int deviceId = device.getDeviceId();
-        int tensorParallelDegree = pyEnv.getTensorParallelDegree();
+        int tensorParallelDegree = 0;
+        if (model.getNDManager().getDevice() instanceof MultiDevice) {
+            tensorParallelDegree =
+                    ((MultiDevice) model.getNDManager().getDevice()).getDevices().size();
+        }
         if (pyEnv.isMpiMode()) {
             String cudaDevices = getVisibleDevices(workerId, tensorParallelDegree);
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);

--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.python.engine;
 
+import ai.djl.Device;
+import ai.djl.Device.MultiDevice;
 import ai.djl.Model;
 import ai.djl.engine.EngineException;
 import ai.djl.metric.Metric;
@@ -59,12 +61,12 @@ class PyProcess {
         this.workerId = workerId;
         int port = counter.getAndIncrement();
         if (pyEnv.isMpiMode()) {
-            int tensorParallelDegree = pyEnv.getTensorParallelDegree();
-            connections = new ArrayList<>(tensorParallelDegree);
-            for (int i = 0; i < tensorParallelDegree; ++i) {
+            List<Device> devices = ((MultiDevice) model.getNDManager().getDevice()).getDevices();
+            connections = new ArrayList<>(devices.size());
+            for (int i = 0; i < devices.size(); ++i) {
                 connections.add(new Connection(pyEnv, port, i));
             }
-            counter.set(port + tensorParallelDegree);
+            counter.set(port + devices.size());
         } else {
             connections = Collections.singletonList(new Connection(pyEnv, port, -1));
         }


### PR DESCRIPTION
This is a refactor to simplify the handling of tensor parallel degree. Before, it is read independently in 3+ locations in code and the behavior determining the tpDegree is hard to follow. This moves the reading to a single place and then represents it using a MultiDevice. This also means that the behavior can be entirely visible - a worker group will show up with the tp devices that it's worker will be using.
