### PR TITLE
[TrtLLM] Support JIT compilation and dynamic batch for TrtLLM python backend

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -78,7 +78,6 @@ public class PyModel extends BaseModel {
                     "Python engine does not support dynamic blocks");
         }
         String entryPoint = null;
-        boolean isTrtLlmBackend = false;
         if (options != null) {
             logger.debug("options in serving.properties for model: {}", modelName);
             for (Map.Entry<String, ?> entry : options.entrySet()) {
@@ -121,9 +120,6 @@ public class PyModel extends BaseModel {
                     case "entryPoint":
                         entryPoint = value;
                         break;
-                    case "rolling_batch":
-                        isTrtLlmBackend = "trtllm".equals(value);
-                        break;
                     case "parallel_loading":
                         parallelLoading = Boolean.parseBoolean(value);
                         break;
@@ -158,6 +154,7 @@ public class PyModel extends BaseModel {
             entryPoint = Utils.getenv("DJL_ENTRY_POINT");
             if (entryPoint == null) {
                 Path modelFile = findModelFile(prefix);
+                String features = Utils.getEnvOrSystemProperty("SERVING_FEATURES");
                 // find default entryPoint
                 String engineName = manager.getEngine().getEngineName();
                 if (modelFile != null) {
@@ -167,7 +164,7 @@ public class PyModel extends BaseModel {
                 } else if ("nc".equals(manager.getDevice().getDeviceType())
                         && pyEnv.getTensorParallelDegree() > 0) {
                     entryPoint = "djl_python.transformers_neuronx";
-                } else if (isTrtLlmBackend) {
+                } else if ("trtllm".equals(features)) {
                     entryPoint = "djl_python.tensorrt_llm";
                 } else if (pyEnv.getInitParameters().containsKey("model_id")) {
                     entryPoint = "djl_python.huggingface";


### PR DESCRIPTION
## Description ##

T5 handler support is in another PR. Separated my changes into multiple PR for easy reviewing https://github.com/deepjavalibrary/djl-serving/pull/1680

This is for TensorRT-LLM T5 python backend
- Does JIT compilation of T5 models
- Automatically sets dynamic batch if not provided.
- Automatically sets engine=MPI and mpi_mode=True

NOTE: User has to disable rolling_batch in order for us to set dynamic batch and engine=mpi with these changes. We could do disable rolling batch ourselves, but did not do that way because, if TRTLLM release C++ backend support for T5 in between our releases, user could upgrade their TRTLLM in requirements.txt and enable rolling batch and test them. But open to suggestions here.

Testing:
Tested with flan-t5-xl in my EC2 machine.

My serving.properties
```
option.model_id=/opt/ml/model/t5/hf-model
option.rolling_batch=disable
option.entryPoint=djl_python.tensorrt_llm
```


