### PR TITLE
[fix] pyarrow breaking change for test dataset

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -36,6 +36,7 @@ ARG bitsandbytes_version=0.41.1
 ARG optimum_version=1.13.2
 ARG auto_gptq_version=0.4.2
 ARG datasets_version=2.14.4
+ARG pyarrow_version=13.0.0
 
 EXPOSE 8080
 
@@ -80,7 +81,7 @@ RUN apt-get update && \
     ${lmi_vllm_wheel} ${lmi_dist_wheel} ${seq_scheduler_wheel} ${peft_wheel} ${mmaploader_wheel} protobuf==${protobuf_version} \
     transformers==${transformers_version} zstandard datasets==${datasets_version} \
     mpi4py sentencepiece einops accelerate==${accelerate_version} bitsandbytes==${bitsandbytes_version} \
-    optimum==${optimum_version} auto-gptq==${auto_gptq_version} vllm==${vllm_version} pandas pyarrow \
+    optimum==${optimum_version} auto-gptq==${auto_gptq_version} vllm==${vllm_version} pandas pyarrow==${pyarrow_version} \
     diffusers[torch]==${diffusers_version} opencv-contrib-python-headless safetensors scipy && \
     scripts/install_aitemplate.sh && \
     scripts/patch_oss_dlc.sh python && \


### PR DESCRIPTION
## Description ##

Rerunning 0.24.0-dlc breaks in smoothquant auto-calibration due to dataset/pyarrow conflicts. Pinning 0.24.0-dlc pyarrow to 13.0.0 to resolve.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
