### PR TITLE
[Refactor][UX] Refactoring vllm rolling batch properties

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -54,9 +54,17 @@ class Properties(BaseModel):
     # TODO: disabling streaming, as it is not supported for all models of the frameworks. Will revisit this
     enable_streaming: StreamingEnum = StreamingEnum.false
     batch_size: int = 1
-    max_rolling_batch_size: int = 32
+    max_rolling_batch_size: Optional[int] = 32
     dtype: Optional[str] = None
     revision: Optional[str] = None
+    output_formatter: Optional[str] = None
+    waiting_steps: Optional[int] = None
+    is_mpi: bool = False
+
+    @root_validator(pre=True)
+    def calculate_is_mpi(cls, properties):
+        properties['is_mpi'] = properties.get("mpi_mode") == "true"
+        return properties
 
     @validator('enable_streaming', pre=True)
     def validate_enable_streaming(cls, enable_streaming: str) -> str:

--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+from enum import Enum
+from typing import Optional
+
+from pydantic.class_validators import validator
+
+from djl_python.properties_manager.properties import Properties
+
+
+class VllmQuantizeMethods(str, Enum):
+    awq = 'awq'
+
+
+class VllmRbProperties(Properties):
+    engine: Optional[str] = None
+    dtype: Optional[str] = "auto"
+    quantize: Optional[VllmQuantizeMethods] = None
+    tensor_parallel_degree: Optional[int] = None
+    max_rolling_batch_prefill_tokens: Optional[int] = None
+
+    @validator('engine')
+    def validate_engine(cls, engine):
+        if engine != "Python":
+            raise AssertionError(
+                f"Need python engine to start vLLM RollingBatcher")
+        return engine

--- a/engines/python/setup/djl_python/rolling_batch/deepspeed_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/deepspeed_rolling_batch.py
@@ -33,7 +33,7 @@ class DeepSpeedRollingBatch(RollingBatch):
         :param kwargs passed while loading the model
         """
 
-        super().__init__(device, **kwargs)
+        super().__init__(**kwargs)
         self.error_requests = []
         self.properties = properties
         self.batch_cls = None

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -40,7 +40,7 @@ class LmiDistRollingBatch(RollingBatch):
         :param kwargs passed while loading the model
         """
 
-        super().__init__(device, **kwargs)
+        super().__init__(**kwargs)
         if properties.get("mpi_mode") != "true" and int(
                 properties.get("tensor_parallel_degree", "1")) != 1:
             raise AssertionError(

--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -23,7 +23,7 @@ class NeuronRollingBatch(RollingBatch):
         :param batch_size: the maximum batch size required by model
         :param tokenizer: the tokenizer used by model
         """
-        super().__init__(-1, **kwargs)
+        super().__init__(**kwargs)
         self.scheduler = NeuronGenerator(model, tokenizer, batch_size,
                                          n_postions)
 

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -190,15 +190,13 @@ class RollingBatch(ABC):
 
     """
 
-    def __init__(self, device, **kwargs):
+    def __init__(self, **kwargs):
         """
         Initializes the rolling batch scheduler.
 
-        :param device: device to load the model
         :param kwargs passed while loading the model
         """
 
-        self.device = device
         self.pending_requests = []
         self.active_requests = []
         self.req_id_counter = 0

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -50,7 +50,7 @@ class SchedulerRollingBatch(RollingBatch):
         :param kwargs passed while loading the model
         """
 
-        super().__init__(device, **kwargs)
+        super().__init__(**kwargs)
         self._init_model_and_tokenizer(model_id_or_path,
                                        device=device,
                                        properties=properties,

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -23,7 +23,7 @@ class TRTLLMRollingBatch(RollingBatch):
         :param model_id_or_path: model id or path
         :param properties: other properties of the model, such as decoder strategy
         """
-        super().__init__(-1, **kwargs)
+        super().__init__(**kwargs)
         if properties.get("mpi_mode") != "true":
             raise AssertionError(
                 f"Need mpi_mode to start tensorrt llm RollingBatcher")


### PR DESCRIPTION
## Description ##

Refactoring the rolling batch handlers to extract out the properties and maintain it in pydantic. Will be doing it for all rolling batch handlers. 

Right now, for easier review, will raise PR for each handler at a time. After this, all the rolling batch based if conditions in huggingface_properties can be removed. Right now, added TODOs, to prevent our CI from breaking. Once all the rolling batch handlers are refactored, will address these TODOs. 

## Testing ##
- Added unit test cases for vllm properties
- Ran vllm rolling batch integration test in my local machine. 