### PR TITLE
Works with manual initialization

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyEngineProvider.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEngineProvider.java
@@ -20,7 +20,8 @@ public class PyEngineProvider implements EngineProvider {
 
     private static final String ENGINE_NAME = "Python";
 
-    private Engine engine;
+    private volatile Engine engine; // NOPMD
+    private volatile boolean initialized; // NOPMD
     protected boolean mpiMode;
 
     /** {@inheritDoc} */
@@ -38,10 +39,13 @@ public class PyEngineProvider implements EngineProvider {
     /** {@inheritDoc} */
     @Override
     public Engine getEngine() {
-        if (engine == null) {
+        if (!initialized) {
             synchronized (this) {
-                PyEnv.init();
-                engine = new PyEngine(getEngineName(), mpiMode);
+                if (!initialized) {
+                    initialized = true;
+                    PyEnv.init();
+                    engine = new PyEngine(getEngineName(), mpiMode);
+                }
             }
         }
         return engine;

--- a/serving/src/main/java/ai/djl/serving/plugins/DependencyManager.java
+++ b/serving/src/main/java/ai/djl/serving/plugins/DependencyManager.java
@@ -166,7 +166,9 @@ public final class DependencyManager {
         // refresh EngineProvider
         MutableClassLoader mcl = MutableClassLoader.getInstance();
         for (EngineProvider provider : ServiceLoader.load(EngineProvider.class, mcl)) {
-            Engine.registerEngine(provider);
+            if (!Engine.hasEngine(provider.getEngineName())) {
+                Engine.registerEngine(provider);
+            }
         }
 
         // refresh ZooProvider


### PR DESCRIPTION
This updates DJL Serving to follow the engine initialization standards set in https://github.com/deepjavalibrary/djl/pull/2885. First, it updates the PyEngineProvider to follow the EngineProvider conventions.

It also updates the DependencyManager, fixing some bugs that inspired https://github.com/deepjavalibrary/djl/pull/2934. The dependency manager before this change would always re-register the engine with a new provider. Beforehand, the engine was fully static and unable to re-initialize, so this would not accidentally re-initialize engines. After this, it would re-initialize engines that did not support it causing errors. Instead, it should only register new engines rather than all providers to avoid these accidental re-initialization.
