### PR TITLE
support streaming for chat completions, refactor chat parsing to stan…

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/__init__.py
+++ b/engines/python/setup/djl_python/chat_completions/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.

--- a/engines/python/setup/djl_python/chat_completions/chat_properties.py
+++ b/engines/python/setup/djl_python/chat_completions/chat_properties.py
@@ -1,3 +1,15 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
 from typing import Optional, Union, List, Dict
 
 from pydantic.v1 import BaseModel, Field, validator, root_validator

--- a/engines/python/setup/djl_python/chat_completions/chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/chat_utils.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+from djl_python.chat_completions.chat_properties import ChatProperties
+
+
+def is_chat_completions_request(inputs: map) -> bool:
+    return "messages" in inputs
+
+
+def parse_chat_completions_request(inputs: map, is_rolling_batch: bool,
+                                   tokenizer):
+    if not hasattr(tokenizer, "apply_chat_template"):
+        raise AttributeError(
+            f"Cannot provide chat completion for tokenizer: {tokenizer.__class__}, "
+            f"please ensure that your tokenizer supports chat templates.")
+    chat_params = ChatProperties(**inputs)
+    _inputs = tokenizer.apply_chat_template(chat_params.messages,
+                                            tokenize=False)
+    _param = chat_params.dict(exclude_unset=True,
+                              exclude={
+                                  'messages', 'model', 'logit_bias',
+                                  'top_logprobs', 'n', 'user'
+                              })
+    if is_rolling_batch:
+        _param["details"] = True
+        _param["output_formatter"] = "jsonlines_chat" if inputs.get(
+            "stream", False) else "json_chat"
+
+    return _inputs, _param

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -195,6 +195,10 @@ def get_output_formatter(output_formatter: Union[str, Callable], stream: bool):
         return _json_output_formatter
     if output_formatter == "jsonlines":
         return _jsonlines_output_formatter
+    if output_formatter == "json_chat":
+        return _json_chat_output_formatter
+    if output_formatter == "jsonlines_chat":
+        return _jsonlines_chat_output_formatter
     if output_formatter == "none":
         return None
     if output_formatter is not None:

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -19,7 +19,7 @@ from djl_python.outputs import Output
 from djl_python.rolling_batch.rolling_batch import get_content_type_from_output_formatter
 from djl_python.rolling_batch.trtllm_rolling_batch import TRTLLMRollingBatch
 from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
-from djl_python.properties_manager.chat_properties import ChatProperties
+from djl_python.chat_completions.chat_utils import is_chat_completions_request, parse_chat_completions_request
 
 
 class TRTLLMService(object):
@@ -71,25 +71,9 @@ class TRTLLMService(object):
                 errors[i] = str(e)
                 continue
 
-            if "messages" in input_map:
-                if not hasattr(self.rolling_batch.get_tokenizer(),
-                               "apply_chat_template"):
-                    raise AttributeError(
-                        f"Cannot provide chat completion for tokenizer: "
-                        f"{self.rolling_batch.get_tokenizer().__class__}, "
-                        f"please ensure that your tokenizer supports chat templates."
-                    )
-                chat_params = ChatProperties(**input_map)
-                _inputs = self.rolling_batch.get_tokenizer(
-                ).apply_chat_template(chat_params.messages, tokenize=False)
-                _param = chat_params.dict(exclude_unset=True,
-                                          exclude={
-                                              'messages', 'model',
-                                              'logit_bias', 'top_logprobs',
-                                              'n', 'user'
-                                          })
-                _param["details"] = True
-                _param["output_formatter"] = "json_chat"
+            if is_chat_completions_request(input_map):
+                _inputs, _param = parse_chat_completions_request(
+                    input_map, True, self.rolling_batch.get_tokenizer())
             else:
                 _inputs = input_map.pop("inputs", input_map)
                 _param = input_map.pop("parameters", {})

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -10,7 +10,7 @@ from djl_python.properties_manager.vllm_rb_properties import VllmRbProperties
 from djl_python.properties_manager.sd_inf2_properties import StableDiffusionNeuronXProperties
 from djl_python.properties_manager.lmi_dist_rb_properties import LmiDistRbProperties, LmiDistQuantizeMethods
 from djl_python.properties_manager.scheduler_rb_properties import SchedulerRbProperties
-from djl_python.properties_manager.chat_properties import ChatProperties
+from djl_python.chat_completions.chat_properties import ChatProperties
 
 import torch
 


### PR DESCRIPTION
## Description ##

This PR does two things:
- separates the chat request parsing into a standalone method
- support streaming output via jsonlines_chat formatter

Tested locally with vllm/lmi-dist/trtllm

Note:
- While chat completions is supported via dynamic batching, the response we return is in our "standard" response format instead of the chat format. That is a separate issue and will be fixed in another PR