### PR TITLE
Remove adapters preview flag

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -183,7 +183,6 @@ jobs:
         working-directory: tests/integration
         run: |
           rm -rf models
-          echo -en "ENABLE_ADAPTERS_PREVIEW=true" > docker_env
           python3 llm/prepare.py huggingface llama-7b-unmerged-lora
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
@@ -252,7 +251,6 @@ jobs:
         working-directory: tests/integration
         run: |
           rm -rf models
-          echo -en "ENABLE_ADAPTERS_PREVIEW=true" > docker_env
           python3 llm/prepare.py unmerged_lora llama-7b-unmerged-lora
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve
@@ -362,7 +360,6 @@ jobs:
         working-directory: tests/integration
         run: |
           rm -rf models
-          echo -en "ENABLE_ADAPTERS_PREVIEW=true" > docker_env
           python3 llm/prepare.py deepspeed gpt4all-lora
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
           serve

--- a/serving/docs/adapters.md
+++ b/serving/docs/adapters.md
@@ -1,6 +1,6 @@
 # Adapters
 
-**Note that this API is experimental and is subject to change. Using it requires the environment variable feature flag `ENABLE_ADAPTERS_PREVIEW`.**
+**Note that this API is experimental and is subject to change.
 
 DJL Serving has first class support for adapters.
 Adapters are patches or changes that can be made to a model to fine tune it for a particular usage.

--- a/serving/docs/adapters_api.md
+++ b/serving/docs/adapters_api.md
@@ -1,6 +1,6 @@
 # DJL Serving Adapters Management API
 
-**Note that this API is experimental and is subject to change. Using it requires the environment variable feature flag `ENABLE_ADAPTERS_PREVIEW`.**
+**Note that this API is experimental and is subject to change.
 
 DJL Serving provides a set of API allow user to manage adapters at runtime:
 

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -164,9 +164,6 @@ public class ModelServerTest {
         String engineCacheDir = Utils.getEngineCacheDir().toString();
         System.setProperty("DJL_CACHE_DIR", "build/cache");
         System.setProperty("ENGINE_CACHE_DIR", engineCacheDir);
-
-        // TODO Remove when removing the temporary feature flag
-        System.setProperty("ENABLE_ADAPTERS_PREVIEW", "true");
     }
 
     @AfterSuite

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -15,7 +15,6 @@ package ai.djl.serving.wlm;
 import ai.djl.inference.Predictor;
 import ai.djl.serving.wlm.WorkerPoolConfig.ThreadConfig;
 import ai.djl.serving.wlm.util.WorkerJob;
-import ai.djl.util.Utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,10 +51,6 @@ public abstract class Adapter {
      * @return the new adapter
      */
     public static Adapter newInstance(WorkerPoolConfig<?, ?> wpc, String name, String src) {
-        if (!Boolean.parseBoolean(Utils.getEnvOrSystemProperty("ENABLE_ADAPTERS_PREVIEW"))) {
-            throw new IllegalStateException("Adapters preview is not enabled");
-        }
-
         if (!(wpc instanceof ModelInfo)) {
             String modelName = wpc.getId();
             throw new IllegalArgumentException("The worker " + modelName + " is not a model");


### PR DESCRIPTION
This removes the adapters preview flag. The features still remain subject to change, but no longer require this additional step to enable.
