### PR TITLE
[CI][fix] remove g5xl and introduce rolling batch in lmic

### DIFF
--- a/.github/workflows/lmic_performance.yml
+++ b/.github/workflows/lmic_performance.yml
@@ -15,15 +15,6 @@ jobs:
   create-runners:
     runs-on: [self-hosted, scheduler]
     steps:
-      - name: Create new G5XL instance
-        id: create_gpu_xl
-        run: |
-          cd /home/ubuntu/djl_benchmark_script/scripts
-          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
-          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
-          --fail \
-          | jq '.token' | tr -d '"' )
-          ./start_instance.sh action_lmic_g5 $token djl-serving
       - name: Create new G5 instance
         id: create_gpu
         run: |
@@ -43,12 +34,12 @@ jobs:
           | jq '.token' | tr -d '"' )
           ./start_instance.sh action_g5 $token djl-serving
     outputs:
-      gpu_instance_id_g5xl: ${{ steps.create_gpu_xl.outputs.action_lmic_g5_instance_id }}
       gpu_instance_id_1: ${{ steps.create_gpu.outputs.action_g5_instance_id }}
       gpu_instance_id_2: ${{ steps.create_gpu2.outputs.action_g5_instance_id }}
 
+
   lmic-neox-g5-test:
-    runs-on: [ self-hosted, g5xl ]
+    runs-on: [ self-hosted, g5 ]
     timeout-minutes: 240
     needs: create-runners
     steps:
@@ -192,7 +183,7 @@ jobs:
           path: tests/integration/logs/
 
   lmic-opt-g5-test:
-    runs-on: [ self-hosted, g5xl ]
+    runs-on: [ self-hosted, g5 ]
     timeout-minutes: 180
     needs: create-runners
     steps:
@@ -227,21 +218,10 @@ jobs:
           name: performance-opt-30b-logs
           path: tests/integration/logs/
 
-  stop-g5xl-runners:
-    if: always()
-    runs-on: [ self-hosted, scheduler ]
-    needs: [ create-runners, lmic-neox-g5-test, lmic-opt-g5-test ]
-    steps:
-      - name: Stop g5xl instances
-        run: |
-          cd /home/ubuntu/djl_benchmark_script/scripts
-          instance_id=${{ needs.create-runners.outputs.gpu_instance_id_g5xl }}
-          ./stop_instance.sh $instance_id "us-west-2"
-
   stop-g5-runners:
     if: always()
     runs-on: [ self-hosted, scheduler ]
-    needs: [ create-runners, lmic-gptj-g5-test, lmic-bloom-g5-test, lmic-llama-g5-test ]
+    needs: [ create-runners, lmic-gptj-g5-test, lmic-bloom-g5-test, lmic-llama-g5-test, lmic-neox-g5-test, lmic-opt-g5-test ]
     steps:
       - name: Stop g5 instances
         run: |

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -200,119 +200,136 @@ sd_handler_list = {
     }
 }
 
