### PR TITLE
[UX] sampling with vllm

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -86,15 +86,19 @@ class VLLMRollingBatch(RollingBatch):
 
         :return: The same parameters dict, but with VLLM style parameter names.
         """
-        parameters.pop('do_sample', None)
+        parameters["max_tokens"] = parameters.pop("max_new_tokens", 30)
         if "seed" in parameters.keys():
             parameters["seed"] = int(parameters["seed"])
-        if "max_new_tokens" in parameters.keys():
-            parameters["max_tokens"] = parameters.pop("max_new_tokens")
+        if not parameters.pop('do_sample', False):
+            # if temperature is zero, vLLM does greedy sampling
+            parameters['temperature'] = 0
         if "stop_sequences" in parameters.keys():
             parameters["stop"] = parameters.pop("stop_sequences")
         if "ignore_eos_token" in parameters.keys():
             parameters["ignore_eos"] = parameters.pop("ignore_eos")
+        if "num_beams" in parameters.keys():
+            parameters["best_of"] = parameters.pop("num_beams")
+            parameters["use_beam_search"] = True
         return parameters
 
     @stop_on_any_exception

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -71,7 +71,6 @@ Apart from these common parameters, there are other parameters that are specific
 ```
 DeepSpeedRollingBatchParameters : {
     'typical_p' : float (default= 1.0), 
-    'seed' : integer (default = 0),
     'stop_sequences' : list (default = None),
     'truncate' : integer (default = None),
 }

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -51,6 +51,8 @@ When providing inputs following the input schema as a string, the output's gener
 
 ### Common rolling batch input parameters
 ```
+    'do_sample' : boolean (default = False),
+    'seed' : integer (default = ramdom value),
     'temperature' : float (default= 1.0),
     'repetition_penalty': float (default= 1.0),
     'top_k' : integer (default = 0), 
@@ -68,8 +70,7 @@ Apart from these common parameters, there are other parameters that are specific
 
 ```
 DeepSpeedRollingBatchParameters : {
-    'typical_p' : float (default= 1.0),
-    'do_sample' : boolean (default = False), 
+    'typical_p' : float (default= 1.0), 
     'seed' : integer (default = 0),
     'stop_sequences' : list (default = None),
     'truncate' : integer (default = None),
@@ -83,8 +84,6 @@ DeepSpeedRollingBatchParameters : {
 ```
 LmiDistRollingBatchParameters : {
     'typical_p' : float (default= 1.0),
-    'do_sample' : boolean (default = false), 
-    'seed' : integer (default = 0),
     'stop_sequences' : list (default = None),
     'truncate' : integer (default = None),
     'ignore_eos_token' : boolean (default = false)
@@ -98,11 +97,13 @@ LmiDistRollingBatchParameters : {
 ```
 vLLMRollingBatchParameters : {
     'stop_sequences' : list,
-    'best_of' : int (default = None),
+    'temperature' : float (default= 0),
+    'top_k' : integer (default = -1)
+    
     'min_p': float (default = 0.0),
     'presence_penalty': float (default = 0.0),
     'frequency_penalty' : float (default = 0.0),
-    'use_beam_search': boolean (default = false),
+    'num_beams': integer (default = 1), (set this greater than 1 to enable beam search)
     'stop_token_ids': list (default = None),
     'include_stop_str_in_output' : boolean (default = false),
     'ignore_eos_token' : boolean (default = false),
@@ -124,7 +125,6 @@ TensorRTLLMRollingBatchParameters : {
     'max_new_tokens' : integer (default = 128),
     'top_k' : integer (default = 5), 
     'top_p' : float (default= 0.85),
-    'seed' : integer (default = None),
     'details' : boolean (default = false),
     'stop' : boolean, 
     'presence_penalty': float,


### PR DESCRIPTION
## Description ##

This PR 
- Makes greedy the default for vllm, [before this PR random sampling was the default for vllm]
- Introduces num_beams should enable beam search. [Even for the beam search, the generated sequence will be 1. It will be greater than 1 only if `n` > 1. `n` in equivalent to `num_return_sequences` in huggingface] 
- Makes default value of max_new_tokens to be 30. [Before this PR, it was 16]