### PR TITLE
[serving] Ignore CUDA OOM when collecting metrics

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -872,7 +872,13 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         }
 
         if (device.isGpu()) {
-            MemoryUsage usage = CudaUtils.getGpuMemory(device);
+            MemoryUsage usage;
+            try {
+                usage = CudaUtils.getGpuMemory(device);
+            } catch (IllegalArgumentException | EngineException e) {
+                logger.warn("Failed to get GPU memory", e);
+                throw new WlmOutOfMemoryException("No enough memory to load the model."); // NOPMD
+            }
             free = usage.getMax() - usage.getCommitted();
             long gpuMem = intValue(prop, "gpu.reserved_memory_mb", -1) * 1024L * 1024;
             if (gpuMem > 0) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
