### PR TITLE
[CI] Adds instance benchmark tabular recording

### DIFF
--- a/.github/workflows/instant_benchmark.yml
+++ b/.github/workflows/instant_benchmark.yml
@@ -26,7 +26,17 @@ on:
           - inf2.24xlarge
           - trn1.2xlarge
           - trn1.32xlarge
+      record:
+        description: 'Whether to record the results'
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - table
 
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   create-runners:
@@ -82,6 +92,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10.x'
+      - name: install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+          pip3 install boto3
       - name: Setup awscurl
         working-directory: tests/integration
         run: |
@@ -95,6 +110,19 @@ jobs:
           --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }} \
           --container deepjavalibrary/djl-serving:${{ github.event.inputs.container }}
           bash instant_benchmark.sh
+      - name: Configure AWS Credentials
+        if: ${{ github.event.inputs.record == 'table' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
+      - name: Record benchmark job
+        if: ${{ github.event.inputs.record == 'table' }}
+        working-directory: tests/integration
+        run: |
+          python3 record_benchmark.py --template template.json \
+          --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }} \
+          --container deepjavalibrary/djl-serving:${{ github.event.inputs.container }} --record table
       - name: Get serving logs
         if: always()
         working-directory: tests/integration

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -51,7 +51,8 @@ class TRTLLMRollingBatch(RollingBatch):
             parameters["runtime_top_k"] = parameters.get("runtime_top_k", 5)
             parameters["runtime_top_p"] = parameters.get("runtime_top_p", 0.85)
             parameters["temperature"] = parameters.get("temperature", 0.8)
-            parameters["repetition_penalty"] = parameters.get("repetition_penalty", 1.2)
+            parameters["repetition_penalty"] = parameters.get(
+                "repetition_penalty", 1.2)
         parameters["streaming"] = parameters.get("streaming", True)
         return parameters
 

--- a/tests/integration/record_benchmark.py
+++ b/tests/integration/record_benchmark.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import boto3
+import json
+import os
+import time
+from decimal import Decimal
+
+logging.basicConfig(level=logging.INFO)
+
+parser = argparse.ArgumentParser(
+    description="Script for saving container benchmark results")
+parser.add_argument("--container",
+                    required=True,
+                    type=str,
+                    help="The container to run the job")
+parser.add_argument("--template",
+                    required=True,
+                    type=str,
+                    help="The template json string")
+parser.add_argument("--instance",
+                    required=True,
+                    type=str,
+                    help="The current instance name")
+parser.add_argument("--record",
+                    choices=["table"],
+                    required=False,
+                    type=str,
+                    help="Where to record to")
+parser.add_argument("--job", required=True, type=str, help="The job string")
+args = parser.parse_args()
+
+data = {}
+
+
+class Benchmark:
+
+    def __init__(self, dyn_resource):
+        self.dyn_resource = dyn_resource
+        self.table = dyn_resource.Table("RubikonBenchmarks")
+        self.table.load()
+
+    def add_benchmark(self):
+        self.table.put_item(Item=data)
+
+
+def record_table():
+    table = boto3.resource("dynamodb").Table("RubikonBenchmarks")
+    table.put_item(Item=data)
+
+
+def data_basic():
+    data["modelServer"] = "DJLServing"
+    data["service"] = "ec2"
+    data["Timestamp"] = Decimal(time.time())
+
+    data["instance"] = args.instance
+
+    container = args.container
+    data["container"] = container
+    if container.startswith("deepjavalibrary/djl-serving:"):
+        container = container[len("deepjavalibrary/djl-serving:"):]
+        split = container.split("-", 1)
+        data["djlVersion"] = split[0]
+        if len(split) > 1:
+            data["image"] = split[1]
+        else:
+            data["image"] = "cpu"
+
+
+def data_from_client():
+    with open("benchmark.log", "r") as f:
+        for line in f.readlines():
+            line = line.strip()
+            if "Total time:" in line:
+                data["totalTime"] = Decimal(line.split(" ")[2])
+            if "error rate:" in line:
+                data["errorRate"] = Decimal(line.split(" ")[-1])
+            if "Concurrent clients:" in line:
+                data["concurrency"] = int(line.split(" ")[2])
+            if "Total requests:" in line:
+                data["requests"] = int(line.split(" ")[2])
+            if "TPS:" in line:
+                data["tps"] = Decimal(line.split(" ")[1].split("/")[0])
+            if "Average Latency:" in line:
+                data["avgLatency"] = Decimal(line.split(" ")[2])
+            if "P50:" in line:
+                data["P50"] = Decimal(line.split(" ")[1])
+            if "P90:" in line:
+                data["P90"] = Decimal(line.split(" ")[1])
+            if "P99:" in line:
+                data["P99"] = Decimal(line.split(" ")[1])
+
+
+def data_from_files():
+    with open("models/test/serving.properties", "r") as f:
+        properties = {}
+        for line in f.readlines():
+            line = line.strip()
+            if line[0] == "#":
+                continue
+            if "=" in line:
+                split = line.split("=", 1)
+                k = split[0].replace(".", "-")
+                v = split[1].replace(".", "-")
+                properties[k] = v
+        data["serving_properties"] = properties
+
+        # Standard properties
+        if "option-model_id" in properties:
+            data["modelId"] = properties["option-model_id"]
+        if "option-tensor_parallel_degree" in properties:
+            data["tensorParallel"] = properties[
+                "option-tensor_parallel_degree"]
+
+    if os.path.isfile("models/test/requirements.txt"):
+        with open("models/test/requirements.txt", "r") as f:
+            req = {}
+            for line in f.readlines():
+                line = line.strip()
+                if line[0] == "#":
+                    continue
+                if "=" in line:
+                    split = line.split("=", 1)
+                    req[split[0]] = split[1]
+            data["requirements_txt"] = req
+
+
+def data_from_template():
+    with open(args.template, "r") as f:
+        template = json.load(f)
+        job_template = template[args.job]
+        data["awscurl"] = bytes.fromhex(
+            job_template['awscurl']).decode("utf-8")
+        if "info" in job_template:
+            for line in job_template["info"]:
+                split = line.split("=", 1)
+                data[split[0]] = split[1]
+            return True
+        else:
+            return False
+
+
+if __name__ == "__main__":
+    data_from_template()
+    data_basic()
+    data_from_client()
+    data_from_files()
+
+    if "errorRate" not in data or data["errorRate"] == 100:
+        print("Not recording failed benchmark")
+        print(data)
+    else:
+        if args.record == "table":
+            record_table()
+        else:
+            print(data)


### PR DESCRIPTION
This improves the instant benchmark action with support to record the data in a DynamoDB table. It saves the input, serving.properties, and all accessible outputs as well. The table with some existing data can be seen [here](https://us-east-1.console.aws.amazon.com/dynamodbv2/home?region=us-east-1#item-explorer?operation=SCAN&table=RubikonBenchmarks) from this [input](https://gist.githubusercontent.com/zachgk/c0090ab15c00a3fda06b63f7a61a370a/raw/867f9b4db107b225b4993e8328f6c8bbf608e107/gistfile1.txt).