### PR TITLE
[fix] Context length estimate datatype

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 import re
-from typing import Optional
+from typing import Optional, Union, List
 
 from pydantic import validator, root_validator
 from enum import IntEnum, Enum
@@ -50,7 +50,7 @@ class TransformerNeuronXProperties(Properties):
     load_in_8bit: Optional[bool] = False
     low_cpu_mem_usage: bool = False
     load_split_model: bool = False
-    context_length_estimate: Optional[dict] = None
+    context_length_estimate: Optional[Union[List[int], int]] = None
     amp: Optional[str] = None
     quantize: Optional[TnXQuantizeMethods] = None
     compiled_graph_path: Optional[str] = None

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -389,6 +389,7 @@ transformers_neuronx_handler_list = {
         "option.n_positions": 512,
         "option.model_loading_timeout": 2400,
         "option.load_split_model": True,
+        "option.context_length_estimate": [256, 512, 1024]
     },
     "opt-1.3b-streaming": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",


### PR DESCRIPTION
## Description ##

After reinvent fix. TransformerNeuronX expects context length estimate as int or List of int. 

Testing:
Modified unit test case. 
Added context length estimate to CI and test it in my ec2 inf2 machine. 

