### PR TITLE
[CI] Fixes vllm unmerged LoRA tests

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -928,6 +928,7 @@ def write_model_artifacts(properties,
             os.makedirs(os.path.join(adapters_path, adapter_name),
                         exist_ok=True)
             snapshot_download(adapter_id,
+                              local_dir_use_symlinks=False,
                               local_dir=os.path.join(adapters_path,
                                                      adapter_name))
 


### PR DESCRIPTION
Example: https://github.com/deepjavalibrary/djl-serving/actions/runs/8422220967/job/23061144377

The issue was that the download was through a symlink using the huggingface cache, but that cache was not in the container. This removes the symlink usage