### PR TITLE
Increase test timeout for TRT-LLM compilation and tokenizer fix

### DIFF
--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -94,7 +94,6 @@ else
     --network="host" \
     ${model_path:+-v ${model_path}:/opt/ml/model:ro} \
     -v ${PWD}/logs:/opt/djl/logs \
-    -v ~/.djl.ai/:/tmp/.djl.ai \
     -v ~/.aws:/home/djl/.aws \
     -v ~/sagemaker_infra/:/opt/ml/.sagemaker_infra/:ro \
     ${env_file} \

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -550,13 +550,11 @@ trtllm_model_spec = {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
     "chatglm3-6b": {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
     "mistral-7b": {
         "max_memory_per_gpu": [22.0],

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -528,6 +528,12 @@ trtllm_model_spec = {
         "seq_length": [256],
         "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
+    "llama2-7b": {
+        "max_memory_per_gpu": [22.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+        "tokenizer": "TheBloke/Llama-2-7B-fp16"
+    },
     "falcon-7b": {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],
@@ -550,13 +556,13 @@ trtllm_model_spec = {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "baichuan-inc/Baichuan2-7B-Base"
+        "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
     "chatglm3-6b": {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "THUDM/chatglm3-6b"
+        "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
     "mistral-7b": {
         "max_memory_per_gpu": [22.0],

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -528,12 +528,6 @@ trtllm_model_spec = {
         "seq_length": [256],
         "tokenizer": "TheBloke/Llama-2-13B-fp16"
     },
-    "llama2-7b": {
-        "max_memory_per_gpu": [22.0],
-        "batch_size": [1, 4],
-        "seq_length": [256],
-        "tokenizer": "TheBloke/Llama-2-7B-fp16"
-    },
     "falcon-7b": {
         "max_memory_per_gpu": [22.0],
         "batch_size": [1, 4],

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -819,7 +819,7 @@ trtllm_handler_list = {
         "option.tensor_parallel_degree": 4,
         "option.output_formatter": "jsonlines",
         "option.trust_remote_code": True,
-        "option.chatglm_model_version": "chatglm3_6b"
+        "option.chatglm_model_version": "chatglm3"
     },
     "mistral-7b": {
         "option.model_id": "s3://djl-llm/mistral-7b/",


### PR DESCRIPTION
## Description ##

1. The new compilation workflow for TRT-LLM takes longer to compile due to two-step process: convert_checkpoint and 
trtllm-build.
2. Currently setting the retry value such that it increases wait time by 4-5 min. This is a bit generous. And if this addresses some of the timeout issues, will be reduced later to a more reasonable value.
3. Also changes some tokenizers for models to use llama, since awscurl fails for them due to the absence of `tokenizer.json`