### PR TITLE
[ci] Fix gpt-j timeout issues in inf2 integration

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -381,8 +381,7 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
         "option.dtype": "fp16",
-        "option.model_loading_timeout": 600,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 600
     },
     "gpt2-quantize": {
         "option.model_id": "gpt2",
@@ -391,8 +390,7 @@ transformers_neuronx_handler_list = {
         "option.n_positions": 512,
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600,
-        "option.quantize": "static_int8",
-        "option.enable_streaming": False
+        "option.quantize": "static_int8"
     },
     "opt-1.3b": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",
@@ -400,17 +398,15 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
         "option.dtype": "fp16",
-        "option.model_loading_timeout": 600,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 600
     },
     "gpt-j-6b": {
         "option.model_id": "s3://djl-llm/gpt-j-6b/",
         "batch_size": 4,
         "option.tensor_parallel_degree": 8,
-        "option.n_positions": 1024,
+        "option.n_positions": 512,
         "option.dtype": "fp32",
-        "option.model_loading_timeout": 900,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 1200
     },
     "pythia-2.8b": {
         "option.model_id": "s3://djl-llm/pythia-2.8b/",
@@ -418,8 +414,7 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
         "option.dtype": "fp16",
-        "option.model_loading_timeout": 900,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 900
     },
     "open-llama-7b": {
         "option.model_id": "s3://djl-llm/open-llama-7b/",
@@ -428,8 +423,7 @@ transformers_neuronx_handler_list = {
         "option.n_positions": 512,
         "option.dtype": "fp16",
         "option.neuron_optimize_level": 1,
-        "option.model_loading_timeout": 1200,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 1200
     },
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
@@ -437,8 +431,7 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 256,
         "option.dtype": "fp16",
-        "option.model_loading_timeout": 720,
-        "option.enable_streaming": False
+        "option.model_loading_timeout": 720
     },
     "llama-7b-split": {
         "option.model_id": "s3://djl-llm/llama-2-7b-split-inf2/split-model/",


### PR DESCRIPTION
## Description ##

Right sizing the compilation of the gpt-j model to compile faster for ci test, and expand the range of timeout for observed compilation time variance. Also removing redundant serving properties from our prepare.py script.
