### PR TITLE
Fix trtllm check logic

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
@@ -93,6 +93,9 @@ public final class LmiUtils {
 
     static boolean isTrtLLM(ModelInfo<?, ?> info) {
         String rollingBatch = info.prop.getProperty("option.rolling_batch");
+	if ("trtllm".equals(rollingBatch)) {
+           return true;
+	}
         if (rollingBatch == null || "auto".equals(rollingBatch)) {
             // FIXME: find a better way to set default rolling batch for trtllm
             String features = Utils.getenv("SERVING_FEATURES");

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
@@ -93,9 +93,9 @@ public final class LmiUtils {
 
     static boolean isTrtLLM(ModelInfo<?, ?> info) {
         String rollingBatch = info.prop.getProperty("option.rolling_batch");
-	if ("trtllm".equals(rollingBatch)) {
-           return true;
-	}
+        if ("trtllm".equals(rollingBatch)) {
+            return true;
+        }
         if (rollingBatch == null || "auto".equals(rollingBatch)) {
             // FIXME: find a better way to set default rolling batch for trtllm
             String features = Utils.getenv("SERVING_FEATURES");


### PR DESCRIPTION
## Description ##

Fixes a bug introduced by https://github.com/deepjavalibrary/djl-serving/pull/1373 where if `trtllm` is specified as rolling_batch, it returns false for `isTrtLLM` check. 
