### PR TITLE
[Partition] Remove redudant model splitting, Improve Input Model Parsing

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -301,7 +301,6 @@ class TNXModelLoader(ModelLoader):
         self.model_config.save_pretrained(save_path)
         self.model = self.load_hf_model()
         self.load_path = self.get_load_path()
-        save_pretrained_split(self.model, self.load_path)
         self.model = self.load_inf2_model_from_disk()
         shutil.copytree(self.load_path, self.split_model_path)
 

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -61,7 +61,8 @@ class PropertiesManager(object):
             model_files = glob.glob(os.path.join(model_dir, '.safetensors'))
             if not model_files:
                 raise ValueError(
-                    f'No .bin or .safetensors files found in the dir: {model_dir}')
+                    f'No .bin or .safetensors files found in the dir: {model_dir}'
+                )
         elif 'option.model_id' in self.properties:
             self.properties['model_dir'] = self.properties_dir
         elif 'option.s3url' in self.properties:
@@ -71,12 +72,14 @@ class PropertiesManager(object):
             self.properties.pop('option.s3url')
         else:
             model_files = glob.glob(os.path.join(self.properties_dir, '*.bin'))
-            model_files = glob.glob(os.path.join(self.properties_dir, '*.safetensors'))
+            model_files = glob.glob(
+                os.path.join(self.properties_dir, '*.safetensors'))
             if model_files:
                 self.properties['model_dir'] = self.properties_dir
             else:
-                raise ValueError(f'No .bin or .safetensors files found in the dir: {self.properties_dir}'
-                                 '\nPlease specify the model_dir or model_id')
+                raise ValueError(
+                    f'No .bin or .safetensors files found in the dir: {self.properties_dir}'
+                    '\nPlease specify the model_dir or model_id')
 
     def validate_and_correct_checkpoints_json(self):
         """

--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -58,9 +58,10 @@ class PropertiesManager(object):
         if 'model_dir' in self.properties:
             model_dir = self.properties['model_dir']
             model_files = glob.glob(os.path.join(model_dir, '*.bin'))
+            model_files = glob.glob(os.path.join(model_dir, '.safetensors'))
             if not model_files:
                 raise ValueError(
-                    f'No .bin files found in the dir: {model_dir}')
+                    f'No .bin or .safetensors files found in the dir: {model_dir}')
         elif 'option.model_id' in self.properties:
             self.properties['model_dir'] = self.properties_dir
         elif 'option.s3url' in self.properties:
@@ -70,10 +71,12 @@ class PropertiesManager(object):
             self.properties.pop('option.s3url')
         else:
             model_files = glob.glob(os.path.join(self.properties_dir, '*.bin'))
+            model_files = glob.glob(os.path.join(self.properties_dir, '*.safetensors'))
             if model_files:
                 self.properties['model_dir'] = self.properties_dir
             else:
-                raise ValueError('Please specify the model_dir or model_id')
+                raise ValueError(f'No .bin or .safetensors files found in the dir: {self.properties_dir}'
+                                 '\nPlease specify the model_dir or model_id')
 
     def validate_and_correct_checkpoints_json(self):
         """


### PR DESCRIPTION
## Description ##

This PR includes 2 changes

1. Removed a redundant call to save_pretrained_split in TNXModelLoader partition(). Previously it was called in partition() and then called again in load_inf2_model_from_disk(). We retain only the call in load_inf2_model_from_disk().
     - This was tested with llama-2-7b, reduced partitioning time from 13 min to 9 min (inf2.48xlarge, 6 neuron cores exposed to container, compiler cache populated for both runs)

3. Improved the error handling of the partition PropertiesManager. Previously, this checked if any .bin files existed in the model artifacts, if not, partitioning would fail. Now, we check for .bin OR .safetensors files, allowing users to pass in models that only have .safetensors files without erros.

cc: @tosterberg 
