### PR TITLE
Fixes changes to hf parse_input signature

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -156,6 +156,7 @@ class HuggingFaceService(object):
         self.peft_config = None
         self.stopping_criteria_list = None
         self.disable_flash_attn = None
+        self.adapters = None
 
     def initialize(self, properties: dict):
         # model_id can point to huggingface model_id or local directory.
@@ -345,13 +346,17 @@ class HuggingFaceService(object):
                 logging.exception(f"Parse input failed: {i}")
                 errors[i] = str(e)
 
-        return input_data, input_size, adapters, parameters, errors, batch
+        self.adapters = adapters
+        return input_data, input_size, parameters, errors, batch
 
     def inference(self, inputs):
         outputs = Output()
 
-        input_data, input_size, adapters, parameters, errors, batch = self.parse_input(
+        input_data, input_size, parameters, errors, batch = self.parse_input(
             inputs)
+        adapters = self.adapters
+        if not adapters:
+            adapters = [""] * len(input_data)
         if len(input_data) == 0:
             for i in range(len(batch)):
                 err = errors.get(i)


### PR DESCRIPTION
This removes the changes to the parse_input signature for adapters for users who override it.

The fix is a bit of a hack using the obj to pass it instead of the return value. However, moving the adapter parsing logic outside of the main parse_input would require redoing much of the decoding work and would therefore increase the parsing costs.

@frankfliu
