### PR TITLE
[CI] split lmi tests to run in parallel

### DIFF
--- a/.github/workflows/rolling_batch_integration.yml
+++ b/.github/workflows/rolling_batch_integration.yml
@@ -178,7 +178,7 @@ jobs:
           name: rb-multi-gpu-logs
           path: tests/integration/logs/
 
-  lmi-dist-test:
+  lmi-dist-test-1:
     runs-on: [ self-hosted, g5 ]
     timeout-minutes: 60
     needs: create-runners
@@ -246,6 +246,42 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG nocode deepspeed
           python3 llm/client.py lmi_dist gpt2
           docker rm -f $(docker ps -aq)
+      - name: On fail step
+        if: ${{ failure() }}
+        working-directory: tests/integration
+        run: |
+          docker rm -f $(docker ps -aq) || true
+          cat logs/serving.log
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: lmi-dist-logs-1
+          path: tests/integration/logs/
+
+  lmi-dist-test-2:
+    runs-on: [ self-hosted, g5 ]
+    timeout-minutes: 60
+    needs: create-runners
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean env
+        run: |
+          yes | docker system prune -a --volumes
+          sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
+          echo "wait dpkg lock..."
+          while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 5; done
+      - name: Set up Python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.x'
+      - name: Install pip dependencies
+        run: pip3 install requests numpy
+      - name: Build container name
+        run: ./serving/docker/scripts/docker_name_builder.sh deepspeed ${{ github.event.inputs.djl-version }}
+      - name: Download docker
+        working-directory: tests/integration
+        run: |
+          docker pull deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG
       - name: Test mpt-7b
         working-directory: tests/integration
         run: |
@@ -291,7 +327,7 @@ jobs:
       - name: Upload test logs
         uses: actions/upload-artifact@v3
         with:
-          name: lmi-dist-logs
+          name: lmi-dist-logs-2
           path: tests/integration/logs/
 
   vllm-test:
@@ -354,13 +390,13 @@ jobs:
       - name: Upload test logs
         uses: actions/upload-artifact@v3
         with:
-          name: lmi-dist-logs
+          name: vllm-logs
           path: tests/integration/logs/
 
   stop-runners:
     if: always()
     runs-on: [ self-hosted, scheduler ]
-    needs: [ create-runners, scheduler-single-gpu-test, scheduler-multi-gpu-test, lmi-dist-test, vllm-test ]
+    needs: [ create-runners, scheduler-single-gpu-test, scheduler-multi-gpu-test, lmi-dist-test-1, lmi-dist-test-2, vllm-test ]
     steps:
       - name: Stop all instances
         run: |


### PR DESCRIPTION
## Description ##

lmi dist tests alone takes 50 mins to run whereas other tests takes only around 10 mins each. We are running it on two machines, and one of the machine usually waits till lmi dist tests are finished running before stopping. So dividing lmi dist into two, to reduce the time it takes to run. 
