### PR TITLE
Creates docker temporary instances

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -4,11 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'release/nightly, default is nightly'
+        description: 'release/nightly/temp, default is nightly'
         required: true
         default: 'nightly'
   schedule:
     - cron: '0 13 * * *'
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   nightly-build:
@@ -29,6 +33,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: install awscli
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -50,6 +63,18 @@ jobs:
           export NIGHTLY="-nightly"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT ${{ matrix.arch }}
           docker compose push ${{ matrix.arch }}
+      - name: Build and push temp image
+        if: ${{ github.event.inputs.mode == 'temp' }}
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(cat ../../gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          export NIGHTLY="-nightly"
+          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT ${{ matrix.arch }}
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:${{ matrix.arch }}-${GITHUB_SHA}"
+          docker tag deepjavalibrary/djl-serving:${{ matrix.arch }}-nightly $tempTag
+          docker push $tempTag
       - name: Build and push release docker image
         if: ${{ github.event.inputs.mode == 'release' }}
         working-directory: serving/docker
@@ -107,6 +132,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: install awscli
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -128,6 +162,18 @@ jobs:
           export NIGHTLY="-nightly"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT aarch64
           docker compose push aarch64
+      - name: Build and push temp image
+        if: ${{ github.event.inputs.mode == 'temp' }}
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(cat ../../gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          export NIGHTLY="-nightly"
+          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT aarch64
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:aarch64-${GITHUB_SHA}"
+          docker tag deepjavalibrary/djl-serving:aarch64-nightly $tempTag
+          docker push $tempTag
       - name: Build and push release docker image
         if: ${{ github.event.inputs.mode == 'release' }}
         working-directory: serving/docker
@@ -153,6 +199,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: install awscli
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -174,6 +229,18 @@ jobs:
           export NIGHTLY="-nightly"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT deepspeed
           docker compose push deepspeed
+      - name: Build and push temp image
+        if: ${{ github.event.inputs.mode == 'temp' }}
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(cat ../../gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          export NIGHTLY="-nightly"
+          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}~SNAPSHOT deepspeed
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:deepspeed-$GITHUB_SHA"
+          docker tag deepjavalibrary/djl-serving:deepspeed-nightly $tempTag
+          docker push $tempTag
       - name: Build and push release docker image
         if: ${{ github.event.inputs.mode == 'release' }}
         working-directory: serving/docker


### PR DESCRIPTION
This creates a new mode to docker_nightly_publish that will create temporary instances tagged with the commit hash such as `185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp:cpu-99f92ba11ef38e2b94d4df73b9b20480d9515cc8`. They are stored in an ECR repository with a lifecycle that will autoclean after 7 days as currently configured.

Right now, this PR only enables the mode for creating these. In a followup PR, I will also use this as a basis for the DJL Serving infrastructure. Specifically, here is the plan. I will modify the temp build so it will be the only docker build (keeping a temp/release option). The integration tests will all read from temp. Then, I will make a sync action that will take a temp instance and copy it to nightly, release, and/or ECR. To put these all together, I will make a combined orchestration workflow that will execute the entire flow of building the image, testing it, and publishing it. So there is only a single nightly job to worry about