### PR TITLE
[python] Workaround bug in PublisherBytesSupplier

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -15,7 +15,7 @@ package ai.djl.python.engine;
 import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.engine.EngineException;
-import ai.djl.inference.streaming.PublisherBytesSupplier;
+import ai.djl.inference.streaming.ChunkedBytesSupplier;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.BytesSupplier;
@@ -375,7 +375,7 @@ class Connection {
 
         private int maxBufferSize;
         private boolean hasMoreChunk;
-        private PublisherBytesSupplier data;
+        private ChunkedBytesSupplier data;
 
         OutputDecoder(int maxBufferSize) {
             this.maxBufferSize = maxBufferSize;
@@ -403,7 +403,7 @@ class Connection {
                     int contentSize = in.readShort();
                     if (contentSize == -1) {
                         hasMoreChunk = true;
-                        data = new PublisherBytesSupplier();
+                        data = new ChunkedBytesSupplier();
                         output.add(data);
                     } else {
                         for (int i = 0; i < contentSize; ++i) {

--- a/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
+++ b/engines/python/src/test/java/ai/djl/python/engine/PyEngineTest.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.inference.Predictor;
 import ai.djl.inference.streaming.ChunkedBytesSupplier;
-import ai.djl.inference.streaming.PublisherBytesSupplier;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.ndarray.BytesSupplier;
@@ -51,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class PyEngineTest {
@@ -204,18 +202,10 @@ public class PyEngineTest {
             input.add("stream", "true");
             Output out = predictor.predict(input);
             BytesSupplier supplier = out.getData();
-            Assert.assertTrue(supplier instanceof PublisherBytesSupplier);
-            PublisherBytesSupplier pub = (PublisherBytesSupplier) supplier;
-            List<byte[]> dat = new ArrayList<>();
-            CompletableFuture<Void> future =
-                    pub.subscribe(
-                            d -> {
-                                if (d != null) {
-                                    dat.add(d);
-                                }
-                            });
-            future.get();
-            Assert.assertEquals(dat.stream().mapToInt(d -> d.length).sum(), 20);
+            Assert.assertTrue(supplier instanceof ChunkedBytesSupplier);
+            ChunkedBytesSupplier pub = (ChunkedBytesSupplier) supplier;
+            byte[] buf = pub.getAsBytes();
+            Assert.assertEquals(buf.length, 20);
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
