### PR TITLE
[docs] add deployment guide section for deploying model to endpoint

### DIFF
--- a/serving/docs/lmi_new/README.md
+++ b/serving/docs/lmi_new/README.md
@@ -51,7 +51,7 @@ model = Model(
   role=iam_role,
   env={
     "HF_MODEL_ID": "TheBloke/Llama-2-7B-fp16",
-    "OPTION_TENSOR_PARALLEL_DEGREE": "max",
+    "TENSOR_PARALLEL_DEGREE": "max",
     "OPTION_ROLLING_BATCH": "vllm",
   }
 )

--- a/serving/docs/lmi_new/deployment_guide/README.md
+++ b/serving/docs/lmi_new/deployment_guide/README.md
@@ -9,15 +9,15 @@ If you have a custom model, it must be saved in the HuggingFace Transformers Pre
 You can read [this guide](model-artifacts.md) to verify your model is saved in the correct format for LMI.
 
 This guide is organized as follows:
-- [1. Instance Type Selection]()
+- [1. Instance Type Selection](instance-type-selection.md)
   - Pick a SageMaker instance type based on your model size and expected runtime usage 
-- [2. Container Selection](#2-container-selection)
+- [2. Backend Selection](backend-selection.md)
   - Pick a backend (vLLM, TensorRT-LLM, DeepSpeed, LMI-Dist, Transformers NeuronX) and corresponding container
-- [3. Model and Container Configurations](#3-container-and-model-configurations)
-  - Configure your setup for optimized performance based on your use-case 
-- [4. Deploying a SageMaker Endpoint](#4-deploying-a-sagemaker-endpoint)
-  - Deploy your setup to a SageMaker Endpoint 
-- [5. Benchmarking your setup](#5-benchmarking-your-endpoint)
+- [3. Model and Container Configurations](configurations.md)
+  - Configure your model for optimized performance based on your use-case 
+- [4. Deploying a SageMaker Endpoint](deploying-your-endpoint.md)
+  - Deploy your model to a SageMaker Endpoint and make inference requests
+- [5. Benchmarking your setup](benchmarking-your-endpoint.md)
   - Benchmark your setup to determine whether additional tuning is needed
 - [6. Advanced Guides]()
   - A collection of advanced guides to further tune your deployment
@@ -30,6 +30,7 @@ We recommend reading this overview to become familiar with some of the LMI speci
 ## Components of LMI
 
 LMI containers bundle together a model server, LLM inference libraries, and inference handler code to deliver a batteries included LLM serving solution.
+The model server, inference libraries, and default inference handler code are brought together through a unified configuration that specifies your deployment setup.
 Brief overviews of the components relevant to LMI are presented below.
 
 ### Model Server
@@ -57,3 +58,13 @@ These libraries expose features and capabilities through different APIs and mech
 With LMI's built-in handlers, there is no need to learn each library and write custom code to leverage the features and optimizations they offer.
 We expose a unified configuration format that allows you to easily switch between libraries as they evolve and improve over time.
 As the ecosystem grows and new libraries become available, LMI can integrate them and offer the same consistent experience.
+
+### Configuration
+
+The configuration provided to LMI specifies your entire setup. The configuration covers many aspects including:
+* Where your model artifacts are stored (HuggingFace ModelId, S3 URI)
+* Model Server Configurations like job/request queue size, auto-scaling behavior for model workers, which engine to use (either Python or MPI for LMI)
+* Engine/Backend Configurations like whether to use quantization, input sequence limits, continuous batching size, tensor parallel degree, and more depending on the specific backend you use
+
+Configurations can be provided as either a `serving.properties` file, or through environment variables passed to the container.
+A more in-depth explanation about configurations is presented in the deployment guide in the [Container and Model Configurations](configurations.md) section.

--- a/serving/docs/lmi_new/deployment_guide/deploying-your-endpoint.md
+++ b/serving/docs/lmi_new/deployment_guide/deploying-your-endpoint.md
@@ -1,6 +1,150 @@
 # Deploying your model on a SageMaker Endpoint
 
-TODO
+We recommend using the SageMaker Python SDK to deploy your model on SageMaker. 
+Depending on which configuration format you are using (`serving.properties` file or environment variables), the steps are slightly different.
+You will need the following to deploy your model with LMI on SageMaker:
+* Model Artifacts (either HuggingFace Hub Model Id, or S3 URI pointing to model artifacts)
+* Instance Type
+* Container URI
+* Configuration File or Environment Variables
+
+## Configuration - serving.properties
+
+If your configuration is specified in a `serving.properties` file, we will need to upload this file to S3.
+If your model artifacts are also stored in S3, then you can either upload the `serving.properties` file under the same object prefix, or in a separate location.
+If you upload the `serving.properties` file under the same object prefix as your model artifacts, you should not specify `option.model_id` in the configuration.
+
+For example, your directory containing model artifacts and serving.properties may look like this (flat structure):
+
+```shell
+my-lmi-model/
+  - serving.properties
+  - config.json
+  - model-0001-of-0002.safetensors
+  - model-0002-of-0002.safetensors
+  - model.safetensors.index.json
+  - tokenizer.json
+  - tokenizer.model
+```
+
+If you upload the `serving.properties` to a different location than your model artifacts, make sure `option.model_id` points to the S3 URI of the object prefix (e.g. `option.model_id=s3://my-bucket/my-model-artifacts/`).
+
+Here is the sample code you can use to upload your configuration to s3:
+
+```shell
+# Assumes that the serving.properties file is stored in a local folder called my-lmi-model/
+# The my-lmi-model folder my also contain your model artifacts
+aws s3 sync ./my-lmi-model s3://my-bucket/my-lmi-model 
+```
+
+Here is the code to deploy your model on SageMaker using LMI:
+
+```python
+import sagemaker
+
+# Your IAM role that provides access to SageMaker and S3. 
+# See https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-ex-role.html if running on a SageMaker notebook
+iam_role = "my-sagemaker-role-arn"
+# manages interactions with the sagemaker apis
+sagemaker_session = sagemaker.session.Session()
+# region is needed to retrieve the lmi container
+region = sagemaker_session._region_name
+# get the lmi image uri
+# available frameworks: "djl-deepspeed" (for vllm, lmi-dist, deepspeed), "djl-tensorrtllm" (for tensorrt-llm), "djl-neuronx" (for transformers neuronx)
+container_uri = sagemaker.image_uris.retrieve(framework="djl-deepspeed", version="0.26.0", region=region)
+# create a unique endpoint name
+endpoint_name = sagemaker.utils.name_from_base("my-lmi-endpoint")
+# s3 uri object prefix under which the serving.properties and optional model artifacts are stored
+# This is how we can specify uncompressed model artifacts
+model_data = {
+    "S3DataSource": {
+        "S3Uri": "s3://my-bucket/my-lmi-model/",
+        'S3DataType': 'S3Prefix',
+        'CompressionType': 'None'
+    }
+} 
+# instance type you will deploy your model to
+instance_type = "ml.g5.12xlarge"
+
+# create your SageMaker Model
+model = sagemaker.Model(image_uri=container_uri, model_data=model_data, role=iam_role)
+# deploy your model
+model.deploy(
+    instance_type=instance_type,
+    initial_instance_count=1,
+    endpoint_name=endpoint_name,
+)
+
+# Get a predictor for your endpoint
+predictor = sagemaker.Predictor(
+    endpoint_name=endpoint_name,
+    sagemaker_session=sagemaker_session,
+    serializer=sagemaker.serializers.JSONSerializer(),
+    deserializer=sagemaker.deserializers.JSONDeserializer(),
+)
+
+# Make a prediction with your endpoint
+outputs = predictor.predict({
+    "inputs": "The meaning of life is", 
+    "parameters": {"do_sample": True, "max_new_tokens": 256}
+})
+```
+
+## Configuration - environment variables
+
+If you are using environment variables for configuration, you will need to pass those configurations to the SageMaker Model object.
+
+```python
+import sagemaker
+
+# Your IAM role that provides access to SageMaker and S3. 
+# See https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-ex-role.html if running on a SageMaker notebook
+iam_role = "my-sagemaker-role"
+# manages interactions with the sagemaker apis
+sagemaker_session = sagemaker.session.Session()
+# region is needed to retrieve the lmi container
+region = sagemaker_session._region_name
+# get the lmi image uri
+# available frameworks: "djl-deepspeed" (for vllm, lmi-dist, deepspeed), "djl-tensorrtllm" (for tensorrt-llm), "djl-neuronx" (for transformers neuronx)
+container_uri = sagemaker.image_uris.retrieve(framework="djl-deepspeed", version="0.26.0", region=region)
+# create a unique endpoint name
+endpoint_name = sagemaker.utils.name_from_base("my-lmi-endpoint")
+# instance type you will deploy your model to
+instance_type = "ml.g5.12xlarge"
+
+# create your SageMaker Model
+model = sagemaker.Model(
+    image_uri=container_uri, 
+    role=iam_role,
+    # specify all environment variable configs in this map
+    env={
+        "SERVING_LOAD_MODELS": "test::Python=/opt/ml/model",
+        "OPTION_MODEL_ID": "<huggingface hub model id or s3 uri>",
+        "OPTION_ROLLING_BATCH": "vllm",
+        "OPTION_TENSOR_PARALLEL_DEGREE": "max",
+    }
+)
+# deploy your model
+model.deploy(
+    instance_type=instance_type,
+    initial_instance_count=1,
+    endpoint_name=endpoint_name,
+)
+
+# Get a predictor for your endpoint
+predictor = sagemaker.Predictor(
+    endpoint_name=endpoint_name,
+    sagemaker_session=sagemaker_session,
+    serializer=sagemaker.serializers.JSONSerializer(),
+    deserializer=sagemaker.deserializers.JSONDeserializer(),
+)
+
+# Make a prediction with your endpoint
+outputs = predictor.predict({
+    "inputs": "The meaning of life is", 
+    "parameters": {"do_sample": True, "max_new_tokens": 256}
+})
+```
 
 Next: [Benchmark your endpoint](benchmarking-your-endpoint.md)
 Previous: [Container Configurations](configurations.md)


### PR DESCRIPTION
## Description ##

Adds guide for deployment (section 4 in deployment guide).

Doing this a bit out of order, but the remaining pieces in the deployment guide are:
- picking your container and backend
- configurations
- benchmarking
