### PR TITLE
[ci] move cw publish step to github hosted runner

### DIFF
--- a/.github/workflows/publish-job-success.yml
+++ b/.github/workflows/publish-job-success.yml
@@ -8,14 +8,19 @@ on:
     branches:
       - master
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish-job-success-to-cloudwatch:
     if: ${{ github.event.workflow_run.event == 'schedule' }}
-    runs-on: [ self-hosted, scheduler ]
+    runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
           aws-region: us-west-2
       - name: Publish Job Success Metric
         env:


### PR DESCRIPTION
## Description ##

The update to configure-aws-credentials@v4 action uses node@20, which requires a higher version of GLIBC than what is available on the self-hosted scheduler instance. See the error in DJL https://github.com/deepjavalibrary/djl/actions/runs/7734256003/job/21087916199.

Rather than updating that instance, I think we can use the ubuntu-latest runner with the iam role that has been configured with github OIDC.

I want to test this here in djl-serving first since we have the iam role setup in the expected manner for this repo. If it works, I'll replicate the roles for djl and djl-demo.
