### PR TITLE
[serving] Uses seconds for ChunkedBytesSupplier timeout

### DIFF
--- a/serving/src/main/java/ai/djl/serving/cache/BaseCacheEngine.java
+++ b/serving/src/main/java/ai/djl/serving/cache/BaseCacheEngine.java
@@ -71,7 +71,7 @@ public abstract class BaseCacheEngine implements CacheEngine {
                                     List<byte[]> list = new ArrayList<>(writeBatch);
                                     while (cbs.hasNext()) {
                                         try {
-                                            list.add(cbs.nextChunk(1, TimeUnit.MINUTES));
+                                            list.add(cbs.nextChunk(60, TimeUnit.SECONDS));
                                         } catch (InterruptedException e) {
                                             throw new IllegalStateException(e);
                                         }

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -395,7 +395,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                 int count = 0;
                 ChunkedBytesSupplier supplier = (ChunkedBytesSupplier) data;
                 while (supplier.hasNext()) {
-                    byte[] buf = supplier.nextChunk(chunkReadTime, TimeUnit.MINUTES);
+                    byte[] buf = supplier.nextChunk(chunkReadTime, TimeUnit.SECONDS);
                     // Defer sending HTTP header until first chunk received.
                     // This allows inference update HTTP code.
                     if (first) {

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -371,12 +371,12 @@ public final class ConfigManager {
     }
 
     /**
-     * Returns the ChunkedBytesSupplier read time in minutes.
+     * Returns the ChunkedBytesSupplier read time in seconds.
      *
-     * @return the ChunkedBytesSupplier read time in minutes
+     * @return the ChunkedBytesSupplier read time in seconds
      */
     public int getChunkedReadTimeout() {
-        return getIntProperty(CHUNKED_READ_TIMEOUT, 2);
+        return getIntProperty(CHUNKED_READ_TIMEOUT, 60);
     }
 
     /**


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
