### PR TITLE
[neuronx] bump to 2.15 for tnx container and scripts

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -13,10 +13,10 @@ FROM ubuntu:20.04
 ARG djl_version=0.24.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG python_version=3.8
-ARG torch_neuronx_version=1.13.1.1.11.0
-ARG transformers_neuronx_version=0.7.84
-ARG neuronx_distributed_version=0.4.0
-ARG neuronx_cc_version=2.10.*
+ARG torch_neuronx_version=1.13.1.1.12.0
+ARG transformers_neuronx_version=0.8.268
+ARG neuronx_distributed_version=0.5.0
+ARG neuronx_cc_version=2.11.*
 ARG protobuf_version=3.20.3
 ARG transformers_version=4.34.0
 ARG accelerate_version=0.23.0

--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -14,9 +14,9 @@ echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc
 curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 
 # https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#inf2-packages
-apt-get update -y && apt-get install -y aws-neuronx-dkms=2.13.* \
-    aws-neuronx-collectives=2.17.* \
-    aws-neuronx-runtime-lib=2.17.* \
-    aws-neuronx-tools=2.14.*
+apt-get update -y && apt-get install -y aws-neuronx-dkms=2.14.* \
+    aws-neuronx-collectives=2.18.* \
+    aws-neuronx-runtime-lib=2.18.* \
+    aws-neuronx-tools=2.15.*
 
 export PATH=/opt/aws/neuron/bin:$PATH


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Update the tnx container to 2.15 sdk

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
