### PR TITLE
[TNX][config] update rolling batch batch size behavior and docs

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -82,17 +82,18 @@ class TransformerNeuronXProperties(Properties):
         return rolling_batch
 
     @validator('batch_size')
-    def validate_batch_size(cls, batch_size, values):
+    def validate_batch_size(cls, batch_size: int, values) -> int:
         """
-        Transformer neuronx has both option.batch_size and batch_size.
-        option.batch_size is to compile the model with batch size, which cannot be
-        differentiated in neuronx handlers. Hence, just throwing a warning here.
+        Transformer neuronx supports batch_size, and max_rolling_batch_size.
+        The batch_size param is for dynamic batching, and max_rolling_batch_size is for rolling batch.
+        We validate here that the values are compatible and set for both compilation and inference.
         """
         if batch_size > 1:
-            if values['rolling_batch'] == RollingBatchEnum.disable and values[
-                    'enable_streaming'] != StreamingEnum.false:
-                logging.warning(
-                    "We cannot enable streaming for dynamic batching")
+            if values['rolling_batch'] != RollingBatchEnum.disable:
+                raise ValueError(
+                    "Dynamic batching and rolling batch cannot be enabled at the same time, please "
+                    "set either batch size or rolling batch with max_rolling_batch_size, but not both."
+                )
         return batch_size
 
     @validator('compiled_graph_path')

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -168,9 +168,18 @@ class TestConfigManager(unittest.TestCase):
                 TransformerNeuronXProperties(**common_properties, **properties)
             del properties['context_length_estimate']
 
+        def test_invalid_batch_sizes_rolling_batch():
+            rb_properties = {
+                **common_properties,
+                **properties, 'rolling_batch': "auto"
+            }
+            with self.assertRaises(ValueError):
+                TransformerNeuronXProperties(**rb_properties)
+
         test_url_not_s3_uri("https://random.url.address/")
         test_non_existent_directory("not_a_directory")
         test_invalid_context_length("invalid")
