### PR TITLE
fix a bug with output formatter

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -159,7 +159,7 @@ class Request(object):
         if output_formatter is not None:
             self.output_formatter = output_formatter
         else:
-            formatter = parameters.get("output_formatter", None)
+            formatter = parameters.pop("output_formatter", None)
             if not formatter or "json" == formatter:
                 self.output_formatter = _json_output_formatter
             elif "jsonlines" == formatter:

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -903,8 +903,10 @@ def test_handler_rolling_batch(model, model_spec):
     if "adapters" in spec:
         req["adapters"] = spec.get("adapters")[0]
     logging.info(f"req {req}")
-    res = send_json(req)
-    logging.info(f"res: {res.content}")
+    res = send_json(req).content.decode("utf-8")
+    logging.info(f"res: {res}")
+    if "error" in res and "code" in res and "424" in res:
+        raise RuntimeError(f"Inference failed!")
     # awscurl little benchmark phase
     for i, batch_size in enumerate(spec["batch_size"]):
         for seq_length in spec["seq_length"]:

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -739,7 +739,7 @@ trtllm_handler_list = {
         "option.output_formatter": "jsonlines",
     },
     "falcon-7b": {
-        "option.model_id": "s3://djl-llm/triton/0.7.1/falcon-7b-tp1-bs16/",
+        "option.model_id": "s3://djl-llm/triton/0.8.0/falcon-7b-tp1-bs16/",
         "option.tensor_parallel_degree": 1,
         "option.max_input_len": 1024,
         "option.max_output_len": 512,


### PR DESCRIPTION
## Description ##

Fix a bug with output formatter

```
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:Rolling batch inference error
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.27.0-SNAPSHOT/djl_python/rolling_batch/rolling_batch.py", line 249, in try_catch_handling
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:    return func(self, *args, **kwargs)
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.27.0-SNAPSHOT/djl_python/rolling_batch/trtllm_rolling_batch.py", line 102, in inference
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:    response = self.model.generate(request.input_text, **param)
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/tensorrt_llm_toolkit/trtllmmodel/modelbuilder.py", line 213, in generate
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:    final_kwargs = self._prepare_inputs_for_generation(inputs, **parameters)
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/tensorrt_llm_toolkit/trtllmmodel/modelbuilder.py", line 282, in _prepare_inputs_for_generation
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:    raise AssertionError(f"Input {key} is not in accepted inputs: {self.model.inputs_metadata.keys()}")
INFO  PyProcess W-1382-test-stdout: [1,0]<stdout>:AssertionError: Input output_formatter is not in accepted inputs: dict_keys(['input_ids', 'input_lengths', 'request_output_len', 'draft_input_ids', 'end_id', 'pad_id', 'stop_words_list', 'bad_words_list', 'embedding_bias', 'beam_width', 'temperature', 'runtime_top_k', 'runtime_top_p', 'len_penalty', 'repetition_penalty', 'min_length', 'presence_penalty', 'frequency_penalty', 'random_seed', 'return_log_probs', 'return_context_logits', 'return_generation_logits', 'stop', 'streaming', 'prompt_embedding_table', 'prompt_vocab_size', 'lora_weights', 'lora_config'])
```

The value was pass through