### PR TITLE
[python] Sets rolling batch threads as daemon thread

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -52,7 +52,13 @@ class RollingBatch implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RollingBatch.class);
     private static final Logger SERVER_METRIC = LoggerFactory.getLogger("server_metric");
 
-    private static ExecutorService threadPool = Executors.newCachedThreadPool();
+    private static ExecutorService threadPool =
+            Executors.newCachedThreadPool(
+                    r -> {
+                        Thread t = Executors.defaultThreadFactory().newThread(r);
+                        t.setDaemon(true);
+                        return t;
+                    });
 
     private PyProcess process;
     private int maxRollingBatchSize;

--- a/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/WorkLoadManager.java
@@ -43,7 +43,13 @@ public class WorkLoadManager {
 
     /** Constructs a {@link WorkLoadManager} instance. */
     public WorkLoadManager() {
-        threadPool = Executors.newCachedThreadPool();
+        threadPool =
+                Executors.newCachedThreadPool(
+                        r -> {
+                            Thread t = Executors.defaultThreadFactory().newThread(r);
+                            t.setDaemon(true);
+                            return t;
+                        });
         workerPools = new ConcurrentHashMap<>();
     }
 


### PR DESCRIPTION
## Description ##

If there is non-daemon thread is running, JVM cannot exit normally (when we programaticall call ModelServer.stop(), or model load failed on startup and trying to stop model server)
