### PR TITLE
[docs][lmi] updating structure for lmi docs

### DIFF
--- a/serving/docs/lmi_new/README.md
+++ b/serving/docs/lmi_new/README.md
@@ -1,0 +1,118 @@
+# Table of Contents
+- [Overview - Large Model Inference (LMI) Containers](#overview---large-model-inference-lmi-containers)
+- [QuickStart](#quickstart)
+  - [Sample Notebooks](#sample-notebooks)
+  - [Deployment Guide](#deployment-guide)
+- [Components of LMI](#components-of-lmi)
+- [Supported LMI Inference Libraries](#supported-lmi-inference-libraries)
+
+# Overview - Large Model Inference (LMI) Containers
+
+LMI containers are a set of high performance Docker Containers purpose built for large language model (LLM) inference. 
+With these containers you can leverage high performance inference libraries like [vLLM](), [TensorRT-LLM](), [DeepSpeed](), [Transformers NeuronX]() to deploy LLMs on [AWS SageMaker Endpoints](). 
+These containers bundle together a model server with open source inference libraries to deliver an all-in-one LLM serving solution.
+We provide quick start notebooks that get you deploying popular open source models in minutes, and advanced guides to maximize performance of your endpoint.
+
+LMI containers provide many features, including:
+* Optimized inference performance for popular model architectures like Llama, Bloom, Falcon, T5, Mixtral, and more
+* Integration with open source inference libraries like vLLM, TensorRT-LLM, DeepSpeed, and Transformers NeuronX
+* Continuous Batching for maximizing throughput at high concurrency
+* Token Streaming
+* Quantization through AWQ, GPTQ, and SmoothQuant
+* Multi GPU inference using Tensor Parallelism
+* Serving LoRA fine-tuned models
+
+## QuickStart
+
+### Using the SageMaker Python SDK to deploy your first model with LMI
+
+The [SageMaker Python SDK](https://github.com/aws/sagemaker-python-sdk) is our recommended way of deploying LLMs using LMI on SageMaker.
+
+Here is how you can deploy [TheBloke/Llama2-7b-fp16](https://huggingface.co/TheBloke/Llama-2-7B-fp16) model using LMI with the SDK:
+```python
+# Assumes SageMaker Python SDK is installed. For example: "pip install sagemaker"
+import sagemaker
+from sagemaker import image_uris, Model, Predictor
+from sagemaker.serializers import JSONSerializer
+from sagemaker.deserializers import JSONDeserializer
+
+# Setup role and sagemaker session
+iam_role = sagemaker.get_execution_role() 
+sagemaker_session = sagemaker.session.Session()
+region = sagemaker_session._region_name
+
+# Fetch the uri of the LMI DeepSpeed container that supports vLLM, LMI-Dist, and DeepSpeed
+container_image_uri = image_uris.retrieve(framework="djl-deepspeed", version="0.26.0", region=region)
+
+# Create the SageMaker Model object. In this example we'll use vLLM as our inference backend
+model = Model(
+  image_uri=container_image_uri,
+  role=iam_role,
+  env={
+    "HF_MODEL_ID": "TheBloke/Llama-2-7B-fp16",
+    "OPTION_TENSOR_PARALLEL_DEGREE": "max",
+    "OPTION_ROLLING_BATCH": "vllm",
+  }
+)
+
+# Deploy your model to a SageMaker Endpoint and create a Predictor to make inference requests
+endpoint_name = sagemaker.utils.name_from_base("llama-7b-endpoint")
+model.deploy(instance_type="ml.g5.2xlarge", initial_instance_count=1, endpoint_name=endpoint_name)
+predictor = Predictor(
+  endpoint_name=endpoint_name,
+  sagemaker_session=sagemaker_session,
+  serializer=JSONSerializer(),
+  deserializer=JSONDeserializer(),
+)
+
+# Make an inference request against the llama2-7b endpoint
+outputs = predictor.predict({
+  "inputs": "The diamondback terrapin was the first reptile to be",
+  "parameters": {
+    "do_sample": True,
+    "max_new_tokens": 256,
+  }
+})
+```
+
+### Sample Notebooks
+The following table provides notebooks that demonstrate how to deploy popular open source LLMs using LMI containers on SageMaker.
+If this is your first time using LMI, or you want a starting point for deploying a specific model, we recommend following the notebooks below.
+
+| Model                                                              | Instance Type      | Sample Notebook |
+|--------------------------------------------------------------------|--------------------|-----------------|
+| [Llama-2-7b](https://huggingface.co/meta-llama/Llama-2-7b-hf)      | `ml.g5.2xlarge`    | [notebook]()    |
+| [Llama-2-13b](https://huggingface.co/meta-llama/Llama-2-13b-hf)    | `ml.g5.12xlarge`   | [notebook]()    |
+| [Llama-2-70b](https://huggingface.co/meta-llama/Llama-2-70b-hf)    | `ml.p4d.24xlarge`  | [notebook]()    |
+| [Llama-2-70b-AWQ](https://huggingface.co/TheBloke/Llama-2-70B-AWQ) | `ml.g5.12xlarge`   | [notebook]()    |
+| [Mistral-7b](https://huggingface.co/mistralai/Mistral-7B-v0.1)     | `ml.g5.2xlarge`    | [notebook]()    |
+| [Mixtral-8x7b](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1) | `ml.p4d.24xlarge`  | [notebook]()    |
+| [Flan-T5-XXL](https://huggingface.co/google/flan-t5-xxl)           | `ml.g5.12xlarge`   | [notebook]()    |
+| [CodeLlama-34b](https://huggingface.co/codellama/CodeLlama-34b-hf) | `ml.g5.48xlarge`   | [notebook]()    |
+| [Falcon-7b](https://huggingface.co/tiiuae/falcon-7b)               | `ml.g5.2xlarge`    | [notebook]()    |
+| [Falcon-40b](https://huggingface.co/tiiuae/falcon-40b)             | `ml.g5.48xlarge`   | [notebook]()    |
+| [Falcon-180b](https://huggingface.co/tiiuae/falcon-180b)           | `ml.p4de.24xlarge` | [notebook]()    |            
+
+**Note: Some models in the table above are available from multiple providers. 
+We link to the specific model we tested with, but we expect same model from a different provider (or a fine-tuned variant) to work.**
+
+### Deployment Guide
+
+We have put together a comprehensive [deployment guide](deployment_guide.md) that takes you through the steps needed to deploy a model using LMI containers on SageMaker.
+The document covers the phases from storing your model artifacts through benchmarking your SageMaker endpoint.
+
+## Supported LMI Inference Libraries
+
+LMI Containers provide integration with multiple inference libraries.
+You can learn more about their integration with LMI from the respective user guides:
+* [DeepSpeed - User Guide](user_guides/deepspeed_user_guide.md)
+* [vLLM - User Guide](user_guides/vllm_user_guide.md)
+* [LMI-Dist - User Guide](user_guides/lmi-dist_user_guide.md)
+* [TensorRT-LLM - User Guide](user_guides/tensorrt-llm_user_guide.md)
+* [Transformers NeuronX - User Guide](user_guides/transformers-neuronx_user_guide.md)
+
+LMI provides access to multiple libraries to enable users to find the best stack for their model and use-case. 
+Each inference framework provides a unique set of features and optimizations that can be tuned for your model and use case.
+With LMIs built-in inference handlers and unified configuration, experimenting with different stacks is as simple as changing a few configurations.
+Refer to the stack specific user guides, and the [LMI deployment guide](deployment_guide.md) to learn more.
+An overview of the different LMI components is provided in the [deployment guide](deployment_guide/README.md#components-of-lmi)

--- a/serving/docs/lmi_new/deployment_guide/README.md
+++ b/serving/docs/lmi_new/deployment_guide/README.md
@@ -1,0 +1,59 @@
+# Steps for Deploying models with LMI Containers on AWS SageMaker
+
+The following document provides a step-by-step guide for deploying LLMs using LMI Containers on AWS SageMaker.
+This is an in-depth guide that will cover all phases from model artifacts through benchmarking your endpoint.
+If this is your first time using LMI, we highly recommend you start with one of our [example notebooks](../README.md#sample-notebooks) to get familiar with LMI and SageMaker.
+
+Before starting this tutorial, you should have the HuggingFace ModelId (e.g. `TheBloke/Llama-2-13b-fp16`) of the model you aim to deploy.
+If you have a custom model, it must be saved in the HuggingFace Transformers Pretrained format.
+You can read [this guide](model-artifacts.md) to verify your model is saved in the correct format for LMI.
+
+This guide is organized as follows:
+- [1. Instance Type Selection]()
+  - Pick a SageMaker instance type based on your model size and expected runtime usage 
+- [2. Container Selection](#2-container-selection)
+  - Pick a backend (vLLM, TensorRT-LLM, DeepSpeed, LMI-Dist, Transformers NeuronX) and corresponding container
+- [3. Model and Container Configurations](#3-container-and-model-configurations)
+  - Configure your setup for optimized performance based on your use-case 
+- [4. Deploying a SageMaker Endpoint](#4-deploying-a-sagemaker-endpoint)
+  - Deploy your setup to a SageMaker Endpoint 
+- [5. Benchmarking your setup](#5-benchmarking-your-endpoint)
+  - Benchmark your setup to determine whether additional tuning is needed
+- [6. Advanced Guides]()
+  - A collection of advanced guides to further tune your deployment
+
+Next: [Selecting an Instance Type](instance-type-selection.md)
+
+Below we provide an overview of the various components of LMI containers.
+We recommend reading this overview to become familiar with some of the LMI specific terminology like Backends and Built-In Handlers.
+
+## Components of LMI
+
+LMI containers bundle together a model server, LLM inference libraries, and inference handler code to deliver a batteries included LLM serving solution.
+Brief overviews of the components relevant to LMI are presented below.
+
+### Model Server
+LMI containers use [DJL Serving](https://github.com/deepjavalibrary/djl-serving) as the Model Server.
+A full architectural overview of DJL Serving is available [here](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docs/architecture.md).
+At a high level, DJL Serving consists of Netty front-end that manages request routing to the backend workers that execute inference for the target model.
+The backend manages model worker scaling, with each model being executed in an Engine.
+The Engine is an abstraction provided by DJL that you can think of as the interface that allows DJL to run inference for a model with a specific deep learning framework.
+In LMI, we use the Python Engine as it allows us to directly leverage the growing Python ecosystem of LLM inference libraries.
+
+### Python Engine and Inference Backends
+The Python Engine allows LMI containers to leverage many Python based inference libraries like vLLM, DeepSpeed, TensorRT-LLM, and Transformers NeuronX.
+These libraries expose Python APIs for loading and executing models with optimized inference on accelerators like GPUs and AWS Inferentia.
+LMI containers integrate the front-end model server with backend workers running Python processes to provide high performance inference of LLMs.
+
+To support multi-gpu inference of large models using model parallelism techniques like tensor parallelism, many of the inference libraries support distributed inference through MPI.
+LMI supports running the Python Engine in mpi mode (referred to as the MPI Engine) to leverage tensor parallelism in mpi aware libraries like DeepSpeed, LMI-Dist, and TensorRT-LLM.
+
+Throughout the LMI documentation, we will use the term `backend` to refer to a combination of Engine and Inference Library (e.g. MPI Engine + LMI-Dist library).
+
+### Built-In Handlers
+LMI provides built-in inference handlers for all the supported backend.
+These handlers take care of parsing configurations, loading the model onto accelerators, applying optimizations, and executing inference.
+These libraries expose features and capabilities through different APIs and mechanisms, so switching between frameworks to maximize performance can be difficult as you need to learn each framework individually.
+With LMI's built-in handlers, there is no need to learn each library and write custom code to leverage the features and optimizations they offer.
+We expose a unified configuration format that allows you to easily switch between libraries as they evolve and improve over time.
+As the ecosystem grows and new libraries become available, LMI can integrate them and offer the same consistent experience.

--- a/serving/docs/lmi_new/deployment_guide/backend-selection.md
+++ b/serving/docs/lmi_new/deployment_guide/backend-selection.md
@@ -1,0 +1,6 @@
+# Backend Selection
+
+TODO
+
+Next: [Container Configuration](configurations.md)
+Previous: [Instance Type Selection](instance-type-selection.md)

--- a/serving/docs/lmi_new/deployment_guide/benchmarking-your-endpoint.md
+++ b/serving/docs/lmi_new/deployment_guide/benchmarking-your-endpoint.md
@@ -1,0 +1,5 @@
+# Benchmarking your Endpoint
+
+TODO
+
+Previous: [Deploying your endpoint](deploying-your-endpoint.md)

--- a/serving/docs/lmi_new/deployment_guide/configurations.md
+++ b/serving/docs/lmi_new/deployment_guide/configurations.md
@@ -1,0 +1,6 @@
+## Container and Model Configurations
+
+TODO
+
+Next: [Deploying your endpoint](deploying-your-endpoint.md)
+Previous: [Backend Selection](backend-selection.md)

--- a/serving/docs/lmi_new/deployment_guide/deploying-your-endpoint.md
+++ b/serving/docs/lmi_new/deployment_guide/deploying-your-endpoint.md
@@ -1,0 +1,6 @@
+# Deploying your model on a SageMaker Endpoint
+
+TODO
+
+Next: [Benchmark your endpoint](benchmarking-your-endpoint.md)
+Previous: [Container Configurations](configurations.md)

--- a/serving/docs/lmi_new/deployment_guide/instance-type-selection.md
+++ b/serving/docs/lmi_new/deployment_guide/instance-type-selection.md
@@ -1,0 +1,95 @@
+# Instance Type Selection
+
+While there are many open source LLMs and architectures available, most models tend to fall within a few common parameter count sizes.
+The following table provides instance type recommendations for common model parameter counts using half-precision weights.
+
+| Model Parameter Count | Instance Type    | Accelerators | Aggregate Accelerator Memory | Sample Models                              | Estimated Max Batch Size Range |
+|-----------------------|------------------|--------------|------------------------------|--------------------------------------------|--------------------------------|
+| ~7 billion            | ml.g5.2xlarge    | 1 x A10G     | 24 GB                        | Llama2-7b, Falcon-7b, GPT-J-6B, Mistral-7b | 32-64                          |
+| ~13 billion           | ml.g5.12xlarge   | 4 x A10G     | 96GB                         | Llama2-13b, CodeLlama-13b, Flan-T5-XXL     | 32-64                          |
+| ~20 billion           | ml.g5.12xlarge   | 4 x A10G     | 96GB                         | GPT-NEOX-20b, Flan-Ul2                     | 16-32                          |
+| ~35 billion           | ml.g5.48xlarge   | 8 x A10G     | 192GB                        | CodeLlama-34b, Falcon-40b                  | 32-64                          |
+| ~70 billion           | ml.g5.48xlarge   | 8 x A10G     | 192GB                        | Llama2-70b, CodeLlama-70b                  | 1-8                            |
+| ~70 billion           | ml.p4d.24xlarge  | 8 x A100     | 320GB                        | Llama2-70b, CodeLlama-70b                  | 32-64                          |
+| ~180 billion          | ml.p4de.24xlarge | 8 x A100     | 640GB                        | Falcon-180b, Bloom-176B                    | 32-64                          |
+
+We recommend starting with the recommendations above.
+The estimated batch size is a conservative estimate.
+You will likely be able to increase the batch size beyond the recommendation, but that is dependent on your model and expected max sequence lengths (prompt + generation tokens).
+
+For a more in-depth instance type sizing guide, you can follow the steps below.
+
+Selecting an instance is based on a few factors:
+* Model Size
+* Desired Accelerators (A10, A100, H100, AWS Inferentia etc)
+    * We recommend using instances with at least A series gpus (g5/p4). The performance is much greater compared to older T series gpus
+    * You should select an instance that has sufficient aggregate memory (across all gpus) for both loading the model, and making requests at runtime
+* Desired Concurrency/Batch Size
+    *  Increasing Batch Size allows for more concurrent requests, but requires additional VRAM
+
+We will walk through a sizing example using the Llama2-13b model.
+
+## Model Size
+
+We can establish a lower bound for the required memory based on the model size.
+The model size is determined by the number of parameters, and the data type.
+We can quickly estimate the model size in GB using the number of parameters and data type like this:
+* Half Precision data type (fp16, bf16): `Size in GB = Number of Parameters * 2 (bytes / param)`
+* Full Precision data type (fp32): `Size in GB = Number of Parameters * 4 (bytes / param)`
+* 8-bit Quantized data type (int8): `Size in GB = Number of Parameters * 1 (bytes / param)`
+
+We recommend using a half precision data type as it requires less memory than full precision without losing accuracy for most cases.
+
+We estimate the Llama2-13b model to take `13 billion params * 2 bytes / param = 26GB` of memory.
+This is just the memory required to load the model.
+To execute inference, additional memory is required at runtime.
+
+## Additional Runtime Memory
+
+To estimate the additional memory required at runtime, we need to estimate the size of the KV cache.
+The KV cache can be thought of as the state of your model for a given generation loop.
+It stores the Key (K) and Value (V) states for each attention layer in your model.
+
+To estimate the size of the KV cache, we will use the following formula.
+
+`KV-Cache Size (bytes / token) = 2 * n_dtype * n_layers * n_hidden_size`
+
+Breaking down this formula:
+* 2 comes from the two matrices we need to cache: Key (K), and Value (V)
+* n_dtype represents the number of bytes per parameter, which is based on the data type (4 for fp32, 2 for fp16)
+* n_layers represents the number of transformer blocks in the model (usually `num_hidden_layers` in model's `config.json`)
+* n_hidden_size represents the dimension of the attention block (num_heads * d_head matrix) (usually `hidden_size` in model's `config.json`)
+
+For the Llama2-13b model, we get the kv-cache size per token as:
+* `2 * 2 * 5120 * 40 = 819,200 bytes/token = ~0.00082 GB / token`
+
+For a single max sequence (4096 tokens for the Llama2-13b model), we require `4096 token * 0.00082 GB / token = 3.36 GB`
+
+## Selecting an Instance Type
+
+Now that we know the memory required to load the model, and have an estimate of the runtime memory required per token, we can figure out what instance type to use.
+We recommend that you have an understanding of the max sequence length you will be operating with (prompt tokens + generation tokens).
+Alternatively, you can select an instance type and calculate and max batch size estimate based on the available memory.
+
+Please see this [link](https://aws.amazon.com/sagemaker/pricing/) for an up-to-date list of available instance types on SageMaker.
+
+For our Llama2-13b model, we need a minimum of 26GB.
+Let's consider two instances types: ml.g5.12xlarge, and ml.g5.48xlarge 
+
+On the ml.g5.12xlarge instance, we will have `96GB - 26GB = 66GB` available for batches of sequences at runtime.
+This would provide us enough memory for roughly 85,300 tokens at a time. This means we can have:
+* batch size of ~20 for maximum sequence length of 4096 tokens
+* batch size of ~40 for maximum sequence length of 2048 tokens
+* And so on
+
+On a ml.g5.48xlarge, we will have `192GB - 26GB = 166GB` available for batches of sequences at runtime
+This would provide us enough memory for roughly 202,400 tokens at runtime. This means we can have:
+* batch size of ~49 for maximum sequence length of 4096
+* batch size of ~98 for maximum sequence length of 2048
+
+This exercise demonstrates how to estimate the memory requirements of your model and use case in order to select an instance type.
+The calculations made are estimates, but should serve as a good starting point for testing. 
+Memory allocation behavior and memory optimization features differ between backends, so actual runtime memory usage will be different than what was derived above.
+We recommend testing your expected traffic against your setup for a specific instance type to determine the proper configuration.
+
+Next: [Backend Selection](backend-selection.md)

--- a/serving/docs/lmi_new/deployment_guide/model-artifacts.md
+++ b/serving/docs/lmi_new/deployment_guide/model-artifacts.md
@@ -1,0 +1,59 @@
+# Model Artifacts for LMI
+
+LMI Containers support deploying models with artifacts stored in either the HuggingFace Hub, or AWS S3.
+For models stored in the HuggingFace Hub you will need the model_id (e.g. [`meta-llama/Llama-2-13b-hf`](https://huggingface.co/meta-llama/Llama-2-13b-hf)).
+For models stored in S3 you will need the S3 uri for the object prefix of your model artifacts (e.g. `s3://my-bucket/my-model-artifacts/`).
+
+Model Artifacts must be in the HuggingFace Transformers pretrained format.
+
+## HuggingFace Transformers Pretrained Format
+
+LMI Containers support loading models saved in the HuggingFace Transformers pretrained format.
+This means that the model has been saved using the [`save_pretrained`](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.save_pretrained) method from HuggingFace Transformers, and is loadable using the [`from_pretrained`](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.save_pretrained) method.
+Most open source LLMs available on the HuggingFace Hub have been saved using this format and are compatible with LMI containers.
+LMI Containers only support loading HuggingFace models weights from PyTorch (pickle) or [SafeTensor](https://huggingface.co/docs/text-generation-inference/conceptual/safetensors) checkpoints.
+Most open source models available on the HuggingFace Hub offer checkpoints in at least one of these formats.
+
+In addition to the model artifacts, we expect that the tokenizer has been saved as part of the model artifacts and is loadable using the [`AutoTokenizer.from_pretrained`](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoTokenizer.from_pretrained) method.
+
+A sample of what the model and tokenizer artifacts looks like is shown below:
+```
+model/
+|- config.json (model configuration file with architecture details)
+|- model-000X-of-000Y.safetensors (safetensor checkpoint shard - large models will have multiple checkpoint shards)
+|- model.safetensors.index.json (safetensor weight mapping)
+|- pytorch_model-000X-of-000Y.bin (PyTorch pickle checkpoint shard - large models will have multiple checkpoint shards)
+|- pytorch_model.bin.index.json (PyTorch weight mapping)
+|- tokenizer_config.json (tokenizer configuration)
+|- special_tokens_map.json (special token mapping)
+|- tokenizer.json (tokenizer model)
+|- tokenizer.model (tokenizer model)
+```
+
+## Storing models in S3
+
+For custom models and production use-cases, we recommend that you store model artifacts in S3.
+
+If you want to use a model available from the huggingface hub, you can download the files locally with `git`:
+```shell
+# Make sure you have git-lfs installed (https://git-lfs.com)
+git lfs install
+git clone https://huggingface.co/<namespace>/<model>
+```
+
+With the model saved locally (either downloaded from the hub, or your own pretrained/fine-tuned model), upload it to S3:
+```shell
+# Assuming the model artifacts are stored in a directory called model/
+aws s3 cp model s3://my-model-bucket/model/ --recursive
+```
+
+## Compiled models (TensorRT-LLM, Transformers NeuronX)
+
+We recommend that you precompile models when using TensorRT-LLM or Transformers NeuronX in production to reduce the endpoint startup time.
+If HuggingFace Pretrained Model artifacts are provided to these backends, they will just-in-time (JIT) compile the model at runtime before it can be used for inference.
+This compilation process increases the endpoint startup time, especially as the model size grows.
+Please see the respective compilation guides for steps on how to compile your model for the given framework.
+* [TensorRT-LLM Compilation Guide]()
+* [Transformers NeuronX Compilation Guide]()
+
+Next: [Instance Type Selection](instance-type-selection.md)

--- a/serving/docs/lmi_new/user_guides/deepspeed_user_guide.md
+++ b/serving/docs/lmi_new/user_guides/deepspeed_user_guide.md
@@ -1,0 +1,9 @@
+# DeepSpeed Engine User Guide
+
+## Supported Model Architectures
+
+## Model Artifact Structure
+
+## Quick Start Configurations
+
+## Advanced Configurations

--- a/serving/docs/lmi_new/user_guides/lmi-dist_user_guide.md
+++ b/serving/docs/lmi_new/user_guides/lmi-dist_user_guide.md
@@ -1,0 +1,9 @@
+# LMI-Dist Engine User Guide
+
+## Supported Model Architectures
+
+## Model Artifact Structure
+
+## Quick Start Configurations
+
+## Advanced Configurations

--- a/serving/docs/lmi_new/user_guides/tensorrt-llm_user_guide.md
+++ b/serving/docs/lmi_new/user_guides/tensorrt-llm_user_guide.md
@@ -1,0 +1,9 @@
+# TensorRT-LLM Engine User Guide
+
+## Supported Model Architectures
+
+## Model Artifact Structure
+
+## Quick Start Configurations
+
+## Advanced Configurations

--- a/serving/docs/lmi_new/user_guides/transformers-neuronx_user_guide.md
+++ b/serving/docs/lmi_new/user_guides/transformers-neuronx_user_guide.md
@@ -1,0 +1,9 @@
+# Transformers NeuronX Engine User Guide
+
+## Supported Model Architectures
+
+## Model Artifact Structure
+
+## Quick Start Configurations
+
+## Advanced Configurations

--- a/serving/docs/lmi_new/user_guides/vllm_user_guide.md
+++ b/serving/docs/lmi_new/user_guides/vllm_user_guide.md
@@ -1,0 +1,9 @@
+# vLLM Engine User Guide
+
+## Supported Model Architectures
+
+## Model Artifact Structure
+
+## Quick Start Configurations
+
+## Advanced Configurations


### PR DESCRIPTION
## Description ##

This PR addes the structure for the new LMI documentation:
- Top Level ReadMe
- User Guides/
   - DeepSpeed, TRTLLM, vLLM, LMI-Dist, TNX
- Conceptual Guides/ 
   - Will contain things like quantization, rolling batch, tensor parallelism etc
- Deployment Guide/
   - Comprehensive guide intended for "advanced"/"thorough" users

We still need to review the specific content and iterate, but initial reviews have been good. 

This is ready to merge so that others can start adding the respective user-guides