### PR TITLE
[CI][IB] Specify container through template

### DIFF
--- a/.github/workflows/instant_benchmark.yml
+++ b/.github/workflows/instant_benchmark.yml
@@ -3,10 +3,6 @@ name: instant benchmark tooling
 on:
   workflow_dispatch:
     inputs:
-      container:
-        description: 'The container used to run benchmark'
-        required: true
-        default: '0.23.0-deepspeed'
       running_template:
         description: 'A json file that contains benchmark plans'
         required: true
@@ -26,6 +22,10 @@ on:
           - inf2.24xlarge
           - trn1.2xlarge
           - trn1.32xlarge
+      container:
+        description: 'The container used to run benchmark (overrides the template). Should be a full docker path such as deepjavalibrary/djl-serving:0.25.0-deepspeed'
+        required: false
+        default: ''
       record:
         description: 'Whether to record the results'
         default: 'none'
@@ -82,10 +82,8 @@ jobs:
         working-directory: tests/integration
         id: generate_matrix
         run: |
-          python3 instant_benchmark.py --parse ${{ github.event.inputs.running_template }}
-      - name: Download container
-        run: |
-          docker pull deepjavalibrary/djl-serving:${{ github.event.inputs.container }}
+          python3 instant_benchmark.py --parse ${{ github.event.inputs.running_template }} \
+          --container "${{ github.event.inputs.container }}"
     outputs:
       jobs: ${{ steps.generate_matrix.outputs.jobs }}
       template: ${{ steps.generate_matrix.outputs.template }}
@@ -118,8 +116,8 @@ jobs:
         run: |
           echo "${{ needs.environment-setup.outputs.template }}" >> template.json
           python3 instant_benchmark.py --template template.json \
-          --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }} \
-          --container deepjavalibrary/djl-serving:${{ github.event.inputs.container }}
+          --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }}
+          
           bash instant_benchmark.sh
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -132,7 +130,6 @@ jobs:
         run: |
           python3 record_benchmark.py --template template.json \
           --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }} \
-          --container deepjavalibrary/djl-serving:${{ github.event.inputs.container }} \
           --model models/test --record ${{ github.event.inputs.record }}
       - name: Get serving logs
         if: always()

--- a/tests/integration/instant_benchmark.py
+++ b/tests/integration/instant_benchmark.py
@@ -159,7 +159,9 @@ def parse_raw_template(url, override_container):
             if override_container is not None and override_container != "":
                 container = override_container
             if container is None or container == "":
-                raise Exception("No container specified. Expected a container in either the job template, arg, or action")
+                raise Exception(
+                    "No container specified. Expected a container in either the job template, arg, or action"
+                )
             cur_result['container'] = container
             if info is not None:
                 cur_result['info'] = info


### PR DESCRIPTION
This allows including the container in the template. This can be useful for having multiple containers specified in the same template. Following this, only one template per instance type is needed. It is still possible to specify the container through the action, which now acts as an override. It also expands to support containers outside of the deepjavalibrary namespace.

Runs:
- No template container, override in action: https://github.com/deepjavalibrary/djl-serving/actions/runs/7674783679
- Template container, no override: https://github.com/deepjavalibrary/djl-serving/actions/runs/7674943363