### PR TITLE
[partition] fix checking for model files

### DIFF
--- a/serving/docker/partition/properties_manager.py
+++ b/serving/docker/partition/properties_manager.py
@@ -58,7 +58,7 @@ class PropertiesManager(object):
         if 'model_dir' in self.properties:
             model_dir = self.properties['model_dir']
             model_files = glob.glob(os.path.join(model_dir, '*.bin'))
-            model_files = glob.glob(os.path.join(model_dir, '.safetensors'))
+            model_files = glob.glob(os.path.join(model_dir, '*.safetensors'))
             if not model_files:
                 raise ValueError(
                     f'No .bin or .safetensors files found in the dir: {model_dir}'


### PR DESCRIPTION
## Description ##

One-liner change to fix how the partition PropertiesManager checks for input model files.

cc: @tosterberg 