### PR TITLE
[lmi] add stream parameter to enable per request streaming config

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -371,6 +371,7 @@ class DeepSpeedService(object):
                 input_map = decode(item, content_type)
                 _inputs = input_map.pop("inputs", input_map)
                 _param = input_map.pop("parameters", {})
+                _param["stream"] = input_map.pop("stream", False)
                 if not self.enable_rolling_batch:
                     if first:
                         parameters.append(_param)
@@ -384,12 +385,12 @@ class DeepSpeedService(object):
                                 "In order to enable dynamic batching, all input batches must have the same parameters"
                             )
 
-                if not "seed" in _param:
+                if "seed" not in _param:
                     # set server provided seed if seed is not part of request
                     if item.contains_key("seed"):
                         _param["seed"] = item.get_as_string(key="seed")
 
-                if not "output_formatter" in _param:
+                if "output_formatter" not in _param:
                     _param[
                         "output_formatter"] = self.properties.output_formatter
 

--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -231,13 +231,14 @@ class HuggingFaceService(object):
             input_size.append(len(_inputs))
 
             _param = input_map.pop("parameters", {})
+            _param["stream"] = input_map.pop("stream", False)
             if "cached_prompt" in input_map:
                 _param["cached_prompt"] = input_map.pop("cached_prompt")
-            if not "seed" in _param:
+            if "seed" not in _param:
                 # set server provided seed if seed is not part of request
                 if item.contains_key("seed"):
                     _param["seed"] = item.get_as_string(key="seed")
-            if not "output_formatter" in _param:
+            if "output_formatter" not in _param:
                 _param["output_formatter"] = self.hf_configs.output_formatter
 
             for _ in range(input_size[i]):
@@ -251,7 +252,7 @@ class HuggingFaceService(object):
             if adapters_per_item:
                 found_adapters = True
             else:
-                ## inference with just base model.
+                # inference with just base model.
                 adapters_per_item = [""] * len(_inputs)
 
             adapters.extend(adapters_per_item)

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -77,16 +77,16 @@ class TRTLLMService(object):
             input_size.append(len(_inputs))
 
             _param = input_map.pop("parameters", {})
+            _param["stream"] = input_map.pop("stream", False)
             if "cached_prompt" in input_map:
                 _param["cached_prompt"] = input_map.pop("cached_prompt")
-            if not "seed" in _param:
+            if "seed" not in _param:
                 # set server provided seed if seed is not part of request
                 if item.contains_key("seed"):
                     _param["seed"] = item.get_as_string(key="seed")
 
-                if not "output_formatter" in _param:
-                    _param[
-                        "output_formatter"] = self.trt_configs.output_formatter
+            if "output_formatter" not in _param:
+                _param["output_formatter"] = self.trt_configs.output_formatter
 
             for _ in range(input_size[i]):
                 parameters.append(_param)

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -7,53 +7,69 @@ from djl_python.rolling_batch.rolling_batch import Request, Token, _json_output_
 class TestRollingBatch(unittest.TestCase):
 
     def test_json_fmt(self):
-        req = Request(0,
-                      "This is a wonderful day",
-                      parameters={"max_new_tokens": 256},
-                      output_formatter=_json_output_formatter)
-        req.set_next_token(Token(244, "He", -0.334532))
-        print(req.get_next_token(), end='')
-        assert req.get_next_token() == '{"generated_text": "He'
-        req.set_next_token(Token(576, "llo", -0.123123))
-        print(req.get_next_token(), end='')
-        assert req.get_next_token() == 'llo'
-        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
-        print(req.get_next_token(), end='')
-        assert req.get_next_token() == ' world"}'
+        req1 = Request(0,
+                       "This is a wonderful day",
+                       parameters={"max_new_tokens": 256},
+                       output_formatter=_json_output_formatter)
+        req2 = Request(1,
+                       "This is a wonderful day",
+                       parameters={
+                           "max_new_tokens": 256,
+                           "stream": False
+                       })
+        for req in [req1, req2]:
+            req.set_next_token(Token(244, "He", -0.334532))
+            print(req.get_next_token(), end='')
+            assert req.get_next_token() == '{"generated_text": "He'
+            req.set_next_token(Token(576, "llo", -0.123123))
+            print(req.get_next_token(), end='')
+            assert req.get_next_token() == 'llo'
+            req.set_next_token(Token(4558, " world", -0.567854), True,
+                               'length')
+            print(req.get_next_token(), end='')
+            assert req.get_next_token() == ' world"}'
 
     def test_jsonlines_fmt(self):
