### PR TITLE
[fix] use fast sample as default sample method for inf2

### DIFF
--- a/.github/workflows/pyunit.yml
+++ b/.github/workflows/pyunit.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: install Python Dependencies
         run: |
           cd engines/python/setup

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -49,6 +49,29 @@ MODEL_TYPE_TO_MODEL = {
 }
 
 
+class NeuronXSampleAdapter(HuggingFaceGenerationModelAdapter):
+
+    def __init__(self, _config, _model):
+        super().__init__(_config, _model)
+        self.model_type = _config.model_type
+        self.sample_options = ["start_ids", "top_k"]
+        if self.model_type == "llama":
+            self.sample_options = self.sample_options + [
+                "top_p", "eos_token_override", "temperature", "streamer"
+            ]
+
+    def neuron_sample(self, *args, **kwargs):
+        sample_kwargs = self.simple_sample_parser(**kwargs)
+        return self.model.sample(*args, **sample_kwargs)
+
+    def simple_sample_parser(self, **kwargs):
+        parsed_kwargs = dict()
+        for key in self.sample_options:
+            if key in kwargs:
+                parsed_kwargs[key] = kwargs[key]
+        return parsed_kwargs
+
+
 class TransformersNeuronXService(object):
 
     def __init__(self) -> None:
@@ -229,9 +252,8 @@ class TransformersNeuronXService(object):
 
         self.load_model(model_config.model_type)
 
-        # HuggingFace compatible generate model
-        self.model = HuggingFaceGenerationModelAdapter(model_config,
-                                                       self.model)
+        # HuggingFace compatible generate model and Neuron custom sample method
+        self.model = NeuronXSampleAdapter(model_config, self.model)
         self.initialized = True
         if "rolling_batch" in properties:
             self.rolling_batch = NeuronRollingBatch(self.model, self.tokenizer,
@@ -334,15 +356,13 @@ class TransformersNeuronXService(object):
         encoded_inputs = self.tokenizer.batch_encode_plus(input_data,
                                                           return_tensors="pt",
                                                           padding=True)
-        use_sample = parameters.pop("use_sample", None)
-        if use_sample:
-            # TODO: Watch transformer-neuronx release for fix on gpt-neox generate functionality
-            output_tokens = self.model.sample(
-                encoded_inputs.input_ids,
-                sequence_length=self.n_positions,
-                pad_token_id=self.tokenizer.pad_token_id,
-                eos_token_id=self.tokenizer.eos_token_id,
-                **parameters)
+        fast_sample = (parameters.pop("use_sample", True)
+                       and parameters.pop("fast_sample", True))
+        if fast_sample:
+            sample_length = parameters.pop("max_new_tokens", self.n_positions)
+            output_tokens = self.model.neuron_sample(encoded_inputs.input_ids,
+                                                     sample_length,
+                                                     **parameters)
         else:
             output_tokens = self.model.generate(
                 input_ids=encoded_inputs.input_ids,

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -356,9 +356,8 @@ class TransformersNeuronXService(object):
         encoded_inputs = self.tokenizer.batch_encode_plus(input_data,
                                                           return_tensors="pt",
                                                           padding=True)
-        fast_sample = (parameters.pop("use_sample", True)
-                       and parameters.pop("fast_sample", True))
-        if fast_sample:
+        use_sample = parameters.pop("use_sample", True)
+        if use_sample:
             sample_length = parameters.pop("max_new_tokens", self.n_positions)
             output_tokens = self.model.neuron_sample(encoded_inputs.input_ids,
                                                      sample_length,


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Updating the default sample strategy to use the neuron models implementation for improved performance. Additionally, adding the alias "fast_sample" to the "use_sample" parameter as use_sample is unclear as it really means "use neuronx model's sample implementation".

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
