### PR TITLE
[ci] remove partition steps for deepspeed/hf based models

### DIFF
--- a/tests/integration/llm/sagemaker-endpoint-tests.py
+++ b/tests/integration/llm/sagemaker-endpoint-tests.py
@@ -66,7 +66,6 @@ SINGLE_MODEL_ENDPOINT_CONFIGS = {
             "dtype": "fp32",
             "number_of_partitions": 1,
         },
-        "partition": True,
         "cls_to_use": HuggingFaceAccelerateModel,
     },
     "gpt-j-6b": {
@@ -76,7 +75,6 @@ SINGLE_MODEL_ENDPOINT_CONFIGS = {
             "tensor_parallel_degree": 2,
             "parallel_loading": True,
         },
-        "partition": True,
         "cls_to_use": DeepSpeedModel,
     },
     "pythia-12b": {
@@ -86,7 +84,6 @@ SINGLE_MODEL_ENDPOINT_CONFIGS = {
             "tensor_parallel_degree": 4,
             "parallel_loading": True,
         },
-        "partition": True,
         "partition_s3_uri": "s3://djl-llm-sm-endpoint-tests/pythia-12b-4p/",
         "cls_to_use": DeepSpeedModel,
     }


### PR DESCRIPTION
## Description ##

Removing partition testing for DeepSpeed models since we favor the fast loading mechanism for this engine. this should fix the issues we're seeing with the gpt-j-6b partition test (the issue will still exist for bf16, but we're considering it a low priority issue)