-default_accel_configs = {
-    "huggingface": {
-        "engine": "Python",
-        "option.entryPoint": "djl_python.huggingface"
-    },
-    "deepspeed": {
-        "engine": "DeepSpeed",
-        "option.entryPoint": "djl_python.deepspeed"
-    }
-}
-
 performance_test_list = {
-    "opt-30b": {
+    "opt-30b-fp16-deepspeed": {
         "option.task": "text-generation",
-        "option.model_id": "s3://djl-llm/opt-30b/"
+        "option.model_id": "s3://djl-llm/opt-30b/",
+        "option.parallel_loading": "true",
+        "engine": "DeepSpeed",
+        "option.dtype": "fp16",
+        "option.rolling_batch": "deepspeed",
+    },
+    "opt-30b-bf16-deepspeed": {
+        "option.task": "text-generation",
+        "option.model_id": "s3://djl-llm/opt-30b/",
+        "option.parallel_loading": "true",
+        "engine": "DeepSpeed",
+        "option.dtype": "bf16",
+        "option.rolling_batch": "deepspeed",
+    },
+    "opt-30b-lmi-dist": {
+        "option.task": "text-generation",
+        "option.model_id": "s3://djl-llm/opt-30b/",
+        "engine": "MPI",
+        "option.rolling_batch": "deepspeed",
     },
     "open-llama-13b-fp16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/open-llama-13b/"
-    },
-    "open-llama-13b-fp16-huggingface": {
-        "option.task": "text-generation",
-        "option.dtype": "fp16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/open-llama-13b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/open-llama-13b/",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
     "open-llama-13b-bf16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "bf16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/open-llama-13b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/open-llama-13b/",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
-    "open-llama-13b-bf16-huggingface": {
+    "open-llama-13b-fp16-lmi-dist": {
         "option.task": "text-generation",
-        "option.dtype": "bf16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/open-llama-13b/"
+        "option.dtype": "fp16",
+        "engine": "MPI",
+        "option.model_id": "s3://djl-llm/open-llama-13b/",
+        "option.rolling_batch": "lmi-dist",
     },
     "open-llama-13b-smoothquant": {
         "option.task": "text-generation",
         "option.model_id": "s3://djl-llm/open-llama-13b/",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
-        "option.quantize": "smoothquant"
+        "engine": "DeepSpeed",
+        "option.quantize": "smoothquant",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
     "gpt-j-6b-fp16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/gpt-j-6b/"
-    },
-    "gpt-j-6b-fp16-huggingface": {
-        "option.task": "text-generation",
-        "option.dtype": "fp16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/gpt-j-6b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
     "gpt-j-6b-bf16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "bf16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/gpt-j-6b/"
-    },
-    "gpt-j-6b-bf16-huggingface": {
-        "option.task": "text-generation",
-        "option.dtype": "bf16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/gpt-j-6b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/gpt-j-6b/",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
     "gpt-j-6b-smoothquant": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
+        "engine": "DeepSpeed",
         "option.model_id": "s3://djl-llm/gpt-j-6b/",
-        "option.quantize": "smoothquant"
+        "option.quantize": "smoothquant",
+        "option.rolling_batch": "deepspeed",
+        "option.max_rolling_batch_size": 4,
     },
-    "bloom-7b1": {
+    "bloom-7b1-fp16-deepspeed": {
+        "engine": "DeepSpeed",
         "option.task": "text-generation",
-        "option.model_id": "s3://djl-llm/bloom-7b1/"
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
+        "option.dtype": "fp16",
+        "option.rolling_batch": "deepspeed",
+    },
+    "bloom-7b1-bf16-deepspeed": {
+        "engine": "DeepSpeed",
+        "option.task": "text-generation",
+        "option.model_id": "s3://djl-llm/bloom-7b1/",
+        "option.dtype": "bf16",
+        "option.rolling_batch": "deepspeed",
+    },
+    "bloom-7b1-fp16-lmi-dist": {
+        "engine": "MPI",
+        "option.task": "text-generation",
+        "option.rolling_batch": "lmi-dist",
     },
     "gpt-neox-20b-fp16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/gpt-neox-20b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/gpt-neox-20b/",
+        "option.parallel_loading": "true",
+        "option.rolling_batch": "deepspeed",
     },
-    "gpt-neox-20b-fp16-huggingface": {
+    "gpt-neox-20b-fp16-lmi-dist": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/gpt-neox-20b/"
+        "engine": "MPI",
+        "option.model_id": "s3://djl-llm/gpt-neox-20b/",
+        "option.rolling_batch": "lmi-dist",
     },
     "gpt-neox-20b-bf16-deepspeed": {
         "option.task": "text-generation",
         "option.dtype": "bf16",
-        "option.engine": "deepspeed",
-        "option.model_id": "s3://djl-llm/gpt-neox-20b/"
-    },
-    "gpt-neox-20b-bf16-huggingface": {
-        "option.task": "text-generation",
-        "option.dtype": "bf16",
-        "option.engine": "huggingface",
-        "option.model_id": "s3://djl-llm/gpt-neox-20b/"
+        "engine": "DeepSpeed",
+        "option.model_id": "s3://djl-llm/gpt-neox-20b/",
+        "option.parallel_loading": "true",
+        "option.rolling_batch": "deepspeed",
     },
     "gpt-neox-20b-smoothquant": {
         "option.task": "text-generation",
         "option.dtype": "fp16",
-        "option.engine": "deepspeed",
+        "engine": "DeepSpeed",
         "option.model_id": "s3://djl-llm/gpt-neox-20b/",
         "option.quantize": "smoothquant",
-        "option.smoothquant_alpha": 0.65
+        "option.smoothquant_alpha": 0.65,
+        "option.rolling_batch": "deepspeed",
     }
 }
 
@@ -785,14 +802,12 @@ def build_performance_model(model):
     if options.get('option.dtype') is None:
         raise ValueError("Need to provide dtype for performance benchmark")
     options["option.tensor_parallel_degree"] = args.tensor_parallel
-    engine = options.get('option.engine')
+    engine = options.get('engine')
     if args.engine:
         engine = args.engine
+        options['engine'] = engine
     if engine is None:
         raise ValueError("Need to provide engine for performance benchmark")
-    for k, v in default_accel_configs[engine].items():
-        if k not in options:
-            options[k] = v
     write_model_artifacts(options)
 
 

--- a/tests/integration/profiles/bloom_7b1.json
+++ b/tests/integration/profiles/bloom_7b1.json
@@ -1,10 +1,8 @@
 {
 	"test_series":"performance",
-	"engine":["deepspeed","huggingface"],
-	"model": "bloom-7b1",
-	"dtype": ["fp16","bf16"],
+	"model": ["bloom-7b1-fp16-deepspeed","bloom-7b1-bf16-deepspeed", "bloom-7b1-fp16-lmi-dist"],
 	"tensor_parallel": 4,
-	"batch_size": 4,
+	"batch_size": 1,
 	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,

--- a/tests/integration/profiles/gpt_j_6b.json
+++ b/tests/integration/profiles/gpt_j_6b.json
@@ -1,8 +1,8 @@
 {
 	"test_series":"performance",
-	"model": ["gpt-j-6b-fp16-deepspeed", "gpt-j-6b-fp16-huggingface", "gpt-j-6b-bf16-deepspeed", "gpt-j-6b-bf16-huggingface", "gpt-j-6b-smoothquant"],
+	"model": ["gpt-j-6b-fp16-deepspeed", "gpt-j-6b-bf16-deepspeed", "gpt-j-6b-smoothquant"],
 	"tensor_parallel": 4,
-	"batch_size": 4,
+	"batch_size": 1,
 	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,

--- a/tests/integration/profiles/gpt_neox_20b.json
+++ b/tests/integration/profiles/gpt_neox_20b.json
@@ -1,8 +1,8 @@
 {
 	"test_series":"performance",
-	"model": ["gpt-neox-20b-fp16-deepspeed", "gpt-neox-20b-fp16-huggingface", "gpt-neox-20b-bf16-deepspeed", "gpt-neox-20b-bf16-huggingface", "gpt-neox-20b-smoothquant"],
+	"model": ["gpt-neox-20b-fp16-deepspeed", "gpt-neox-20b-fp16-lmi-dist", "gpt-neox-20b-bf16-deepspeed", "gpt-neox-20b-smoothquant"],
 	"tensor_parallel": 4,
-	"batch_size": 4,
+	"batch_size": 1,
 	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,

--- a/tests/integration/profiles/llama_13b.json
+++ b/tests/integration/profiles/llama_13b.json
@@ -1,8 +1,8 @@
 {
 	"test_series":"performance",
-	"model": ["open-llama-13b-fp16-deepspeed", "open-llama-13b-fp16-huggingface", "open-llama-13b-bf16-deepspeed", "open-llama-13b-bf16-huggingface", "open-llama-13b-smoothquant"],
+	"model": ["open-llama-13b-fp16-deepspeed", "open-llama-13b-fp16-lmi-dist", "open-llama-13b-bf16-deepspeed", "open-llama-13b-smoothquant"],
 	"tensor_parallel": 4,
-	"batch_size": 4,
+	"batch_size": 1,
 	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,

--- a/tests/integration/profiles/opt_30b.json
+++ b/tests/integration/profiles/opt_30b.json
@@ -1,10 +1,8 @@
 {
 	"test_series":"performance",
-	"engine":["deepspeed"],
-	"model": "opt-30b",
-	"dtype": ["fp16","bf16"],
+	"model": ["opt-30b-fp16-deepspeed", "opt-30b-bf16-deepspeed", "opt-30b-lmi-dist"],
 	"tensor_parallel": 4,
-	"batch_size": 4,
+	"batch_size": 1,
 	"in_tokens": [256, 512],
 	"out_tokens": 256,
 	"count": 10,


### PR DESCRIPTION
## Description ## 
- Removed the g5xl and removed huggingface testing. 
- Replaced huggingface testing with lmi dist test. 


## Testing 
Tested through running in our CI 
https://github.com/deepjavalibrary/djl-serving/actions/runs/7266944676 
Note that gptj failed because of lmi dist gptj is not supported in the above runner. `sharded is not supported for AutoModel` Lmidist work with non shared version though. So removed the gpt-j-lmi-dist for now. 
