### PR TITLE
[DLC][TNX] Freeze all aws-neuronx deps

### DIFF
--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -14,9 +14,9 @@ echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc
 curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 
 # https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#inf2-packages
-apt-get update -y && apt-get install -y aws-neuronx-dkms=2.14.* \
-    aws-neuronx-collectives=2.18.* \
-    aws-neuronx-runtime-lib=2.18.* \
-    aws-neuronx-tools=2.15.*
+apt-get update -y && apt-get install -y aws-neuronx-dkms=2.14.5.0 \
+    aws-neuronx-collectives=2.18.19.0* \
+    aws-neuronx-runtime-lib=2.18.15.0* \
+    aws-neuronx-tools=2.15.4.0
 
 export PATH=/opt/aws/neuron/bin:$PATH


### PR DESCRIPTION
## Description ##

Freeze the aws-neuronx dependencies down to the patch version. Collectives and runtime have hashes on the end of their version so I am taking the end of the collectives and runtimes as a *glob to get the correct hash.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
