### PR TITLE
fix the bug in the cuda compat settings

### DIFF
--- a/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
+++ b/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
@@ -7,12 +7,11 @@ verlte() {
 
 # Follow https://docs.aws.amazon.com/sagemaker/latest/dg/inference-gpu-drivers.html
 if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
-    cat /usr/local/cuda/version.txt
     CUDA_COMPAT_MAX_DRIVER_VERSION=$(readlink /usr/local/cuda/compat/libcuda.so.1 |cut -d'.' -f 3-)
     echo "CUDA compat package requires Nvidia driver ⩽${CUDA_COMPAT_MAX_DRIVER_VERSION}"
     NVIDIA_DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)
     echo "Current installed Nvidia driver version is ${NVIDIA_DRIVER_VERSION}"
-    if [ $(verlte $CUDA_COMPAT_MAX_DRIVER_VERSION $NVIDIA_DRIVER_VERSION) ]; then
+    if [ $(verlte $NVIDIA_DRIVER_VERSION $CUDA_COMPAT_MAX_DRIVER_VERSION) ]; then
         echo "Setup CUDA compatibility libs path to LD_LIBRARY_PATH"
         export LD_LIBRARY_PATH=/usr/local/cuda/compat:$LD_LIBRARY_PATH
         echo $LD_LIBRARY_PATH


### PR DESCRIPTION
## Description ##

Use CUDA compat with old drivers, not new ones

```
% verlt() {
    [ "$1" = "$2" ] && return 1 || [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
}
% verlte 2.5.7 2.5.6 && echo "yes" || echo "no"
no
% verlte 535.129.03 515.65.01 && echo "yes" || echo "no"
no
% verlte 515.65.01 535.129.03 && echo "yes" || echo "no"
yes
% verlte 470.129.03 555.68.01 && echo "yes" || echo "no"
yes
```
