### PR TITLE
[Build] Pins datasets version to fix pip dependency resolution failure

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -35,7 +35,7 @@ ARG diffusers_version=0.16.0
 ARG bitsandbytes_version=0.41.1
 ARG optimum_version=1.13.2
 ARG auto_gptq_version=0.4.2
-ARG datasets_version=2.17.1
+ARG datasets_version=2.14.7
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Description ##

See #1614

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
