### PR TITLE
[fix] Refactor device on the scheduler

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -220,10 +220,7 @@ class SchedulerRollingBatch(RollingBatch):
         input_ids = self.tokenizer(input_texts,
                                    return_tensors="pt",
                                    padding=True).input_ids
-        if self.device:
-            input_ids = input_ids.to(self.device)
-        else:
-            input_ids = input_ids.to(self.model.device)
+        input_ids = input_ids.to(self.model.device)
         return input_ids
 
     def _get_prompt_ids(self, prompts):


### PR DESCRIPTION
## Description ##

The change on line 226 :         `input_ids = input_ids.to(self.model.device)`
is for Bloom560m support where the model is loaded to cuda:3
