### PR TITLE
Single model adapter API

### DIFF
--- a/serving/docs/adapters_api.md
+++ b/serving/docs/adapters_api.md
@@ -16,7 +16,6 @@ This is an extension of the [Management API](management_api.md) and can be acces
 ### Register an adapter
 
 `POST /models/{modelName}/adapters`
-`POST /adapters` (only for single model use case)
 
 * name - The adapter name.
 * src - The adapter src. It currently requires a file, but eventually an id or URL can be supported depending on the model handler.
@@ -32,7 +31,6 @@ curl -X POST "http://localhost:8080/models/adaptecho/adapters?name=a1&src=..."
 ### Describe adapter
 
 `GET /models/{model_name}/adapters/{adapter_name}`
-`GET /adapters/{adapter_name}` (only for single model use case)
 
 Use the Describe Adapter API to get the status of an adapter:
 
@@ -50,7 +48,6 @@ curl http://localhost:8080/models/adaptecho/adapters/a1
 ### Unregister an adapter
 
 `DELETE /models/{model_name}/adapters/{adapter_name}`
-`DELETE /adapters/{adapter_name}` (only for single model use case)
 
 Use the Unregister Adapter API to free up system resources:
 
@@ -65,7 +62,6 @@ curl -X DELETE http://localhost:8080/models/adaptecho/adapters/a1
 ### List adapters
 
 `GET /models/{model_name}/adapters`
-`GET /adapters` (only for single model use case)
 
 * limit - (optional) the maximum number of items to return. It is passed as a query parameter. The default value is `100`.
 * next_page_token - (optional) queries for next page. It is passed as a query parameter. This value is return by a previous API call.
@@ -90,3 +86,7 @@ curl "http://localhost:8080/models/adaptecho/adapters?limit=2&next_page_token=0"
   ]
 }
 ```
+
+### Advanced
+
+For the single model use case, the `/models/{model_name}` API prefix can be omitted resulting in queries such as `GET /adapters`.

--- a/serving/docs/adapters_api.md
+++ b/serving/docs/adapters_api.md
@@ -16,6 +16,7 @@ This is an extension of the [Management API](management_api.md) and can be acces
 ### Register an adapter
 
 `POST /models/{modelName}/adapters`
+`POST /adapters` (only for single model use case)
 
 * name - The adapter name.
 * src - The adapter src. It currently requires a file, but eventually an id or URL can be supported depending on the model handler.
@@ -31,6 +32,7 @@ curl -X POST "http://localhost:8080/models/adaptecho/adapters?name=a1&src=..."
 ### Describe adapter
 
 `GET /models/{model_name}/adapters/{adapter_name}`
+`GET /adapters/{adapter_name}` (only for single model use case)
 
 Use the Describe Adapter API to get the status of an adapter:
 
@@ -48,6 +50,7 @@ curl http://localhost:8080/models/adaptecho/adapters/a1
 ### Unregister an adapter
 
 `DELETE /models/{model_name}/adapters/{adapter_name}`
+`DELETE /adapters/{adapter_name}` (only for single model use case)
 
 Use the Unregister Adapter API to free up system resources:
 
@@ -62,6 +65,7 @@ curl -X DELETE http://localhost:8080/models/adaptecho/adapters/a1
 ### List adapters
 
 `GET /models/{model_name}/adapters`
+`GET /adapters` (only for single model use case)
 
 * limit - (optional) the maximum number of items to return. It is passed as a query parameter. The default value is `100`.
 * next_page_token - (optional) queries for next page. It is passed as a query parameter. This value is return by a previous API call.

--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -35,8 +35,8 @@ import java.util.regex.Pattern;
 /** A class handling inbound HTTP requests to the management API for adapters. */
 public class AdapterManagementRequestHandler extends HttpRequestHandler {
 
-    static final Pattern ADAPTERS_PATTERN = Pattern.compile("^/models/[^/^?]+/adapters([/?].*)?");
-    static final Pattern ADAPTERS_SINGLE_PATTERN = Pattern.compile("^/adapters([/?].*)?");
+    static final Pattern ADAPTERS_PATTERN =
+            Pattern.compile("^(/models/[^/^?]+)?/adapters([/?].*)?");
 
     /** {@inheritDoc} */
     @Override
@@ -44,8 +44,7 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
         if (super.acceptInboundMessage(msg)) {
             FullHttpRequest req = (FullHttpRequest) msg;
             String uri = req.uri();
-            return ADAPTERS_PATTERN.matcher(uri).matches()
-                    || ADAPTERS_SINGLE_PATTERN.matcher(uri).matches();
+            return ADAPTERS_PATTERN.matcher(uri).matches();
         }
         return false;
     }

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -50,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -194,10 +193,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
             }
         }
         if (modelName == null) {
-            Set<String> startModels = ModelManager.getInstance().getStartupWorkflows();
-            if (startModels.size() == 1) {
-                modelName = startModels.iterator().next();
-            }
+            modelName = ModelManager.getInstance().getSingleStartupWorkflow().orElse(null);
             if (modelName == null) {
                 throw new BadRequestException("Parameter model_name is required.");
             }

--- a/serving/src/main/java/ai/djl/serving/models/ModelManager.java
+++ b/serving/src/main/java/ai/djl/serving/models/ModelManager.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -312,6 +313,22 @@ public final class ModelManager {
      */
     public Set<String> getStartupWorkflows() {
         return startupWorkflows;
+    }
+
+    /**
+     * Returns the single startup workflow.
+     *
+     * <p>Returns only if there was exactly 1 startup workflow passed in. Used with integration of
+     * SageMaker SME and single model services.
+     *
+     * @return the workflow name
+     */
+    public Optional<String> getSingleStartupWorkflow() {
+        Set<String> startModels = getStartupWorkflows();
+        if (startModels.size() == 1) {
+            return Optional.ofNullable(startModels.iterator().next());
+        }
+        return Optional.empty();
     }
 
     /**

--- a/serving/src/test/resources/smeAdapt.config.properties
+++ b/serving/src/test/resources/smeAdapt.config.properties
@@ -1,0 +1,4 @@
+inference_address=https://127.0.0.1:8443
+management_address=https://127.0.0.1:8443
+model_store=build/models
+load_models=src/test/resources/adaptecho


### PR DESCRIPTION
This adds a shortcut for the adapter API for single model use case. In addition to being able to call it through `/models/{modelName}/adapters`, it can also be called through `/adapters` if this is unambiguous. This use case may be run into in cases like SageMaker SME.