### PR TITLE
[CUDA Compat] fix the verlte settings on the script

### DIFF
--- a/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
+++ b/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
@@ -2,7 +2,7 @@
 #set -e
 
 verlte() {
-    [ "$1" = "$2" ] && return 1 || [ "$2" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+    [ "$1" = "$2" ] && return 1 || [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
 }
 
 # Follow https://docs.aws.amazon.com/sagemaker/latest/dg/inference-gpu-drivers.html
@@ -11,7 +11,7 @@ if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
     echo "CUDA compat package requires Nvidia driver ⩽${CUDA_COMPAT_MAX_DRIVER_VERSION}"
     NVIDIA_DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)
     echo "Current installed Nvidia driver version is ${NVIDIA_DRIVER_VERSION}"
-    if [ $(verlte $NVIDIA_DRIVER_VERSION $CUDA_COMPAT_MAX_DRIVER_VERSION) ]; then
+    if verlte $NVIDIA_DRIVER_VERSION $CUDA_COMPAT_MAX_DRIVER_VERSION; then
         echo "Setup CUDA compatibility libs path to LD_LIBRARY_PATH"
         export LD_LIBRARY_PATH=/usr/local/cuda/compat:$LD_LIBRARY_PATH
         echo $LD_LIBRARY_PATH


### PR DESCRIPTION
## Description ##

Some more changes to the script

```
root@10607c153a8a:/opt/djl# bash test.sh
CUDA compat package requires Nvidia driver ⩽535.129.03
Current installed Nvidia driver version is 535.104.12
Setup CUDA compatibility libs path to LD_LIBRARY_PATH
/usr/local/cuda/compat:/opt/tritonserver/lib:/usr/local/lib/python3.10/dist-packages/tensorrt_libs:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
```

