### PR TITLE
[ci] fix action metric publish on failure

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -71,6 +71,7 @@ jobs:
 
   publish-success-metric:
     needs: [ analyze ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-CodeQL-Failure

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -266,6 +266,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runner ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-DockerNightlyPublish-Failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -279,6 +279,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-IntegrationTests-Failure

--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -385,6 +385,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-LLMIntegrationTests-INF2-Failure

--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -899,6 +899,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-LLMIntegrationTests

--- a/.github/workflows/llm_integration_p4d.yml
+++ b/.github/workflows/llm_integration_p4d.yml
@@ -264,6 +264,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners-p4d ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-LLMIntegrationTests-P4D

--- a/.github/workflows/lmic_performance.yml
+++ b/.github/workflows/lmic_performance.yml
@@ -233,6 +233,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-g5-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-LMIPerformanceTests-Failure

--- a/.github/workflows/nightly-docker-ecr-sync.yml
+++ b/.github/workflows/nightly-docker-ecr-sync.yml
@@ -66,6 +66,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-aarch64-runner ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-NightlyDockerECRSync-Failure

--- a/.github/workflows/rolling_batch_integration.yml
+++ b/.github/workflows/rolling_batch_integration.yml
@@ -535,6 +535,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-RollingBatchIntegrationTests-Failure

--- a/.github/workflows/sagemaker-integration.yml
+++ b/.github/workflows/sagemaker-integration.yml
@@ -164,6 +164,7 @@ jobs:
 
   publish-success-metric:
     needs: [ stop-runners ]
+    if: always()
     uses: ./.github/workflows/publish-job-success.yml
     with:
       metric-name: DJLServing-SageMakerIntegrationTests-Failure


### PR DESCRIPTION
## Description ##

Failed tests aren't publishing metrics - the calling step needs the `always()` condition even if the called workflow specifies a condition in order to run at all
