### PR TITLE
change line in documentation examples (vllm serving.properties)

### DIFF
--- a/serving/docs/configurations_model.md
+++ b/serving/docs/configurations_model.md
@@ -176,7 +176,7 @@ max_batch_delay=1
 To enable rolling batch for Python engine:
 
 ```
-# lmi-dist and vllm requires running mpi mode
+# lmi-dist requires running mpi mode
 engine=MPI
 option.rolling_batch=auto
 # use FlashAttention


### PR DESCRIPTION
vllm backend does not use mpi engine