### PR TITLE
[lmi] add parameter to allow full text including prompt to be returne…

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -62,7 +62,7 @@ def _json_output_formatter(token: Token, first_token: bool, last_token: bool,
 
     :return: formatted output
     """
-    json_encoded_str = f"{{\"generated_text\": \"" if first_token else ""
+    json_encoded_str = f"{{\"generated_text\": \"{generated_tokens}" if first_token else ""
     json_encoded_str = f"{json_encoded_str}{json.dumps(token.text, ensure_ascii=False)[1:-1]}"
     if last_token:
         if details:
@@ -123,6 +123,8 @@ class Request(object):
         self.generated_tokens = []
         if parameters.pop("details", False):
             self.token_cache = []
+        self.full_text_prefix = input_text if parameters.pop(
+            "return_full_text", False) else ""
         # spec_dec
         self.step_token_number = 0
 
@@ -155,9 +157,9 @@ class Request(object):
         self.step_token_number = len(
             next_token.id) if next_token.id[0] != -1 else -1
         details = {}
-        generated_text = None
+        generated_text = self.full_text_prefix
         if last_token:
-            generated_text = ''.join(self.generated_tokens)
+            generated_text = generated_text + ''.join(self.generated_tokens)
             if self.token_cache is not None:
                 details["finish_reason"] = finish_reason
                 details["tokens"] = self.token_cache

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -54,6 +54,47 @@ class TestRollingBatch(unittest.TestCase):
             "generated_text": "Hello world"
         }
 
+    def test_return_full_text(self):
+        req = Request(0, "This is a wonderful day", {
+            "max_new_tokens": 256,
+            "return_full_text": True,
+        })
+
+        final_str = []
+        req.set_next_token(Token(244, "He", -0.334532), _json_output_formatter)
+        final_str.append(req.get_next_token())
+        req.set_next_token(Token(576, "llo", -0.123123),
+                           _json_output_formatter)
+        final_str.append(req.get_next_token())
+        req.set_next_token(Token(4558, " world", -0.567854),
+                           _json_output_formatter, True, 'length')
+        final_str.append(req.get_next_token())
+        final_json = json.loads(''.join(final_str))
+        print(final_json, end='')
+        assert final_json == {
+            "generated_text": "This is a wonderful dayHello world",
+        }
+
+        req = Request(0, "This is a wonderful day", {
+            "max_new_tokens": 256,
+            "return_full_text": True
+        })
+        req.set_next_token(Token(244, "He", -0.334532),
+                           _jsonlines_output_formatter)
+        req.set_next_token(Token(576, "llo", -0.123123),
+                           _jsonlines_output_formatter)
+        req.set_next_token(Token(4558, " world", -0.567854),
+                           _jsonlines_output_formatter, True, 'length')
+        print(req.get_next_token(), end='')
+        assert json.loads(req.get_next_token()) == {
+            "token": {
+                "id": [4558],
+                "text": " world",
+                "log_prob": -0.567854
+            },
+            "generated_text": "This is a wonderful dayHello world",
+        }
+
     def test_details(self):
         req = Request(0, "This is a wonderful day", {
             "max_new_tokens": 256,

--- a/serving/docs/lmi/lmi_input_output_schema.md
+++ b/serving/docs/lmi/lmi_input_output_schema.md
@@ -57,6 +57,7 @@ When providing inputs following the input schema as a string, the output's gener
     'top_p' : float (default= 1.0),
     'max_new_tokens' : integer (default = 30),
     'details' : boolean (default = false, details only available for rolling batch),
+    'return_full_text': boolean (default = false),
 ```
 
 Note: For TensorRTLLM handler, it also has all the common parameters, but it uses different default values. Kindly check below to know the TensorRT LLM default values. 


### PR DESCRIPTION
…d in generated response

## Description ##

In non rolling batch use-cases, the default generation api from huggingface will by default prepend the prompt to the generated responses.

In rolling batch use-cases, we only return the generated text. This could be considered a regression from the standard dynamic batch use-case behavior. 

This PR adds a parameter, `return_full_text`, that allows users to retrieve the full response including prompt/input string. This parameter is available in the transformers generation api, as well as tgi.

By default, `return_full_text` is false to maintain the same behavior we currently have in LMI.
