### PR TITLE
dump OPTION_ env vars at startup

### DIFF
--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -451,6 +451,7 @@ public final class ConfigManager {
                     || key.startsWith("PYTHON")
                     || key.startsWith("DJL_")
                     || key.startsWith("HF_")
+                    || key.startsWith("OPTION_")
                     || key.contains("SAGEMAKER")
                     || "TENSOR_PARALLEL_DEGREE".equals(key)
                     || "OMP_NUM_THREADS".equals(key)


### PR DESCRIPTION
With the LMI changes to support all configs via `OPTION_` env vars, we should write those at startup similar to writing the other relevant environment variables to be consistent.
