### PR TITLE
[Fix] set batch size property for handlers

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -56,6 +56,10 @@ public final class LmiConfigRecommender {
 
     private static void setRollingBatch(
             Properties lmiProperties, LmiUtils.HuggingFaceModelConfig modelConfig) {
+        // If dynamic batch is enabled, we don't enable rolling batch.
+        if (Integer.parseInt(lmiProperties.getProperty("batch_size", "1")) > 1) {
+            return;
+        }
         String rollingBatch = lmiProperties.getProperty("option.rolling_batch", "auto");
         String features = Utils.getEnvOrSystemProperty("SERVING_FEATURES");
         if (!"auto".equals(rollingBatch)) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -778,6 +778,9 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         if (batchSize <= 0) {
             batchSize = intValue(prop, "max_dynamic_batch_size", wlmc.getBatchSize());
             batchSize = intValue(prop, "batch_size", batchSize);
+            if (prop.containsKey("max_dynamic_batch_size")) {
+                prop.setProperty("batch_size", String.valueOf(batchSize));
+            }
         }
         if (maxBatchDelayMillis <= 0) {
             maxBatchDelayMillis = intValue(prop, "max_batch_delay", wlmc.getMaxBatchDelayMillis());


### PR DESCRIPTION
## Description ##

I am getting an inf2 machine and testing it. 

Why this fix?
When the user give max_dynamic_batch_size, we set the batchSize of workerpool config, which will do the dynamic batching. But in TNX handler, they check the batch_size in property and validate with the input size. So setting the batch_size property when max_dynamic_batch_size is given. 

Testing:
- Tested with inf2 machine with gpt2 handler (CI test which is failing)
