### PR TITLE
type hints and comments for trtllm handler

### DIFF
--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -46,15 +46,13 @@ class TRTLLMService(object):
         """
         Preprocessing function that extracts information from Input objects.
 
-        Args:
-            inputs (Input): a batch of inputs, each corresponding to a new request
+        :param inputs (Input): a batch of inputs, each corresponding to a new request
 
-        Returns:
-            input_data (list[str]): a list of strings, each string being the prompt in a new request
-            input_size (list[int]): a list of ints being the size of each new request
-            parameters (list[dict]): parameters pertaining to each request
-            errors (dict): a dictionary mapping int indices to corresponding error strings if any
-            batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
+        :return input_data (list[str]): a list of strings, each string being the prompt in a new request
+        :return input_size (list[int]): a list of ints being the size of each new request
+        :return parameters (list[dict]): parameters pertaining to each request
+        :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
+        :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
         """
         input_data = []
         input_size = []
@@ -93,11 +91,9 @@ class TRTLLMService(object):
         """
         Does preprocessing and sends new requests to the rolling batch script for inference
 
-        Args:
-            inputs (Input): a batch of inputs, each corresponding to a new request
+        :param inputs (Input): a batch of inputs, each corresponding to a new request
 
-        Returns:
-            outputs (Output): a batch of outputs that contain status code, output text, and other information
+        :return outputs (Output): a batch of outputs that contain status code, output text, and other information
         """
         outputs = Output()
 
@@ -143,11 +139,9 @@ def handle(inputs: Input) -> Output:
     """
     Handler function for the default TensorRT-LLM handler.
 
-    Args:
-        inputs (Input): a batch of inputs, each corresponding to a new request
+    :param inputs (Input): a batch of inputs, each corresponding to a new request
 
-    Returns:
-        outputs (Output): a batch of outputs that contain status code, output text, and other information.
+    :return outputs (Output): a batch of outputs that contain status code, output text, and other information.
     """
     if not _service.initialized:
         # stateful model

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -21,6 +21,11 @@ from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
 
 
 class TRTLLMService(object):
+    """
+    A TRTLLMService is an intermediary for the default TensorRT-LLM handler. Its functions are invoked to turn
+    Inputs into Outputs and it is responsible for sending new requests to the rolling batcher, which
+    calls TensorRT-LLM in the back-end.
+    """
 
     def __init__(self):
         self.initialized = False
@@ -35,7 +40,22 @@ class TRTLLMService(object):
         self.initialized = True
         return
 
-    def parse_input(self, inputs):
+    def parse_input(
+            self, inputs: Input
+    ) -> tuple[list[str], list[int], list[dict], dict, list]:
+        """
+        Preprocessing function that extracts information from Input objects.
+
+        Args:
+            inputs (Input): a batch of inputs, each corresponding to a new request
+
+        Returns:
+            input_data (list[str]): a list of strings, each string being the prompt in a new request
+            input_size (list[int]): a list of ints being the size of each new request
+            parameters (list[dict]): parameters pertaining to each request
+            errors (dict): a dictionary mapping int indices to corresponding error strings if any
+            batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
+        """
         input_data = []
         input_size = []
         parameters = []
@@ -69,7 +89,16 @@ class TRTLLMService(object):
 
         return input_data, input_size, parameters, errors, batch
 
-    def inference(self, inputs):
+    def inference(self, inputs: Input) -> Output:
+        """
+        Does preprocessing and sends new requests to the rolling batch script for inference
+
+        Args:
+            inputs (Input): a batch of inputs, each corresponding to a new request
+
+        Returns:
+            outputs (Output): a batch of outputs that contain status code, output text, and other information
+        """
         outputs = Output()
 
         input_data, input_size, parameters, errors, batch = self.parse_input(
@@ -110,9 +139,15 @@ class TRTLLMService(object):
 _service = TRTLLMService()
 
 
-def handle(inputs: Input):
+def handle(inputs: Input) -> Output:
     """
-    Default handler function
+    Handler function for the default TensorRT-LLM handler.
+
+    Args:
+        inputs (Input): a batch of inputs, each corresponding to a new request
+
+    Returns:
+        outputs (Output): a batch of outputs that contain status code, output text, and other information.
     """
     if not _service.initialized:
         # stateful model


### PR DESCRIPTION
## Description ##

Trial commit for type hints and code clarity.

Only works for Python 3.9 and newer - older type hints style that is compatible with 3.8 is deprecated soon. Please let me know if compatibility with 3.8 is a must.
