### PR TITLE
[fix] quantization properties for lmi dist and hf acc

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -165,15 +165,13 @@ class HuggingFaceProperties(Properties):
             if "device_map" not in kwargs:
                 raise ValueError(
                     "device_map should be set when load_in_8bit is set")
-            kwargs["load_in_8bit"] = properties['load_in_8bit']
-            properties['quantize'] = HFQuantizeMethods.bitsandbytes8
+            kwargs["load_in_8bit"] = True
         if properties[
                 'quantize'].value == HFQuantizeMethods.bitsandbytes4.value:
             if "device_map" not in kwargs:
                 raise ValueError(
                     "device_map should set when load_in_4bit is set")
-            kwargs["load_in_4bit"] = properties['load_in_4bit']
-            properties['quantize'] = HFQuantizeMethods.bitsandbytes4
+            kwargs["load_in_4bit"] = True
 
         properties['kwargs'] = kwargs
         return properties

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -23,7 +23,7 @@ from lmi_dist.utils.types import (Batch, Request, Generation)
 
 import torch
 
-QUANTIZATION_SUPPORT_ALGO = ["bitsandbytes", "gptq"]
+QUANTIZATION_SUPPORT_ALGO = ["bitsandbytes8", "bitsandbytes", "gptq"]
 
 
 class LmiDistRollingBatch(RollingBatch):
@@ -58,15 +58,17 @@ class LmiDistRollingBatch(RollingBatch):
         revision = self.properties.get('revision', None)
         paged_attention = self.properties.get("paged_attention",
                                               "true").lower() == "true"
-        if quantize is not None and dtype is not None:
-            raise ValueError(
-                f"Can't set both dtype: {dtype} and quantize: {quantize}")
-        if quantize is not None and quantize not in QUANTIZATION_SUPPORT_ALGO:
-            raise ValueError(
-                f"Invalid value for quantize: {quantize}. Valid values when using option rolling_batch=lmi-dist are: {QUANTIZATION_SUPPORT_ALGO}"
-            )
         if quantize is not None:
             os.environ["CUDA_MEMORY_FRACTION"] = "0.9"
+            if dtype is not None:
+                raise ValueError(
+                    f"Can't set both dtype: {dtype} and quantize: {quantize}")
+            if quantize not in QUANTIZATION_SUPPORT_ALGO:
+                raise ValueError(
+                    f"Invalid value for quantize: {quantize}. Valid values when using option rolling_batch=lmi-dist are: {QUANTIZATION_SUPPORT_ALGO}"
+                )
+            if quantize == "bitsandbytes8":
+                quantize = "bitsandbytes"
         if quantize is None and dtype == "int8":
             quantize = "bitsandbytes"
         from lmi_dist.models import get_model


### PR DESCRIPTION
## Description ##

Found a bug while testing quantization with new properties for HF Accelerate and lmi-dist

LMI Dist rolling batch takes in the parsed properties instead of pydantic, so new bitsandbytes8 needs to be handled in rolling batch handler. 

Testing:
Tested HF and LMI Dist in my machine with bitsandbytes option
Tested TnX quantization in my machine , works 

vllm, deepseed, trtllm has no changes for quantization
