### PR TITLE
roll back enum changes

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -19,6 +19,10 @@ class HFQuantizeMethods(str, Enum):
     bitsandbytes4 = 'bitsandbytes4'
     bitsandbytes8 = 'bitsandbytes8'
 
+    # TODO remove this after refactor of all handlers
+    # supported by vllm
+    awq = 'awq'
+
 
 def get_torch_dtype_from_str(dtype: str):
     if dtype == "auto":


### PR DESCRIPTION
## Description ##

Rolls back part of #1536 temporarily to pass rolling batch integration tests.

To fix the root cause, it's necessary to determine whether we can change all tests involving vllm awq in tests/integration/llm/prepare.py to use Vllm Rolling batch instead. 

