### PR TITLE
Downgrade to pydantic version 1.10.13

### DIFF
--- a/engines/python/setup/setup.py
+++ b/engines/python/setup/setup.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     test_requirements = [
         'numpy', 'requests', 'Pillow', 'transformers', 'torch', 'einops',
-        'accelerate', 'sentencepiece', 'protobuf', 'yapf', 'pydantic'
+        'accelerate', 'sentencepiece', 'protobuf', 'yapf', 'pydantic==1.10.13'
     ]
 
     setup(name='djl_python',

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -22,7 +22,7 @@ ARG protobuf_version=3.20.3
 ARG transformers_version=4.34.0
 ARG accelerate_version=0.23.0
 ARG diffusers_version=0.16.0
-ARG pydantic_version=2.4
+ARG pydantic_version=1.10.13
 EXPOSE 8080
 
 # Sets up Path for Neuron tools


### PR DESCRIPTION
## Description ##

Discussed with @tosterberg. He pointed out DeepSpeed is also using pydantic, checking their version it is 1.10.13. So downgrading from 2.4 to 1.10.13 as it has breaking changes. 

Testing:
Build a inf2 container and their integration test
https://github.com/deepjavalibrary/djl-serving/actions/runs/6757166039