### PR TITLE
[TNX] version update to 2.16.0 sdk and continuous batching

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -284,15 +284,15 @@ jobs:
           python3 llm/client.py transformers_neuronx llama-7b-split
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
-      - name: Test load optimum llama2 7B in handler
+      - name: Test mistral 7B with handler
         working-directory: tests/integration
         run: |
           rm -rf models
-          python3 llm/prepare.py transformers_neuronx llama2-7b
+          python3 llm/prepare.py transformers_neuronx mistral-7b
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-2 \
           serve
           curl http://127.0.0.1:8080/models
-          python3 llm/client.py transformers_neuronx llama2-7b
+          python3 llm/client.py transformers_neuronx mistral-7b
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
       - name: On fail step

--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -10,6 +10,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
+
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, Token, FINISH_REASON_MAPPER
 from djl_python.transformers_neuronx_scheduler.optimum_neuron_scheduler import NeuronGenerator
 
@@ -22,6 +23,7 @@ class NeuronRollingBatch(RollingBatch):
         :param model: the Neuron HuggingFace model
         :param batch_size: the maximum batch size required by model
         :param tokenizer: the tokenizer used by model
+        :param n_positions: the maximum sequence size for model
         """
         super().__init__(**kwargs)
         self.scheduler = NeuronGenerator(model, tokenizer, batch_size,

--- a/engines/python/setup/djl_python/tests/test_stable_diffusion_inf2.py
+++ b/engines/python/setup/djl_python/tests/test_stable_diffusion_inf2.py
@@ -17,8 +17,8 @@ from djl_python.tests.utils import parameterized, parameters, mock_import_module
 
 MOCK_MODULES = [
     "torch_neuronx", "transformers_neuronx", "transformers_neuronx.config",
-    "optimum", "optimum.neuron", "diffusers", "diffusers.models",
-    "diffusers.models.unet_2d_condition",
+    "transformers_neuronx.module", "optimum", "optimum.neuron", "diffusers",
+    "diffusers.models", "diffusers.models.unet_2d_condition",
     "diffusers.models.attention_processor"
 ]
 mock_import_modules(MOCK_MODULES)

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -46,8 +46,11 @@ class TransformersNeuronXService(object):
         if self.model_config.architectures is not None and any(
                 "CausalLM" in arch
                 for arch in self.model_config.architectures):
+            # Limit optimum model loading to implemented models listed in the constant above
             use_tnx = self.model_config.model_type not in OPTIMUM_CAUSALLM_MODEL_TYPES
-        use_tnx = use_tnx or self.config.load_split_model or self.config.load_in_8bit
+        # Limit optimum model loading from using non hf schema models or using non-implemented neuron configs
+        use_tnx = use_tnx or self.config.load_split_model or self.config.load_in_8bit or (
+            self.config.rolling_batch != "disable")
         if use_tnx:
             self._model_loader_class = TNXModelLoader
 

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -13,12 +13,12 @@ FROM ubuntu:20.04
 ARG djl_version=0.26.0~SNAPSHOT
 ARG torch_version=1.13.1
 ARG python_version=3.9
-ARG neuronsdk_version=2.15.2
+ARG neuronsdk_version=2.16.0
 ARG torch_neuronx_version=1.13.1.1.12.1
-ARG transformers_neuronx_version=0.8.268
-ARG neuronx_distributed_version=0.5.0
-ARG neuronx_cc_version=2.11.0.35
-ARG protobuf_version=3.20.3
+ARG transformers_neuronx_version=0.9.474
+ARG neuronx_distributed_version=0.6.0
+ARG neuronx_cc_version=2.12.54.0
+ARG protobuf_version=3.19.6
 ARG transformers_version=4.35.0
 ARG accelerate_version=0.23.0
 ARG diffusers_version=0.22.0

--- a/serving/docker/scripts/install_inferentia2.sh
+++ b/serving/docker/scripts/install_inferentia2.sh
@@ -6,7 +6,8 @@ apt-get update -y && apt-get install -y --no-install-recommends \
   curl \
   git \
   gnupg2 \
-  pciutils
+  pciutils \
+  udev
 
 # Configure Linux for Neuron repository updates
 . /etc/os-release
@@ -14,9 +15,12 @@ echo "deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main" >/etc
 curl -L https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | apt-key add -
 
 # https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#inf2-packages
-apt-get update -y && apt-get install -y aws-neuronx-dkms=2.14.5.0 \
-    aws-neuronx-collectives=2.18.19.0* \
-    aws-neuronx-runtime-lib=2.18.15.0* \
-    aws-neuronx-tools=2.15.4.0
+apt-get update -y && apt-get install -y aws-neuronx-collectives=2.19.7.0* \
+    aws-neuronx-runtime-lib=2.19.5.0* \
+    aws-neuronx-tools=2.16.1.0
+
+# TODO: Remove this hack after aws-neuronx-dkms install no longer throws an error, this bypasses the `set -ex`
+#       exit criteria. The package is installed and functional after running, just throws an error on install.
+apt-get install -y aws-neuronx-dkms=2.15.9.0 || echo "Installed aws-neuronx-dkms with errors"
 
 export PATH=/opt/aws/neuron/bin:$PATH

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -289,9 +289,9 @@ transformers_neuronx_model_spec = {
         "batch_size": [2],
         "stream_output": True,
     },
-    "llama2-7b": {
+    "mistral-7b": {
         "worker": 1,
-        "seq_length": [128, 256, 512],
+        "seq_length": [128, 256],
         "batch_size": [4],
     },
 }

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -449,14 +449,13 @@ transformers_neuronx_handler_list = {
         "option.load_split_model": True,
         "option.context_length_estimate": '256, 512, 1024'
     },
-    "llama2-7b": {
-        "option.model_id": "s3://djl-llm/llama-2-7b-neuronx/",
+    "mistral-7b": {
+        "option.model_id": "s3://djl-llm/mistral-7b/",
         "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.dtype": "fp16",
-        "option.n_positions": 2048,
+        "option.n_positions": 512,
         "option.model_loading_timeout": 2400,
-        "option.enable_streaming": False
     },
     "opt-1.3b-streaming": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",


### PR DESCRIPTION
## Description ##

Updates TNX container to 2.16.0
Adds mistral-7b test replacing redundant llama2-7b test
Adds continuous batching integration
Removed workaround functions that were fixed in TNX update and have been reimported `save_pretrained_split` as an example
Updated TNX unit tests for new model loader determinations when supporting continuous batching

Further needs:
 - continuous batching CI tests
 - future updates when optimum is compatible with 2.16.0
 - GQA and Llama2-70b testing and integration

**Note**: The change will break some precompiled models so downstream users of nightly builds should be informed
