### PR TITLE
[serving] Adds rolling batch metrics

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
@@ -55,9 +55,7 @@ class PyPredictor<I, O> extends Predictor<I, O> {
                 model.getProperty("rolling_batch") != null
                         && !"disable".equals(model.getProperty("rolling_batch"));
         if (isRollingBatch) {
-            String outputFormatter = model.getProperty("output_formatter");
-            int maxRollingBatchSize = model.intProperty("max_rolling_batch_size", 32);
-            rollingBatch = new RollingBatch(process, maxRollingBatchSize, timeout, outputFormatter);
+            rollingBatch = new RollingBatch(process, model, timeout);
         }
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -268,6 +268,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                 builder.optOption("model_id", downloadDir.toAbsolutePath().toString());
             }
             ZooModel<I, O> m = builder.build().loadModel();
+            m.setProperty("endpoint_id", id);
 
             long duration = (System.nanoTime() - begin) / 1000;
             Metric metric = new Metric("LoadModel", duration, Unit.MICROSECONDS);


### PR DESCRIPTION
- **Revert "[python] Buffer tokens for rolling batch (#1249)"**
- **[serving] Adds rolling batch metrics**

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
