### PR TITLE
Use server-provided seed if not in request params in deepspeed handler

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -387,6 +387,12 @@ class DeepSpeedService(object):
                             raise ValueError(
                                 "In order to enable dynamic batching, all input batches must have the same parameters"
                             )
+
+                if not "seed" in _param:
+                    # set server provided seed if seed is not part of request
+                    if item.contains_key("seed"):
+                        _param["seed"] = item.get_as_string(key="seed")
+
                 if not isinstance(_inputs, list):
                     _inputs = [_inputs]
                 input_data.extend(_inputs)


### PR DESCRIPTION
## Description ##

The same logic that was added to the huggingface handler for lmi_dist rolling batch in https://github.com/deepjavalibrary/djl-serving/pull/912 is needed in the deepspeed handler, too.

The current buggy behavior is that every request uses seed 0 if none is provided from user. Instead, we should use the server-provided seed when the request params do not include a specific seed.

I verified the fix by running a sequence of requests with the same prompt with concurrency 1, with no explicit seed, with do_sample=true, with and without this fix. Without the fix, all the outputs are exactly the same. After this fix, the outputs are all different, showing that they are now each seeded with a different value. With the fix, if I send the requests with explicit seed 0, I get the same result that I was getting before the fix.
