### PR TITLE
[UX] Changing some default parameters

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_v2_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_v2_rolling_batch.py
@@ -109,7 +109,7 @@ class LmiDistRollingBatch(RollingBatch):
         if "stop_sequences" in parameters.keys():
             parameters["stop"] = parameters.pop("stop_sequences")
         if "ignore_eos_token" in parameters.keys():
-            parameters["ignore_eos"] = parameters.pop("ignore_eos")
+            parameters["ignore_eos"] = parameters.pop("ignore_eos_token")
         if "num_beams" in parameters.keys():
             parameters["best_of"] = parameters.pop("num_beams")
             parameters["use_beam_search"] = True

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -10,7 +10,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-import logging
 import tensorrt_llm_toolkit
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, Token
 
@@ -61,7 +60,7 @@ class TRTLLMRollingBatch(RollingBatch):
         """
         if "request_output_len" not in parameters.keys():
             parameters["request_output_len"] = parameters.pop(
-                "max_new_tokens", 128)
+                "max_new_tokens", 30)
         if "top_k" in parameters.keys():
             parameters["runtime_top_k"] = parameters.pop("top_k")
         if "top_p" in parameters.keys():

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -105,7 +105,7 @@ class VLLMRollingBatch(RollingBatch):
         if "stop_sequences" in parameters.keys():
             parameters["stop"] = parameters.pop("stop_sequences")
         if "ignore_eos_token" in parameters.keys():
-            parameters["ignore_eos"] = parameters.pop("ignore_eos")
+            parameters["ignore_eos"] = parameters.pop("ignore_eos_token")
         if "num_beams" in parameters.keys():
             parameters["best_of"] = parameters.pop("num_beams")
             parameters["use_beam_search"] = True

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -76,7 +76,7 @@ DeepSpeedRollingBatchParameters : {
 }
 ```
 
-Decoding method supported in DeepSpeed: Greed (Default) and Sampling.
+Decoding method supported in DeepSpeed: Greedy (Default) and Sampling.
 
 ### LMI Dist rolling batch input parameters schema
 

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -60,6 +60,7 @@ When providing inputs following the input schema as a string, the output's gener
     'max_new_tokens' : integer (default = 30),
     'details' : boolean (default = false, details only available for rolling batch),
     'return_full_text': boolean (default = false),
+    'stop_sequences' : list[str] (default = None),
 ```
 
 Note: For TensorRTLLM handler, it also has all the common parameters, but it uses different default values. Kindly check below to know the TensorRT LLM default values. 
@@ -71,32 +72,29 @@ Apart from these common parameters, there are other parameters that are specific
 ```
 DeepSpeedRollingBatchParameters : {
     'typical_p' : float (default= 1.0), 
-    'stop_sequences' : list (default = None),
     'truncate' : integer (default = None),
 }
 ```
 
-
+Decoding method supported in DeepSpeed: Greed (Default) and Sampling.
 
 ### LMI Dist rolling batch input parameters schema
 
 ```
 LmiDistRollingBatchParameters : {
     'typical_p' : float (default= 1.0),
-    'stop_sequences' : list (default = None),
     'truncate' : integer (default = None),
     'ignore_eos_token' : boolean (default = false)
 }
 ```
 
+Decoding method supported in LmiDist : Greedy (Default) and Sampling.
 
 
 ### vLLM rolling batch input parameters schema
 
 ```
 vLLMRollingBatchParameters : {
-    'stop_sequences' : list,
-    'temperature' : float (default= 0),
     'top_k' : integer (default = -1)
     
     'min_p': float (default = 0.0),
@@ -113,25 +111,31 @@ vLLMRollingBatchParameters : {
 }
 ```
 
+Decoding method supported in vLLM : Greedy (Default), Sampling and Beam search.
+
 ### TensorRTLLM rolling batch input parameters schema
 
 For TensorRTLLM handler, it also has all the common parameters, but it uses different default values. 
 
 ```
 TensorRTLLMRollingBatchParameters : {
-    'temperature' : float (default= 0.8),
-    'repetition_penalty' : float (default = None),
-    'max_new_tokens' : integer (default = 128),
-    'top_k' : integer (default = 5), 
-    'top_p' : float (default= 0.85),
-    'details' : boolean (default = false),
+    # Common parameters with different default values
+    'temperature' : float (default = 0.8 when greedy, 1.0 when do_sample=True),
+    'top_k' : integer (default = 0 when greedy, 5 when do_sample=True), 
+    'top_p' : float (default= 0 when greedy, 0.85 when do_sample=True),
+    
+    # parameters specific to TensorRT-LLM
+    'min_length' : integer (default = 1)
+    'bad_sequences' : list[str] (default = None), 
     'stop' : boolean, 
     'presence_penalty': float,
     'length_penalty' : float, 
-    'stop_words_list' : list, 
-    'bad_words_list' : list, 
-    'min_length' : integer
 }
 ```
+
+Decoding method supported in TensorRT-LLM : Greedy (Default) and Sampling.
+
+NOTE: TensorRT-LLM C++ runtime, does not have the option `do_sample`. If top_k and top_p are 0, TensorRT-LLM automatically recognizes it as greedy. 
+So in order to do sampling, we set top_k, top_p and temperature values to a certain values. You can change these parameters for your use-case and pass them at runtime.
 
 For those without default values, they remain optional. If these parameters are not provided, they will be ignored.


### PR DESCRIPTION
## Description ##

**Unifying TensorRT-LLM parameters**:
- TensorRT-LLM does not have do_sample parameters, so if top_p=0 and top_k=0, then it automatically does greedy, which are also the default values . So the default values of top_p and top_k has to be different from other optimization engines. 
- Retaining the same numbers for do_sample as before, but clairfied it in our schema doc. 
- In future, this will be changed if TensorRT-LLM's Inference API started supporting all the models, in which they do have `do_sample` parameters and also in python API. 

Ref: https://github.com/NVIDIA/TensorRT-LLM/blob/66ca3378c61efa3154ed34a48cfc362351405eef/docs/source/gpt_runtime.md?plain=1#L385
https://github.com/NVIDIA/TensorRT-LLM/issues/646#issuecomment-1853151562

In their c++ code, I could not find where they set their default parameters yet. https://github.com/NVIDIA/TensorRT-LLM/blob/66ca3378c61efa3154ed34a48cfc362351405eef/cpp/include/tensorrt_llm/runtime/samplingConfig.h#L66 - In here they set only beam_width=1

**vLLM temperature**:
- vLLM also does not do_sample parameter and they decide to greedy decoding when temperature=0. Although, we set temperature=0 by default to enable greedy in our handler code, internally, they change it to temperature back to 1. 

Code Ref: https://github.com/vllm-project/vllm/blob/v0.3.3/vllm/model_executor/sampling_metadata.py#L101

