### PR TITLE
[lmi] use hf token to get model config for gated/private models

### DIFF
--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -447,7 +447,10 @@ public final class ConfigManager {
                 .append("\nEnvironment variables:");
         for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
             String key = entry.getKey();
-            if (key.startsWith("SERVING")
+            // Do not log HF_TOKEN value
+            if ("HF_TOKEN".equals(key)) {
+                sb.append("\n\t").append(key).append(": ***");
+            } else if (key.startsWith("SERVING")
                     || key.startsWith("PYTHON")
                     || key.startsWith("DJL_")
                     || key.startsWith("HF_")

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -259,6 +259,7 @@ public class ModelInfoTest {
                         put("openai-community/gpt2", "vllm");
                         put("tiiuae/falcon-7b", "lmi-dist");
                         put("mistralai/Mistral-7B-v0.1", "vllm");
+                        put("src/test/resources/local-hf-model", "vllm");
                     }
                 };
         Path modelStore = Paths.get("build/models");

--- a/wlm/src/test/resources/local-hf-model/config.json
+++ b/wlm/src/test/resources/local-hf-model/config.json
@@ -1,0 +1,3 @@
+{
+  "model_type": "gpt2"
+}


### PR DESCRIPTION
## Description ##

Use hf token when provided to access to the gated repos. This is needed to read configs of private/gated models and determine which engine to use.


