### PR TITLE
making default dtype to fp16 for compilation

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -52,7 +52,7 @@ class TransformerNeuronXProperties(Properties):
     """Transformer neuronx related configurations"""
     neuron_optimize_level: Optional[OptimizeLevel] = None
     enable_mixed_precision_accumulation: bool = False
-    dtype: Dtype = Dtype.f32
+    dtype: Dtype = Dtype.f16
     n_positions: int = 128
     unroll: Optional[str] = None
     load_in_8bit: Optional[bool] = False


### PR DESCRIPTION
## Description ##

Change Neuron default compilation dtype
