### PR TITLE
Supports docker build with local .deb

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -29,6 +29,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 11
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+      - name: Build serving package for nightly
+        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        run: |
+          ./gradlew :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
         if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
         working-directory: serving/docker
@@ -94,6 +107,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 11
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+      - name: Build serving package for nightly
+        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        run: |
+          ./gradlew :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
         if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
         working-directory: serving/docker
@@ -127,6 +153,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 11
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+      - name: Build serving package for nightly
+        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        run: |
+          ./gradlew :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
         if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
         working-directory: serving/docker

--- a/serving/.gitignore
+++ b/serving/.gitignore
@@ -1,2 +1,3 @@
 /plugins
 /logs
+docker/distributions

--- a/serving/build.gradle
+++ b/serving/build.gradle
@@ -68,6 +68,7 @@ run {
 clean {
     delete file("plugins")
     delete file("logs")
+    delete file("docker/distributions")
 }
 
 tasks.register('prepareDeb') {
@@ -96,6 +97,13 @@ tasks.register('createDeb', Deb) {
         into "/usr/local/djl-serving-${project.version}"
     }
     link("/usr/bin/djl-serving", "/usr/local/djl-serving-${project.version}/bin/serving")
+}
+
+tasks.register('dockerDeb', Copy) {
+    dependsOn createDeb
+    from layout.buildDirectory.dir("distributions")
+    include "*.deb"
+    into("${project.projectDir}/docker/distributions")
 }
 
 startScripts {

--- a/serving/docker/Dockerfile
+++ b/serving/docker/Dockerfile
@@ -16,6 +16,10 @@ COPY scripts scripts/
 RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/ml/model
 COPY config.properties /opt/djl/conf/
+
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 RUN scripts/install_djl_serving.sh $djl_version && \
     scripts/install_s5cmd.sh x64 && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \

--- a/serving/docker/aarch64.Dockerfile
+++ b/serving/docker/aarch64.Dockerfile
@@ -33,6 +33,9 @@ RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/ml/model
 COPY config.properties /opt/djl/conf/
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 RUN scripts/install_djl_serving.sh $djl_version && \
     scripts/install_djl_serving.sh $djl_version $torch_version && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \

--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -65,6 +65,9 @@ RUN mkdir -p /opt/djl/conf && \
 COPY config.properties /opt/djl/conf/config.properties
 COPY partition /opt/djl/partition
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 RUN apt-get update && \
     scripts/install_djl_serving.sh $djl_version && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \

--- a/serving/docker/fastertransformer.Dockerfile
+++ b/serving/docker/fastertransformer.Dockerfile
@@ -57,6 +57,9 @@ RUN mkdir -p /opt/djl/conf && \
 COPY config.properties /opt/djl/conf/config.properties
 COPY partition /opt/djl/partition
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 # Install all dependencies
 RUN apt-get update && apt-get install -y wget git libnuma-dev zlib1g-dev rapidjson-dev && \
     mkdir ompi && cd ompi && \

--- a/serving/docker/pytorch-cu118.Dockerfile
+++ b/serving/docker/pytorch-cu118.Dockerfile
@@ -41,6 +41,9 @@ ENV HUGGINGFACE_HUB_CACHE=/tmp/.cache/huggingface/hub
 ENV TRANSFORMERS_CACHE=/tmp/.cache/huggingface/transformers
 ENV PYTORCH_KERNEL_CACHE_PATH=/tmp/.cache
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 COPY scripts scripts/
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh && \
     scripts/install_djl_serving.sh $djl_version && \

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -50,6 +50,9 @@ ENV NEURON_CC_FLAGS="--logfile /tmp/compile.log --temp-dir=/tmp"
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 COPY scripts scripts/
 RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/djl/deps && \

--- a/serving/docker/scripts/install_djl_serving.sh
+++ b/serving/docker/scripts/install_djl_serving.sh
@@ -16,9 +16,12 @@ if [ -z "$PYTORCH_JNI" ]; then
     unzip
 
   # install DJLServing
-  curl https://publish.djl.ai/djl-serving/djl-serving_${DJL_VERSION}-1_all.deb -f -o djl-serving_all.deb
+  if [ ! -f djl-serving_all.deb ]; then
+    curl https://publish.djl.ai/djl-serving/djl-serving_${DJL_VERSION}-1_all.deb -f -o djl-serving_all.deb
+  fi
   dpkg -i djl-serving_all.deb
   rm djl-serving_all.deb
+
   cp /usr/local/djl-serving-*/conf/log4j2.xml /opt/djl/conf/
   cp -r /usr/local/djl-serving-*/plugins /opt/djl/plugins
 else

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -47,6 +47,9 @@ RUN mkdir -p /opt/djl/conf && \
 COPY config.properties /opt/djl/conf/config.properties
 COPY partition /opt/djl/partition
 
+COPY distribution[s]/ ./
+RUN mv *.deb djl-serving_all.deb || true
+
 # Install OpenMPI and other deps
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget unzip openmpi-bin libopenmpi-dev libffi-dev git-lfs rapidjson-dev && \


### PR DESCRIPTION
Before, we only supported docker builds that depend on the DJL global djl-serving.deb for the release. This PR begins by updating the Dockerfiles to search for `serving/docker/distributions/*.deb` and copy it to the container if it exists. This can then be used for the build instead of downloading. It enables easier local testing with a custom version of DJL Serving.

As part of this, it also creates a new gradle task `dockerDeb` that will move the build into the docker building context directory. It will be git ignored and cleaned through gradle.

Finally, it also modifies the nightly CI to no longer rely on the global build. This means that the nightly publish job does not require running the serving publish in the DJL repo first.
