### PR TITLE
[docs] update docs to use djl 0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ brew services stop djl-serving
 For Ubuntu
 
 ```
-curl -O https://publish.djl.ai/djl-serving/djl-serving_0.23.0-1_all.deb
-sudo dpkg -i djl-serving_0.23.0-1_all.deb
+curl -O https://publish.djl.ai/djl-serving/djl-serving_0.25.0-1_all.deb
+sudo dpkg -i djl-serving_0.25.0-1_all.deb
 ```
 
 For Windows
 
 We are considering to create a `chocolatey` package for Windows. For the time being, you can
-download djl-serving zip file from [here](https://publish.djl.ai/djl-serving/serving-0.23.0.zip).
+download djl-serving zip file from [here](https://publish.djl.ai/djl-serving/serving-0.25.0.zip).
 
 ```
-curl -O https://publish.djl.ai/djl-serving/serving-0.23.0.zip
-unzip serving-0.23.0.zip
+curl -O https://publish.djl.ai/djl-serving/serving-0.25.0.zip
+unzip serving-0.25.0.zip
 # start djl-serving
-serving-0.23.0\bin\serving.bat
+serving-0.25.0\bin\serving.bat
 ```
 
 ### Docker

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -43,25 +43,25 @@ sudo snap alias djlbench djl-bench
 - Or download .deb package from S3
 
 ```
-curl -O https://publish.djl.ai/djl-bench/0.23.0/djl-bench_0.23.0-1_all.deb
-sudo dpkg -i djl-bench_0.23.0-1_all.deb
+curl -O https://publish.djl.ai/djl-bench/0.25.0/djl-bench_0.25.0-1_all.deb
+sudo dpkg -i djl-bench_0.25.0-1_all.deb
 ```
 
 For macOS, centOS or Amazon Linux 2
 
-You can download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.23.0/benchmark-0.23.0.zip).
+You can download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.25.0/benchmark-0.25.0.zip).
 
 ```
-curl -O https://publish.djl.ai/djl-bench/0.23.0/benchmark-0.23.0.zip
-unzip benchmark-0.23.0.zip
-rm benchmark-0.23.0.zip
-sudo ln -s $PWD/benchmark-0.23.0/bin/benchmark /usr/bin/djl-bench
+curl -O https://publish.djl.ai/djl-bench/0.25.0/benchmark-0.25.0.zip
+unzip benchmark-0.25.0.zip
+rm benchmark-0.25.0.zip
+sudo ln -s $PWD/benchmark-0.25.0/bin/benchmark /usr/bin/djl-bench
 ```
 
 For Windows
 
 We are considering to create a `chocolatey` package for Windows. For the time being, you can
-download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.23.0/benchmark-0.23.0.zip).
+download djl-bench zip file from [here](https://publish.djl.ai/djl-bench/0.25.0/benchmark-0.25.0.zip).
 
 Or you can run benchmark using gradle:
 

--- a/engines/python/README.md
+++ b/engines/python/README.md
@@ -29,13 +29,13 @@ The javadocs output is generated in the `build/doc/javadoc` folder.
 ## Installation
 You can pull the Python engine from the central Maven repository by including the following dependency:
 
-- ai.djl.python:python:0.23.0
+- ai.djl.python:python:0.25.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.python</groupId>
     <artifactId>python</artifactId>
-    <version>0.23.0</version>
+    <version>0.25.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/serving/docker/README.md
+++ b/serving/docker/README.md
@@ -32,7 +32,7 @@ mkdir models
 cd models
 curl -O https://resources.djl.ai/test-models/pytorch/bert_qa_jit.tar.gz
 
-docker run -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.23.0
+docker run -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.25.0
 ```
 
 ### GPU
@@ -42,7 +42,7 @@ mkdir models
 cd models
 curl -O https://resources.djl.ai/test-models/pytorch/bert_qa_jit.tar.gz
 
-docker run -it --runtime=nvidia --shm-size 2g -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.26.0-pytorch-gpu
+docker run -it --runtime=nvidia --shm-size 2g -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.25.0-pytorch-gpu
 ```
 
 ### AWS Inferentia
@@ -52,5 +52,5 @@ mkdir models
 cd models
 
 curl -O https://resources.djl.ai/test-models/pytorch/resnet18_inf2_2_4.tar.gz
-docker run --device /dev/neuron0 -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.23.0-pytorch-inf2
+docker run --device /dev/neuron0 -it --rm -v $PWD:/opt/ml/model -p 8080:8080 deepjavalibrary/djl-serving:0.25.0-pytorch-inf2
 ```

--- a/wlm/README.md
+++ b/wlm/README.md
@@ -56,7 +56,7 @@ You can pull the server from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.serving</groupId>
     <artifactId>wlm</artifactId>
-    <version>0.23.0</version>
+    <version>0.25.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description ##

some of the docs were outdated - updating them to the correct djl versions