+        test_invalid_batch_sizes_rolling_batch()
 
     def test_trtllm_configs(self):
         properties = {

--- a/engines/python/setup/djl_python/tests/test_transformers_neuronx.py
+++ b/engines/python/setup/djl_python/tests/test_transformers_neuronx.py
@@ -79,6 +79,10 @@ class TestTransformerNeuronXService(unittest.TestCase):
     }, {
         "load_in_8bit": True
     }, {
+        "rolling_batch": "auto",
+        "batch_size": 1,
+        "max_rolling_batch_size": 4
+    }, {
         "model_id":
         "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"
     }, {
@@ -90,6 +94,8 @@ class TestTransformerNeuronXService(unittest.TestCase):
         expected = self.config_builder(test_properties)
         if expected.task is None:
             expected.task = "text-generation"
+        if expected.rolling_batch != "disable":
+            expected.batch_size = expected.max_rolling_batch_size
         model_loader_classes = [
             TNXModelLoader.__class__.__name__,
             OptimumModelLoader.__class__.__name__

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -53,6 +53,9 @@ class TransformersNeuronXService(object):
 
     def set_configs(self, properties):
         self.config = TransformerNeuronXProperties(**properties)
+        if self.config.rolling_batch != "disable":
+            """batch_size needs to match max_rolling_batch_size for precompiled neuron models running rolling batch"""
+            self.config.batch_size = self.config.max_rolling_batch_size
         self.model_config = AutoConfig.from_pretrained(
             self.config.model_id_or_path, revision=self.config.revision)
 

--- a/serving/docs/lmi/tuning_guides/tnx_tuning_guide.md
+++ b/serving/docs/lmi/tuning_guides/tnx_tuning_guide.md
@@ -10,7 +10,7 @@ The table below illustrates the recommended configurations for the most requeste
 | Llama2 13b (int8)	 | 13	              | inf2.xlarge	   | 2	                      | 4	                      | 512	         |
 | Llama2 13b	        | 26	              | inf2.24xlarge	 | 8	                      | 4	                      | 2048	        |
 
-**Current limitations:** Using the 2.15.0 release we are limited to `batch_size=4` as our max batch size when compiling using normal optimization flags. This can be increased to 8 by lowering the optimization level to 1 but this is a not a good solution. Currently, lower `tensor_parallel_degree` corresponds with significantly higher latency, so to improve latency by increasing the number of neuron cores that the model is split across. Both of these limitations are supposed to be addressed in the next release 2.16.0.
+**Current limitations:** Using the 2.15.2 release we are limited to `batch_size=4` / `max_rolling_batch_size=4` as our max batch size when compiling using normal optimization flags. This can be increased to 8 by lowering the optimization level to 1 but this is a not a good solution. Currently, lower `tensor_parallel_degree` corresponds with significantly higher latency, so to improve latency by increasing the number of neuron cores that the model is split across. Both of these limitations are supposed to be addressed in the next release 2.16.0.
 
 
 ## Configurations
@@ -23,10 +23,10 @@ inf2.xlarge
 engine=Python
 option.entryPoint=djl_python.transformers_neuronx
 option.model_id=llama-2-7b
-option.batch_size=4
 option.tensor_parallel_degree=2
 option.n_positions=2048
 option.rolling_batch=auto
+option.max_rolling_batch_size=4
 option.dtype=fp16
 option.model_loading_timeout=1600
 ```
@@ -37,10 +37,10 @@ inf2.24xlarge
 engine=Python
 option.entryPoint=djl_python.transformers_neuronx
 option.model_id=llama-2-7b
-option.batch_size=4
 option.tensor_parallel_degree=8
 option.n_positions=2048
 option.rolling_batch=auto
+option.max_rolling_batch_size=4
 option.dtype=fp16
 option.model_loading_timeout=1600
 ```
@@ -55,13 +55,13 @@ option.entryPoint=djl_python.transformers_neuronx
 option.model_id=llama-2-13b-split
 option.load_split_model=True
 option.compiled_graph_path=llama-2-13b-compiled
-option.batch_size=4
 option.tensor_parallel_degree=2
-option.load_in_8bit=true
+option.quantize=static_int8
 option.n_positions=2048
 option.rolling_batch=auto
+option.max_rolling_batch_size=4
 option.dtype=fp16
-option.model_loading_timeout=3600
+option.model_loading_timeout=1600
 ```
 
 inf2.24xlarge
@@ -70,12 +70,12 @@ inf2.24xlarge
 engine=Python
 option.entryPoint=djl_python.transformers_neuronx
 option.model_id=llama-2-13b
-option.batch_size=4
 option.tensor_parallel_degree=2
-option.load_in_8bit=true
+option.quantize=static_int8
 option.n_positions=512
 option.rolling_batch=auto
+option.max_rolling_batch_size=4
 option.dtype=fp16
-option.model_loading_timeout=3600
+option.model_loading_timeout=1600
 ```
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -348,8 +348,8 @@ transformers_neuronx_aot_handler_list = {
         "fp16",
         "option.model_loading_timeout":
         600,
-        "option.load_in_8bit":
-        True,
+        "option.quantize":
+        "static_int8",
         "option.enable_streaming":
         False,
         "option.save_mp_checkpoint_path":
@@ -360,7 +360,7 @@ transformers_neuronx_aot_handler_list = {
 transformers_neuronx_handler_list = {
     "gpt2": {
         "option.model_id": "gpt2",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
         "option.dtype": "fp16",
@@ -369,17 +369,17 @@ transformers_neuronx_handler_list = {
     },
     "gpt2-quantize": {
         "option.model_id": "gpt2",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600,
-        "option.load_in_8bit": True,
+        "option.quantize": "static_int8",
         "option.enable_streaming": False
     },
     "opt-1.3b": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
         "option.dtype": "fp16",
@@ -388,7 +388,7 @@ transformers_neuronx_handler_list = {
     },
     "gpt-j-6b": {
         "option.model_id": "s3://djl-llm/gpt-j-6b/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 8,
         "option.n_positions": 1024,
         "option.dtype": "fp32",
@@ -397,7 +397,7 @@ transformers_neuronx_handler_list = {
     },
     "pythia-2.8b": {
         "option.model_id": "s3://djl-llm/pythia-2.8b/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
         "option.dtype": "fp16",
@@ -406,7 +406,7 @@ transformers_neuronx_handler_list = {
     },
     "open-llama-7b": {
         "option.model_id": "s3://djl-llm/open-llama-7b/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
         "option.dtype": "fp16",
@@ -416,7 +416,7 @@ transformers_neuronx_handler_list = {
     },
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 256,
         "option.dtype": "fp16",
@@ -425,7 +425,7 @@ transformers_neuronx_handler_list = {
     },
     "llama-7b-split": {
         "option.model_id": "s3://djl-llm/llama-2-7b-split-inf2/split-model/",
-        "option.batch_size": 1,
+        "batch_size": 1,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
         "option.model_loading_timeout": 2400,
@@ -434,7 +434,7 @@ transformers_neuronx_handler_list = {
     },
     "llama2-7b": {
         "option.model_id": "s3://djl-llm/llama-2-7b-neuronx/",
-        "option.batch_size": 4,
+        "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp16",
         "option.n_positions": 2048,


### PR DESCRIPTION
## Description ##

This PR specifies the use of `batch_size` and `max_rolling_batch_size` in TNX properties. Specifically, this removes the need for `option.batch_size` for all but one case (batch size > 1 and streaming enabled). Tests and docs are updated to reflect the change.

One additional constraint was added to the properties, which is if `batch_size` > 1 and `rolling_batch` is enabled will now throw an error. This behavior should have existed previously, but due to being unable to differentiate `batch_size` and `option.batch_size` when setting properties, it was not detectable.

One warning that was previously thrown, was removed. Originally, a warning was thrown when `batch_size` > 1 and `enable_streaming` was enabled. Due to our inability to differentiate dynamic batching `batch_size` and `option.batch_size` this warning is erroneous.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
