### PR TITLE
[CI][IB] Support variables

### DIFF
--- a/tests/integration/instant_benchmark.py
+++ b/tests/integration/instant_benchmark.py
@@ -41,46 +41,46 @@ def var_replace(template, vars):
     if isinstance(template, dict):
         for k, v in template.items():
             if isinstance(v, str):
-                for varKey, varVal in vars.items():
-                    v = v.replace("$" + varKey, varVal)
+                for var_key, var_val in vars.items():
+                    v = v.replace("$" + var_key, var_val)
                 template[k] = v
             else:
                 var_replace(v, vars)
     elif isinstance(template, list):
         for k, v in enumerate(template):
             if isinstance(v, str):
-                for varKey, varVal in vars.items():
-                    v = v.replace("$" + varKey, varVal)
+                for var_key, var_val in vars.items():
+                    v = v.replace("$" + var_key, var_val)
                 template[k] = v
             else:
                 var_replace(v, vars)
 
 
-def multiply_template_with_vars(name, template, rawVars):
-    if not rawVars:
+def multiply_template_with_vars(name, template, raw_var):
+    if not raw_var:
         return {name: template}
     result = {}
     vars = {}
-    for rawVar in rawVars:
-        [k, v] = rawVar.split("=", 2)
+    for raw_var in raw_var:
+        [k, v] = raw_var.split("=", 2)
         if "{" in v:
             v = v[1:-1].split(",")
         elif "[" in v:
             v = v[1:-1]
-            [vStart, vEnd] = v.split("..")
-            v = [str(i) for i in range(int(vStart), int(vEnd))]
+            [v_start, v_end] = v.split("..")
+            v = [str(i) for i in range(int(v_start), int(v_end))]
         else:
-            raise Exception("Unknown var in template: " + rawVar)
+            raise Exception("Unknown var in template: " + raw_var)
         vars[k] = v
-    varCombinations = [
+    var_combinations = [
         dict(zip(vars.keys(), x)) for x in itertools.product(*vars.values())
     ]
-    for curVars in varCombinations:
-        curName = "%s[%s]" % (name, ",".join(
-            [str(k) + "=" + str(v) for k, v in curVars.items()]))
-        curTemplate = copy.deepcopy(template)
-        var_replace(curTemplate, curVars)
-        result[curName] = curTemplate
+    for cur_vars in var_combinations:
+        cur_name = "%s[%s]" % (name, ",".join(
+            [str(k) + "=" + str(v) for k, v in cur_vars.items()]))
+        cur_template = copy.deepcopy(template)
+        var_replace(cur_template, cur_vars)
+        result[cur_name] = cur_template
     return result
 
 

--- a/tests/integration/record_benchmark.py
+++ b/tests/integration/record_benchmark.py
@@ -92,6 +92,8 @@ def data_from_client():
                 data["P90"] = Decimal(line.split(" ")[1])
             if "P99:" in line:
                 data["P99"] = Decimal(line.split(" ")[1])
+            if "totalTime" in data and "requests" in data:
+                data["throughput"] = data["requests"] / data["totalTime"]
 
 
 def data_from_files():


### PR DESCRIPTION
This adds support for a new section on variables in the IB configurations. They are specified by

```
[test_name]
test
[vars]
CONCURRENCY={1,16,32}
RANGE=[1..5]
```

This will then produce a template result for each combination of vars (note ranges are following python semantics of inclusive start and exclusive end).

It can be used to support larger configurations with variations.

I also added a small update to the record benchmarks script to also pre-compute throughput.

Successful run at https://github.com/deepjavalibrary/djl-serving/actions/runs/7067209325
