### PR TITLE
[serving] Skip testPrometheusMetrics when run in IDE

### DIFF
--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -243,7 +243,9 @@ public class ModelServerTest {
             testAsyncInference(channel);
             testDjlModelZoo(channel);
             testConfigLogging(channel);
-            testPrometheusMetrics(channel);
+            if (Boolean.parseBoolean(Utils.getEnvOrSystemProperty("SERVING_PROMETHEUS"))) {
+                testPrometheusMetrics(channel);
+            }
 
             testPredictionsInvalidRequestSize(channel);
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
