### PR TITLE
[CVE][Build] Pins huggingface-hub to fix pip dependency resolution failure

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -36,7 +36,8 @@ ARG diffusers_version=0.16.0
 ARG bitsandbytes_version=0.41.1
 ARG optimum_version=1.13.2
 ARG auto_gptq_version=0.4.2
-ARG datasets_version=2.17.1
+ARG datasets_version=2.14.7
+ARG huggingface_hub_version=0.17.3
 
 EXPOSE 8080
 
@@ -81,7 +82,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-
 
 RUN pip3 install torch==${torch_version} torchvision==${torch_vision_version} --extra-index-url https://download.pytorch.org/whl/cu118 \
     ${deepspeed_wheel} ${seq_scheduler_wheel} ${peft_wheel} ${mmaploader_wheel} ${aiccl_wheel} protobuf==${protobuf_version} \
-    transformers==${transformers_version} zstandard datasets==${datasets_version} \
+    transformers==${transformers_version} zstandard datasets==${datasets_version} huggingface-hub==${huggingface_hub_version} \
     mpi4py sentencepiece einops accelerate==${accelerate_version} bitsandbytes==${bitsandbytes_version} \
     optimum==${optimum_version} auto-gptq==${auto_gptq_version} pandas pyarrow \
     diffusers[torch]==${diffusers_version} opencv-contrib-python-headless safetensors scipy && \


### PR DESCRIPTION
## Description ##

Failure during container rebuild: https://github.com/deepjavalibrary/djl-serving/actions/runs/8207124712/job/22447771144#step:12:2588

The following 2 changes fix the dependency issue. Verified that this works locally on branch `0.25.0` by running `docker compose build deepspeed`

* Pinning version of `huggingface-hub` to be the same as the current DLC version
```
$ docker run --rm -it 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.25.0-deepspeed0.11.0-cu118 pip show huggingface-hub
Name: huggingface-hub
Version: 0.17.3
Summary: Client library to download and publish models, datasets and other repos on the huggingface.co hub
Home-page: https://github.com/huggingface/huggingface_hub
Author: Hugging Face, Inc.
Author-email: julien@huggingface.co
License: Apache
Location: /usr/local/lib/python3.9/dist-packages
Requires: filelock, fsspec, packaging, pyyaml, requests, tqdm, typing-extensions
Required-by: accelerate, datasets, diffusers, optimum, tokenizers, transformers
```

* Reverting #1566 and decrementing `datasets==2.14.7` [[release notes](https://github.com/huggingface/datasets/releases/tag/2.14.7)] which is >2.14.5 and has the CVE fix.

```
$ docker run --rm -it 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.25.0-deepspeed0.11.0-cu118 pip show datasets
Name: datasets
Version: 2.14.5
Summary: HuggingFace community-driven open-source library of datasets
Home-page: https://github.com/huggingface/datasets
Author: HuggingFace Inc.
Author-email: thomas@huggingface.co
License: Apache 2.0
Location: /usr/local/lib/python3.9/dist-packages
Requires: aiohttp, dill, fsspec, huggingface-hub, multiprocess, numpy, packaging, pandas, pyarrow, pyyaml, requests, tqdm, xxhash
Required-by: auto-gptq, optimum
```

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
