### PR TITLE
remove a bit of unused code

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -19,21 +19,6 @@ class HFQuantizeMethods(str, Enum):
     bitsandbytes4 = 'bitsandbytes4'
     bitsandbytes8 = 'bitsandbytes8'
 
-    # TODO remove this after refactor of all handlers
-    # supported by vllm
-    awq = 'awq'
-
-
-LMI_DIST_ADV_MODEL = {
-    "RWForCausalLM",
-    "GPTNeoXForCausalLM",
-    "T5ForConditionalGeneration",
-    "LlamaForCausalLM",
-    "FalconForCausalLM",
-    "MPTForCausalLM",
-    "GPTBigCodeForCausalLM",
-}
-
 
 def get_torch_dtype_from_str(dtype: str):
     if dtype == "auto":


### PR DESCRIPTION
Please let me know if it is alright to remove this code now that it's not needed

This PR removes 2 things in hf_properties:
1) the awq value in the HFQuantizeMethods enum
2) LMI_DIST_ADV_MODEL, which has been moved to huggingface handler