### PR TITLE
Adds adapter registration options

### DIFF
--- a/engines/python/src/test/resources/adaptecho/model.py
+++ b/engines/python/src/test/resources/adaptecho/model.py
@@ -27,7 +27,7 @@ adapters = dict()
 def register_adapter(inputs: Input):
     global adapters
     name = inputs.get_properties()["name"]
-    adapters[name] = True
+    adapters[name] = inputs
     return Output().add("Successfully registered adapter")
 
 
@@ -51,13 +51,17 @@ def handle(inputs: Input):
     for i, input in enumerate(inputs.get_batches()):
         data = input.get_as_string()
         if input.contains_key("adapter"):
-            adapter = input.get_as_string("adapter")
-            if adapter in adapters:
+            adapter_name = input.get_as_string("adapter")
+            if adapter_name in adapters:
+                adapter = adapters[adapter_name]
+                option = ""
+                if adapter.contains_key("echooption"):
+                    option = adapter.get_as_string("echooption")
                 # Registered adapter
-                out = adapter + data
+                out = adapter_name + option + data
             else:
                 # Dynamic adapter
-                out = "dyn" + adapter + data
+                out = "dyn" + adapter_name + data
         else:
             out = data
         outputs.add(out, key="data", batch_index=i)

--- a/serving/docs/adapters.md
+++ b/serving/docs/adapters.md
@@ -58,6 +58,7 @@ For the simple model + adapter case, you can also directly use the adapter [work
 With our workflows, multiple workflows sharing models will be de-duplicated.
 So, the effect of having multiple adapters can be easily made with having one workflow for each adapter.
 This system can be used on [Amazon SageMaker Multi-Model Endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html).
+More details can be found on the [AdapterWorkflowFunction docs](https://javadoc.io/doc/ai.djl.serving/serving/latest/ai/djl/serving/workflow/function/AdapterWorkflowFunction.html).
 
 ```
 workflow.json:
@@ -165,6 +166,7 @@ These can then take the adapters and save the src, pre-download it, cache it in 
 def register_adapter(inputs: Input):
   name = inputs.get_properties()["name"]
   src = inputs.get_properties()["src"]
+  options = inputs.get_content()
   # Do adapter registration tasks
   return Output().add("Successfully registered adapter")
 

--- a/serving/docs/adapters_api.md
+++ b/serving/docs/adapters_api.md
@@ -19,6 +19,7 @@ This is an extension of the [Management API](management_api.md) and can be acces
 
 * name - The adapter name.
 * src - The adapter src. It currently requires a file, but eventually an id or URL can be supported depending on the model handler.
+* All additional arguments will be treated as additional model-specific options and will be passed to the model during adapter registration
 
 ```bash
 curl -X POST "http://localhost:8080/models/adaptecho/adapters?name=a1&src=..."

--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -30,6 +30,8 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /** A class handling inbound HTTP requests to the management API for adapters. */
@@ -154,7 +156,15 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
         if (wp == null) {
             throw new BadRequestException("The model " + modelName + " was not found");
         }
-        Adapter adapter = Adapter.newInstance(wp.getWpc(), adapterName, src);
+
+        Map<String, String> options = new ConcurrentHashMap<>();
+        for (Map.Entry<String, List<String>> entry : decoder.parameters().entrySet()) {
+            if (entry.getValue().size() == 1) {
+                options.put(entry.getKey(), entry.getValue().get(0));
+            }
+        }
+
+        Adapter adapter = Adapter.newInstance(wp.getWpc(), adapterName, src, options);
         adapter.register(wp);
 
         String msg = "Adapter " + adapterName + " registered";

--- a/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java
@@ -32,12 +32,13 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>To use this workflow function, you must pre-specify the adapted functions in the configs. In
  * the configs, create an object "adapters" with keys as reference names and values as objects. The
- * adapter reference objects should have three properties:
+ * adapter reference objects should have the following properties:
  *
  * <ul>
  *   <li>model - the model name
  *   <li>name - the adapter name
  *   <li>url - the adapter url
+ *   <li>options (optional) - an object containing additional string options
  * </ul>
  *
  * <p>To call this workflow function, it requires two arguments. The first is the adapter config
@@ -69,8 +70,18 @@ public class AdapterWorkflowFunction extends WorkflowFunction {
                 String adapterName = entry.getKey();
                 String src = (String) config.get("src");
 
+                Map<String, String> options = new ConcurrentHashMap<>();
+                if (config.containsKey("options") && config.get("options") instanceof Map) {
+                    for (Map.Entry<String, Object> option :
+                            ((Map<String, Object>) config.get("options")).entrySet()) {
+                        if (option.getValue() instanceof String) {
+                            options.put(option.getKey(), (String) option.getValue());
+                        }
+                    }
+                }
+
                 WorkerPool<?, ?> wp = wlm.getWorkerPoolById(modelName);
-                Adapter adapter = Adapter.newInstance(wp.getWpc(), adapterName, src);
+                Adapter adapter = Adapter.newInstance(wp.getWpc(), adapterName, src, options);
                 adapters.put(adapterName, new AdapterReference(modelName, adapter));
             }
         }

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -319,7 +319,7 @@ public class ModelServerTest {
             assertTrue(server.isRunning());
             Channel channel = initTestChannel();
 
-            testAdapterWorkflowPredict(channel, "adapter1", "a1");
+            testAdapterWorkflowPredict(channel, "adapter1", "a1weo");
             testAdapterWorkflowPredict(channel, "adapter2", "a2");
             testRegisterAdapterWorkflowTemplate(channel);
 
@@ -868,7 +868,7 @@ public class ModelServerTest {
         testAdapterMissing();
 
         String strModelPrefix = modelPrefix ? "/models/adaptecho" : "";
-        url = strModelPrefix + "/adapters?name=" + "adaptable" + "&src=" + "src";
+        url = strModelPrefix + "/adapters?name=adaptable&src=src&echooption=opt";
         request(channel, HttpMethod.POST, url);
         assertHttpOk();
     }
@@ -926,7 +926,7 @@ public class ModelServerTest {
         req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
         request(channel, req);
         assertHttpOk();
-        assertEquals(result, "adaptabletestPredictAdapter");
+        assertEquals(result, "adaptableopttestPredictAdapter");
     }
 
     private void testAdapterDirPredict(Channel channel) throws InterruptedException {
@@ -942,7 +942,7 @@ public class ModelServerTest {
         assertEquals(result, "myBuiltinAdaptertestPredictBuiltinAdapter");
     }
 
-    private void testAdapterWorkflowPredict(Channel channel, String workflow, String adapter)
+    private void testAdapterWorkflowPredict(Channel channel, String workflow, String prefix)
             throws InterruptedException {
         logTestFunction();
         String url = "/predictions/" + workflow;
@@ -953,7 +953,7 @@ public class ModelServerTest {
         req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
         request(channel, req);
         assertHttpOk();
-        assertEquals(result, adapter + "testAWP");
+        assertEquals(result, prefix + "testAWP");
     }
 
     private void testRegisterAdapterWorkflowTemplate(Channel channel) throws InterruptedException {
@@ -980,7 +980,7 @@ public class ModelServerTest {
         request(channel, req);
 
         assertHttpOk();
-        assertEquals(result, "adaptabletestInvokeAdapter");
+        assertEquals(result, "adaptableopttestInvokeAdapter");
     }
 
     private void testAdapterList(Channel channel, boolean modelPrefix) throws InterruptedException {

--- a/serving/src/test/resources/adapterWorkflows/w1/workflow.json
+++ b/serving/src/test/resources/adapterWorkflows/w1/workflow.json
@@ -8,7 +8,10 @@
     "adapters": {
       "a1": {
         "model": "m",
-        "src": "url1"
+        "src": "url1",
+        "options": {
+          "echooption": "weo"
+        }
       }
     }
   },

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -18,6 +18,7 @@ import ai.djl.serving.wlm.util.WorkerJob;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -27,16 +28,19 @@ public abstract class Adapter {
 
     protected String name;
     protected String src;
+    protected Map<String, String> options;
 
     /**
      * Constructs an {@link Adapter}.
      *
      * @param name the adapter name
      * @param src the adapter source
+     * @param options additional adapter options
      */
-    protected Adapter(String name, String src) {
+    protected Adapter(String name, String src, Map<String, String> options) {
         this.name = name;
         this.src = src;
+        this.options = options;
     }
 
     /**
@@ -48,9 +52,11 @@ public abstract class Adapter {
      * @param wpc the worker pool config for the new adapter
      * @param name the adapter name
      * @param src the adapter source
+     * @param options additional adapter options
      * @return the new adapter
      */
-    public static Adapter newInstance(WorkerPoolConfig<?, ?> wpc, String name, String src) {
+    public static Adapter newInstance(
+            WorkerPoolConfig<?, ?> wpc, String name, String src, Map<String, String> options) {
         if (!(wpc instanceof ModelInfo)) {
             String modelName = wpc.getId();
             throw new IllegalArgumentException("The worker " + modelName + " is not a model");
@@ -69,7 +75,7 @@ public abstract class Adapter {
         ModelInfo<?, ?> modelInfo = (ModelInfo<?, ?>) wpc;
         // TODO Replace usage of class name with creating adapters by Engine.newPatch(name ,src)
         if ("PyEngine".equals(modelInfo.getEngine().getClass().getSimpleName())) {
-            return new PyAdapter(name, src);
+            return new PyAdapter(name, src, options);
         } else {
             throw new IllegalArgumentException(
                     "Adapters are only currently supported for Python models");

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -51,6 +51,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -282,7 +283,8 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                                                 Adapter.newInstance(
                                                         this,
                                                         adapterName,
-                                                        adapterDir.toAbsolutePath().toString());
+                                                        adapterDir.toAbsolutePath().toString(),
+                                                        Collections.emptyMap());
                                         registerAdapter(adapter);
                                         long d = (System.nanoTime() - start) / 1000;
                                         Metric me =

--- a/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
@@ -17,6 +17,8 @@ import ai.djl.modality.Input;
 import ai.djl.modality.Output;
 import ai.djl.translate.TranslateException;
 
+import java.util.Map;
+
 /** An overload of {@link Adapter} for the python engine. */
 public class PyAdapter extends Adapter {
 
@@ -25,9 +27,10 @@ public class PyAdapter extends Adapter {
      *
      * @param name the adapter name
      * @param src the adapter src
+     * @param options additional adapter options
      */
-    protected PyAdapter(String name, String src) {
-        super(name, src);
+    protected PyAdapter(String name, String src, Map<String, String> options) {
+        super(name, src, options);
     }
 
     @SuppressWarnings("unchecked")
@@ -38,6 +41,9 @@ public class PyAdapter extends Adapter {
         input.addProperty("handler", "register_adapter");
         input.addProperty("name", name);
         input.addProperty("src", src);
+        for (Map.Entry<String, String> entry : options.entrySet()) {
+            input.add(entry.getKey(), entry.getValue());
+        }
         try {
             p.predict(input);
         } catch (TranslateException e) {


### PR DESCRIPTION
This adds support for additional options that can be used for adapter registration. These options will be passed through to the model and can therefore be model specific. The options are formatted as a Map<String, String> and can be passed through both HTTP and AdapterWorkflowFunction registration. Using the adapter directory support does not support options.
