### PR TITLE
[CI] replace chatglm with s3 model

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -760,7 +760,7 @@ trtllm_handler_list = {
         "option.trust_remote_code": True
     },
     "chatglm3-6b": {
-        "option.model_id": "THUDM/chatglm3-6b",
+        "option.model_id": "s3://djl-llm/chatglm3-6b/",
         "option.tensor_parallel_degree": 4,
         "option.output_formatter": "jsonlines",
         "option.trust_remote_code": True,


### PR DESCRIPTION
This may fix the CI error caused by possibly an unfinished download.