### PR TITLE
[docs] fix some links that do not work on mkdocs site

### DIFF
--- a/serving/docs/large_model_inference.md
+++ b/serving/docs/large_model_inference.md
@@ -5,5 +5,5 @@ We maintain a collection of deep learning containers (DLC) specifically designed
 You can explore the available deep learning containers [here](https://github.com/aws/deep-learning-containers/blob/master/available_images.md#large-model-inference-containers). 
 The [AWS DLC for LMI](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference-dlc.html) provides documentation detailing the description of libraries available for use with these DLCs.
 
-To learn more about Large Model Inference with DJLServing on SageMaker, please see our dedicated docs [here](lmi).
+To learn more about Large Model Inference with DJLServing on SageMaker, please see our dedicated docs [here](lmi/README.md).
 

--- a/serving/docs/lmi/README.md
+++ b/serving/docs/lmi/README.md
@@ -108,7 +108,7 @@ We link to the specific model we tested with, but we expect same model from a di
 
 ### Deployment Guide
 
-We have put together a comprehensive [deployment guide](deployment_guide) that takes you through the steps needed to deploy a model using LMI containers on SageMaker.
+We have put together a comprehensive [deployment guide](deployment_guide/README.md) that takes you through the steps needed to deploy a model using LMI containers on SageMaker.
 The document covers the phases from storing your model artifacts through benchmarking your SageMaker endpoint.
 
 ## Supported LMI Inference Libraries
@@ -125,7 +125,7 @@ You can learn more about their integration with LMI from the respective user gui
 LMI provides access to multiple libraries to enable users to find the best stack for their model and use-case. 
 Each inference framework provides a unique set of features and optimizations that can be tuned for your model and use case.
 With LMIs built-in inference handlers and unified configuration, experimenting with different stacks is as simple as changing a few configurations.
-Refer to the stack specific user guides, and the [LMI deployment guide](deployment_guide) to learn more.
+Refer to the stack specific user guides, and the [LMI deployment guide](deployment_guide/README.md) to learn more.
 An overview of the different LMI components is provided in the [deployment guide](deployment_guide/README.md#components-of-lmi)
 
 The following table shows which SageMaker DLC (deep learning container) to use for each backend.

--- a/serving/docs/lmi/deployment_guide/backend-selection.md
+++ b/serving/docs/lmi/deployment_guide/backend-selection.md
@@ -35,7 +35,7 @@ The most important factor when selecting a backend is to use a backend that supp
 Some architectures are only supported by a few backends. For example, T5 models are only supported by lmi-dist and TensorRT-LLM.
 Llama2 models are supported by all backends.
 
-You can find out model architecture support by referencing the backend [user guides](../user_guides).
+You can find out model architecture support by referencing the backend [user guides](../user_guides/README.md).
 
 ## Factor 2: Use-Case and Traffic Patterns
 
@@ -84,7 +84,7 @@ The lower memory footprint can enable deployments to smaller instances.
 Each inference backend offers support for different quantization methods.
 Across LMI, we offer GPTQ, AWQ, SmoothQuant, and Int8 quantization.
 Quantization does lead to lower quality, but the quality degradation is usually acceptable and a better option than switching to a smaller model.
-Refer to the backend [user guides](../user_guides) to learn about the quantization methods available in each backend.
+Refer to the backend [user guides](../user_guides/README.md) to learn about the quantization methods available in each backend.
 
 Another option is to switch from GPU based instances to AWS Inferentia2 instances using Transformers NeuronX.
 These instances are typically cheaper than the equivalent G5/P4 instances, but Transformers NeuronX has less model architecture support than other backends.

--- a/serving/docs/lmi/deployment_guide/configurations.md
+++ b/serving/docs/lmi/deployment_guide/configurations.md
@@ -22,7 +22,7 @@ Configurations specified in the `serving.properties` files will override configu
 
 Both configuration mechanisms offer access to the same set of configurations.
 
-If you know which backend you are going to use, you can find a set of starter configurations in the corresponding [user guide](../user_guides).
+If you know which backend you are going to use, you can find a set of starter configurations in the corresponding [user guide](../user_guides/README.md).
 We recommend using the quick start configurations as a starting point if you have decided on a particular backend.
 The only change required to the starter configurations is specifying `option.model_id` to point to your model artifacts.
 
@@ -119,7 +119,7 @@ The following list of configurations is intended to highlight the relevant confi
 ## Backend Specific Configurations
 
 Each backend provides access to additional configurations.
-You can find these configurations in the respective [user guides](../user_guides).
+You can find these configurations in the respective [user guides](../user_guides/README.md).
 
 ## Environment Variable Configurations
 

--- a/serving/docs/lmi/user_guides/deepspeed_user_guide.md
+++ b/serving/docs/lmi/user_guides/deepspeed_user_guide.md
@@ -28,9 +28,6 @@ The below model architectures have been carefully tested with LMI's DeepSpeed in
 
 ### Complete Model Set
 
-<details>
-  <summary>Expand this section to see the full set of model architectures supported by DeepSpeed.</summary>
-
 Kernel Injection:
 
 * GPT2
@@ -91,7 +88,6 @@ Auto Tensor-Parallelism:
 * xglm
 * xlm_roberta
 * yoso
-</details>
 
 ## Quick Start Configurations
 


### PR DESCRIPTION
## Description ##

Fixes some formatting issues that are present on the docs site but not on github
