### PR TITLE
[vllm] pass hf revision to vllm engine, pin phi2 model revision for test

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -53,7 +53,8 @@ class VLLMRollingBatch(RollingBatch):
             max_rolling_batch_prefill_tokens,
             trust_remote_code=self.vllm_configs.trust_remote_code,
             load_format=self.vllm_configs.load_format,
-            quantization=self.vllm_configs.quantize)
+            quantization=self.vllm_configs.quantize,
+            revision=self.vllm_configs.revision)
         self.engine = LLMEngine.from_engine_args(args)
         self.request_cache = OrderedDict()
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -657,7 +657,8 @@ vllm_model_list = {
         "option.model_id": "microsoft/phi-2",
         "option.trust_remote_code": True,
         "option.tensor_parallel_degree": 4,
-        "option.max_rolling_batch_size": 4
+        "option.max_rolling_batch_size": 4,
+        "option.revision": "834565c23f9b28b96ccbeabe614dd906b6db551a",
     },
     "llama2-70b": {
         "option.model_id": "s3://djl-llm/llama-2-70b-hf/",


### PR DESCRIPTION
## Description ##

Fixes bug where user supplied revision was not passed to vllm engine.

Pin version of phi2 model in rolling batch test since latest changes in HF require transformers==4.37.0.dev0
