### PR TITLE
[ci] publish scheduled workflow failures to cloudwatch for monitoring

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -68,3 +68,9 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+  publish-success-metric:
+    needs: [ analyze ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-CodeQL-Failure

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -263,3 +263,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runner.outputs.cpu_instance_id }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runner ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-DockerNightlyPublish-Failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -276,3 +276,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.aarch64_instance_id }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-IntegrationTests-Failure

--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -382,3 +382,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.inf2_instance_id_2 }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-LLMIntegrationTests-INF2-Failure

--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -896,3 +896,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.gpu_instance_id_3 }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-LLMIntegrationTests

--- a/.github/workflows/llm_integration_p4d.yml
+++ b/.github/workflows/llm_integration_p4d.yml
@@ -261,3 +261,9 @@ jobs:
           cd /home/ubuntu/djl_benchmark_script/scripts
           instance_id=${{ needs.create-runners-p4d.outputs.p4d_instance_id }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners-p4d ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-LLMIntegrationTests-P4D

--- a/.github/workflows/lmic_performance.yml
+++ b/.github/workflows/lmic_performance.yml
@@ -230,3 +230,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.gpu_instance_id_2 }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-g5-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-LMIPerformanceTests-Failure

--- a/.github/workflows/nightly-docker-ecr-sync.yml
+++ b/.github/workflows/nightly-docker-ecr-sync.yml
@@ -63,3 +63,9 @@ jobs:
           cd /home/ubuntu/djl_benchmark_script/scripts
           instance_id=${{ needs.create-aarch64-runner.outputs.aarch64_instance_id }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-aarch64-runner ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-NightlyDockerECRSync-Failure

--- a/.github/workflows/publish-job-success.yml
+++ b/.github/workflows/publish-job-success.yml
@@ -1,0 +1,27 @@
+name: Publish Job Success Metric to CloudWatch
+
+on:
+  workflow_call:
+    inputs:
+      metric-name:
+        description: "The name of the job to publish a metric for"
+        type: string
+        required: true
+
+jobs:
+  publish-job-success-to-cloudwatch:
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+      - name: Publish Job Success Metric
+        run: |
+          [[ ${{ job.status }} == "success" ]]
+          failedBuild=$?
+          aws cloudwatch put-metric-data --namespace GithubCI \
+            --metric-name ${{ inputs.metric-name }} \
+            --value $failedBuild \
+            --unit Count

--- a/.github/workflows/rolling_batch_integration.yml
+++ b/.github/workflows/rolling_batch_integration.yml
@@ -532,3 +532,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.gpu_instance_id_2 }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-RollingBatchIntegrationTests-Failure

--- a/.github/workflows/sagemaker-integration.yml
+++ b/.github/workflows/sagemaker-integration.yml
@@ -161,3 +161,9 @@ jobs:
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.cpu_instance_id2 }}
           ./stop_instance.sh $instance_id
+
+  publish-success-metric:
+    needs: [ stop-runners ]
+    uses: ./.github/workflows/publish-job-success.yml
+    with:
+      metric-name: DJLServing-SageMakerIntegrationTests-Failure


### PR DESCRIPTION
## Description ##

Adds failure metrics for each of the scheduled workflows. This will allow us to create monitors/ticketing from the cloudwatch metrics. The ticketing helps alert the oncall sooner, and allows for investigations to be captured in the ticket itself.

Notes:
- Only publishes failures for scheduled runs. Manual runs of workflows will not result in metrics being published
- Uses our self-hosted runner because it's convenient for aws credentials
- Metric Names follow `DJLServing-<TestName>-Failure` format

I'll do the same thing for djl/djl-demo if we think it's useful
