### PR TITLE
fix batch_size type conversion

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/ds_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/ds_properties.py
@@ -37,7 +37,7 @@ class DeepSpeedProperties(Properties):
     training_mp_size: Optional[int] = 1
     checkpoint: Optional[str] = None
     save_mp_checkpoint_path: Optional[str] = None
-    ds_config: Optional[Any] = None
+    ds_config: Optional[Any] = Field(default={}, alias='deepspeed_config_path')
 
     @validator('device', always=True)
     def set_device(cls, device):
@@ -111,10 +111,7 @@ class DeepSpeedProperties(Properties):
 
     @root_validator()
     def construct_ds_config(cls, properties):
-        if properties.get("deepspeed_config_path"):
-            with open(properties.get("deepspeed_config_path"), "r") as f:
-                properties['ds_config'] = json.load(f)
-        else:
+        if not properties.get("ds_config"):
             ds_config = {
                 "tensor_parallel": {
                     "tp_size": properties['tensor_parallel_degree']

--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -63,6 +63,7 @@ class Properties(BaseModel):
 
     @validator('batch_size', pre=True)
     def validate_batch_size(cls, batch_size, values):
+        batch_size = int(batch_size)
         if batch_size > 1:
             if not is_rolling_batch_enabled(
                     values['rolling_batch']) and is_streaming_enabled(


### PR DESCRIPTION
## Description ##

Issue:
Pydantic does auto conversion, but we do validate batch_size before assigning, so manually need to type cast them. 

Test case:
These were not caught in unit test case before because, tested it as int not str. Changed all input to Properties as str and added more test cases.  
