### PR TITLE
[fix] gpt2 neuron support handler and ci

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -180,12 +180,7 @@ class TransformersNeuronXService(object):
         # TODO: workaround on Neuron Compiler bug for SM
         path = os.getcwd()
         os.chdir("/tmp")
-        if model_type == "gpt2":
-            self.model._load_compiled_artifacts(load_path)
-            self.model.to_neuron()
-            self.model._save_compiled_artifacts(load_path)
-        else:
-            self.model.to_neuron()
+        self.model.to_neuron()
         os.chdir(path)
         elapsed = time.time() - start
         logging.info(


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Remove compiled_artifacts methods for gpt2, they are broken by the 2.15 neff changes

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
