### PR TITLE
[serving] Allows plugin to override default HTTP handler

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ServerInitializer.java
+++ b/serving/src/main/java/ai/djl/serving/ServerInitializer.java
@@ -76,8 +76,8 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
                 break;
             case BOTH:
             default:
-                pipeline.addLast("inference", new InferenceRequestHandler());
                 pipeline.addLast(new ConfigurableHttpRequestHandler(pluginManager));
+                pipeline.addLast("inference", new InferenceRequestHandler());
                 pipeline.addLast("management", new ManagementRequestHandler());
                 pipeline.addLast("management-adapter", new AdapterManagementRequestHandler());
                 break;


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
