### PR TITLE
[python] Fixes scheduler rolling batch device data type error

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -123,7 +123,7 @@ class SchedulerRollingBatch(RollingBatch):
         else:
             device_map = "cpu"
             if device:
-                if isinstance(device, str):
+                if isinstance(device, str) or isinstance(device, int):
                     device_map = device
                 elif isinstance(device,
                                 torch.device) and device.type == "cuda":


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
