### PR TITLE
[feat] Build flash-attn from fork which allows smaller block-sizes for paged-attn

### DIFF
--- a/.github/workflows/lmi-dist-deps-build.yml
+++ b/.github/workflows/lmi-dist-deps-build.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           . ./venv/bin/activate
           export FLASH_ATTENTION_FORCE_BUILD=TRUE
-          git clone https://github.com/Dao-AILab/flash-attention.git flash-attention-v2 -b v2.5.6
+          git clone https://github.com/ymwangg/flash-attention flash-attention-v2 -b specdec_v0.3.3
           cd flash-attention-v2
           pip wheel . --no-deps
           cp flash_attn-*.whl ../build_artifacts


### PR DESCRIPTION
## Description ##
Build flash-attn from fork which allows smaller block-sizes for paged-attn. [[branch](https://github.com/ymwangg/flash-attention/tree/specdec_v0.3.3)]

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made? N/A
- Interesting edge cases to note here: N/A
