### PR TITLE
[docker] map select tgi env vars to lmi env vars

### DIFF
--- a/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
+++ b/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
@@ -5,6 +5,16 @@ verlte() {
     [ "$1" = "$2" ] && return 1 || [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
 }
 
+# Takes 2 environment variables: SM/TGI env var name, LMI env var name
+# If SM/TGI env var is set, and LMI env var is unset, set LMI env var to SM/TGI env var value.
+translateTGIToLMI() {
+  local tgiVal="${!1}"
+  local lmiVal="${!2}"
+  if [ -n "$tgiVal" ]; then
+    export "$2"=${lmiVal:-$tgiVal}
+  fi
+}
+
 # Follow https://docs.aws.amazon.com/sagemaker/latest/dg/inference-gpu-drivers.html
 if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
     CUDA_COMPAT_MAX_DRIVER_VERSION=$(readlink /usr/local/cuda/compat/libcuda.so.1 |cut -d'.' -f 3-)
@@ -21,6 +31,15 @@ if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
 else
     echo "Skip CUDA compat libs setup as package not found"
 fi
+
+# Convert select SM/TGI Environment Variables to LMI Equivalents
+translateTGIToLMI "HF_MODEL_QUANTIZE" "OPTION_QUANTIZE"
+# We use HF_TRUST_REMOTE_CODE in our properties parsing
+translateTGIToLMI "HF_MODEL_TRUST_REMOTE_CODE" "HF_TRUST_REMOTE_CODE"
+translateTGIToLMI "SM_NUM_GPUS" "TENSOR_PARALLEL_DEGREE"
+translateTGIToLMI "MAX_CONCURRENT_REQUESTS" "SERVING_JOB_QUEUE_SIZE"
+translateTGIToLMI "MAX_BATCH_PREFILL_TOKENS" "OPTION_MAX_ROLLING_BATCH_PREFILL_TOKENS"
+translateTGIToLMI "MAX_BATCH_SIZE" "OPTION_MAX_ROLLING_BATCH_SIZE"
 
 if [[ "$1" = "serve" ]]; then
     shift 1


### PR DESCRIPTION
## Description ##

This PR adds support for mapping some TGI environment variables to equivalent LMI environment variables.

The set of environment variables may change based on more discussion, but this at least sets it up so we can add/remove from the list.

This change is only added to the deepspeed/trtllm containers, not NeuronX.

---
Tested locally with: ` docker run -it --runtime=nvidia -p 8080:8080 --shm-size=2g -e MODEL_ID=TheBloke/Llama-2-13b-fp16 -e SM_NUM_GPUS=max -e MAX_BATCH_SIZE=32 -e OPTION_MAX_ROLLING_BATCH_SIZE=64 deepjavalibrary/djl-serving:deepspeed`

Logs show:
```
Environment variables:
	HF_HUB_ENABLE_HF_TRANSFER: 1
	HF_HOME: /tmp/.cache/huggingface
	OPTION_MAX_ROLLING_BATCH_SIZE: 64
	OMP_NUM_THREADS: 1
	HF_MODEL_ID: TheBloke/Llama-2-13b-fp16
	OPTION_TENSOR_PARALLEL_DEGREE: max
	DJL_CACHE_DIR: /tmp/.djl.ai
```