-        req = Request(0,
-                      "This is a wonderful day",
-                      parameters={"max_new_tokens": 256},
-                      output_formatter=_jsonlines_output_formatter)
-        req.set_next_token(Token(244, "He", -0.334532))
-        print(req.get_next_token(), end='')
-        assert json.loads(req.get_next_token()) == {
-            "token": {
-                "id": [244],
-                "text": "He",
-                "log_prob": -0.334532
+        req1 = Request(0,
+                       "This is a wonderful day",
+                       parameters={"max_new_tokens": 256},
+                       output_formatter=_jsonlines_output_formatter)
+        req2 = Request(1,
+                       "This is a wonderful day",
+                       parameters={
+                           "max_new_tokens": 256,
+                           "stream": True
+                       })
+        for req in [req1, req2]:
+            req.set_next_token(Token(244, "He", -0.334532))
+            print(req.get_next_token(), end='')
+            assert json.loads(req.get_next_token()) == {
+                "token": {
+                    "id": [244],
+                    "text": "He",
+                    "log_prob": -0.334532
+                }
             }
-        }
-        req.set_next_token(Token(576, "llo", -0.123123))
-        print(req.get_next_token(), end='')
-        assert json.loads(req.get_next_token()) == {
-            "token": {
-                "id": [576],
-                "text": "llo",
-                "log_prob": -0.123123
+            req.set_next_token(Token(576, "llo", -0.123123))
+            print(req.get_next_token(), end='')
+            assert json.loads(req.get_next_token()) == {
+                "token": {
+                    "id": [576],
+                    "text": "llo",
+                    "log_prob": -0.123123
+                }
             }
-        }
-        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
-        print(req.get_next_token(), end='')
-        assert json.loads(req.get_next_token()) == {
-            "token": {
-                "id": [4558],
-                "text": " world",
-                "log_prob": -0.567854
-            },
-            "generated_text": "Hello world"
-        }
+            req.set_next_token(Token(4558, " world", -0.567854), True,
+                               'length')
+            print(req.get_next_token(), end='')
+            assert json.loads(req.get_next_token()) == {
+                "token": {
+                    "id": [4558],
+                    "text": " world",
+                    "log_prob": -0.567854
+                },
+                "generated_text": "Hello world"
+            }
 
     def test_return_full_text(self):
         req = Request(0,

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -132,21 +132,20 @@ class TransformersNeuronXService(object):
                 content_type = item.get_property("Content-Type")
                 input_map = decode(item, content_type)
                 _inputs = input_map.pop("inputs", input_map)
+                _param = input_map.pop("parameters", {})
+                if "output_formatter" not in _param:
+                    _param["output_formatter"] = self.config.output_formatter
+                _param["stream"] = input_map.pop("stream", False)
                 if first or self.rolling_batch:
-                    parameters.append(input_map.pop("parameters", {}))
+                    parameters.append(_param)
                     first = False
                 else:
-                    param = input_map.pop("parameters", {})
-                    if parameters[0] != param:
+                    if parameters[0] != _param:
                         logging.warning(
-                            f"expected param: {parameters}, actual: {param}")
+                            f"expected param: {parameters}, actual: {_param}")
                         raise ValueError(
                             "In order to enable dynamic batching, all input batches must have the same parameters"
                         )
-
-                    if not "output_formatter" in param:
-                        param[
-                            "output_formatter"] = self.config.output_formatter
 
                 if isinstance(_inputs, list):
                     input_data.extend(_inputs)


### PR DESCRIPTION
## Description ##

This PR adds support for `stream` as a request configuration. With the change to make output formatter a request level concern, we can now support request level streaming.

The same thing can be achieved now by specifying output formatter as either json (non-streaming), or jsonlines (streaming). However, using a separate stream parameter is what we need for chat completions support. It is also more user friendly than specifying output formatter.

If output_formatter is specified in the request, we use that. 

If output_formatter is not specified, we then use the stream parameter to determine which format to use.

Sample Payload:
```
{
    "inputs": <inputs>,
    "parameters": {...},
    "stream": <bool>
}
```


## Testing

tested this with both deepspeed-nighlty and tensorrt-llm-nightly. Have not tested in neuronx container yet
