### PR TITLE
T5 support with python backend in TensorRT LLM

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/trt_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/trt_properties.py
@@ -14,7 +14,7 @@ from djl_python.properties_manager.properties import Properties, RollingBatchEnu
 from pydantic import validator
 
 TRT_SUPPORTED_ROLLING_BATCH_TYPES = [
-    RollingBatchEnum.auto.value, RollingBatchEnum.trtllm.value
+    RollingBatchEnum.auto.value, RollingBatchEnum.trtllm.value, RollingBatchEnum.disable.value
 ]
 
 
@@ -23,12 +23,6 @@ class TensorRtLlmProperties(Properties):
     @validator('rolling_batch', pre=True)
     def validate_rolling_batch(cls, rolling_batch: str) -> str:
         rolling_batch = rolling_batch.lower()
-
-        if rolling_batch == RollingBatchEnum.disable.value:
-            raise ValueError(
-                f"You cannot disable rolling batch for TensorRT LLM."
-                f"Kindly enable it with auto or tensorrt values to option.rolling_batch"
-            )
         if rolling_batch not in TRT_SUPPORTED_ROLLING_BATCH_TYPES:
             raise ValueError(
                 f"tensorrt llm only supports "

--- a/engines/python/setup/djl_python/properties_manager/trt_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/trt_properties.py
@@ -14,7 +14,8 @@ from djl_python.properties_manager.properties import Properties, RollingBatchEnu
 from pydantic import validator
 
 TRT_SUPPORTED_ROLLING_BATCH_TYPES = [
-    RollingBatchEnum.auto.value, RollingBatchEnum.trtllm.value, RollingBatchEnum.disable.value
+    RollingBatchEnum.auto.value, RollingBatchEnum.trtllm.value,
+    RollingBatchEnum.disable.value
 ]
 
 

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -23,6 +23,7 @@ from transformers import AutoConfig
 
 from djl_python.properties_manager.properties import is_rolling_batch_enabled
 
+
 class TRTLLMService(object):
 
     def __init__(self):
@@ -35,7 +36,8 @@ class TRTLLMService(object):
 
     def initialize(self, properties: dict):
         self.trt_configs = TensorRtLlmProperties(**properties)
-        self.enable_rolling_batch = is_rolling_batch_enabled(self.trt_configs.rolling_batch)
+        self.enable_rolling_batch = is_rolling_batch_enabled(
+            self.trt_configs.rolling_batch)
         self._read_model_config()
         self._load_model(properties)
         self.initialized = True
@@ -43,9 +45,10 @@ class TRTLLMService(object):
 
     def _load_model(self, properties):
         if self.model_config and self.model_config.model_type == "t5":
-            self.model = tensorrt_llm_toolkit.init_inference(self.trt_configs.model_id_or_path,
-                                                             **properties,
-                                                             use_python_backend=True)
+            self.model = tensorrt_llm_toolkit.init_inference(
+                self.trt_configs.model_id_or_path,
+                **properties,
+                use_python_backend=True)
         else:
             if not self.enable_rolling_batch:
                 raise ValueError(
@@ -53,7 +56,8 @@ class TRTLLMService(object):
                     f"Kindly enable it with auto or tensorrt values to option.rolling_batch"
                 )
             self.rolling_batch = TRTLLMRollingBatch(
-                self.trt_configs.model_id_or_path, None, properties, **properties)
+                self.trt_configs.model_id_or_path, None, properties,
+                **properties)
 
     def _read_model_config(self):
         try:

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -214,18 +214,12 @@ class TestConfigManager(unittest.TestCase):
             "model_dir": "model_dir",
         }
 
-        def test_trtllm_rb_disable():
-            properties['rolling_batch'] = 'disable'
-            with self.assertRaises(ValueError):
-                TensorRtLlmProperties(**properties)
-
         def test_trtllm_rb_invalid():
             properties['rolling_batch'] = 'lmi-dist'
             with self.assertRaises(ValueError):
                 TensorRtLlmProperties(**properties)
 
         test_trtllm_rb_invalid()
-        test_trtllm_rb_disable()
 
     def test_ds_properties(self):
         ds_properties = {


### PR DESCRIPTION
## Description ##

This PR is to support  t5 model with python backend of TRTLLM. 

serving.properties
```
option.model_id={t5-model}
option.entryPoint=djl_python.tensorrt_llm
option.rolling_batch=disable
```

There are a few things to be do, which will be done in other PRs.
1. To make JIT compilation for python backend
2. Infer entrypoint automatically for tensorrt llm
3. Log probs and other details for the generated text. 
4. Add integration test cases for t5 model
