### PR TITLE
[ci][lcnc] add trt-llm container to no code tests

### DIFF
--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -7,6 +7,8 @@ on:
         description: 'The released version of DJL'
         required: false
         default: ''
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
   create-runners:
@@ -46,13 +48,13 @@ jobs:
 
   p4d-no-code-tests:
     runs-on: [self-hosted, p4d]
-    timeout-minutes: 120
+    timeout-minutes: 240
     needs: create-runners
     strategy:
       # Limit to 1 so we don't steal a p4d from another test that may be running
       max-parallel: 1
       matrix:
-        container: [deepspeed]
+        container: [tensorrt-llm, deepspeed]
     steps:
       - uses: actions/checkout@v4
       - name: Clean env
@@ -81,7 +83,7 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/llama-2-70b-hf/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code llama-70b
           docker rm -f $(docker ps -aq)
@@ -90,7 +92,7 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=codellama/CodeLlama-34b-hf" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code codellama
           docker rm -f $(docker ps -aq)
@@ -99,7 +101,7 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/mixtral-8x7b/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code mixtral-8x7b
           docker rm -f $(docker ps -aq)
@@ -108,7 +110,7 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/falcon-40b/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code falcon-40b 
           docker rm -f $(docker ps -aq) 
@@ -125,11 +127,11 @@ jobs:
 
   g512-no-code-tests:
     runs-on: [self-hosted, g5]
-    timeout-minutes: 120
+    timeout-minutes: 240
     needs: create-runners
     strategy:
       matrix:
-        container: [deepspeed]
+        container: [tensorrt-llm, deepspeed]
     steps:
       - uses: actions/checkout@v4
       - name: Clean env
@@ -158,7 +160,7 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/llama-2-7b-hf/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code llama-7b
           docker rm -f $(docker ps -aq)
@@ -167,17 +169,17 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/llama-2-13b-hf/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code llama-13b
           docker rm -f $(docker ps -aq)
       - name: Gemma-7b lmi container
-        if: ${{ matrix.container }} == "deepspeed"
+        if: ${{ matrix.container  == 'deepspeed' }}
         working-directory: tests/integration
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/gemma-7b/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code gemma-7b
           docker rm -f $(docker ps -aq)
@@ -186,27 +188,25 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/mistral-7b/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code mistral-7b
           docker rm -f $(docker ps -aq)
       - name: GPTNeox lmi container
-        if: ${{ matrix.container }} == "deepspeed"
         working-directory: tests/integration
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/gpt-neox-20b/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code gpt-neox
           docker rm -f $(docker ps -aq)
       - name: Phi2 lmi container
-        if: ${{ matrix.container }} == "deepspeed"
         working-directory: tests/integration
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=microsoft/phi-2" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code phi-2
           docker rm -f $(docker ps -aq)
@@ -215,25 +215,27 @@ jobs:
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=s3://djl-llm/baichuan2-13b/\nHF_MODEL_TRUST_REMOTE_CODE=true" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code baichuan-13b
           docker rm -f $(docker ps -aq)
       - name: Qwen-1.5 lmi container
         working-directory: tests/integration
+        if: ${{ matrix.container == 'deepspeed' }}
         run: |
           rm -rf models
           echo -en "HF_MODEL_ID=Qwen/Qwen1.5-14B" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code qwen-1.5-14b
           docker rm -f $(docker ps -aq)
-      - name: Starcoder lmi container
+      - name: Starcoder2 lmi container
         working-directory: tests/integration
+        if: ${{ matrix.container == 'deepspeed' }}
         run: |
           rm -rf models
-          echo -en "HF_MODEL_ID=s3://djl-llm/bigcode-starcoder/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models deepspeed \
+          echo -en "HF_MODEL_ID=s3://djl-llm/bigcode-starcoder2/" > docker_env
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }} \
           serve
           python3 llm/client.py no_code starcoder
           docker rm -f $(docker ps -aq)

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -23,7 +23,7 @@ fi
 is_llm=false
 if [[ "$platform" == *"-gpu"* ]]; then # if the platform has cuda capabilities
   runtime="nvidia"
-elif [[ "$platform" == *"deepspeed"* || "$platform" == *"trtllm"* ]]; then # Runs multi-gpu
+elif [[ "$platform" == *"deepspeed"* || "$platform" == *"trtllm"*  || "$platform" == *"tensorrt-llm"* ]]; then # Runs multi-gpu
   runtime="nvidia"
   is_llm=true
   shm="12gb"
@@ -117,8 +117,8 @@ if $is_llm; then
   if [[ "$platform" == *"inf2"* ]]; then
     total_retries=80
   fi
-  if [[ "$platform" == *"trtllm"* ]]; then
-    total_retries=100
+  if [[ "$platform" == *"trtllm"* || "$platform" == *"tensorrt-llm"* ]]; then
+    total_retries=150
     echo "extra sleep of 10 min for trtllm compilation"
   fi
   if [[ "$platform" == *"trtllm-sq"* ]]; then


### PR DESCRIPTION
## Description ##

Adds trt-llm to no code suite.

I've tested portions of the full suite independently, and i'm pretty confident everything will work together.

Struggling with capacity to test the full suite.

This test suite will take a LONG time to run. Couple options:
- add a new input: `run_all` that allows you to run all the tests. The default would be a `$RANDOM` number. This number could be used to run half the tests if even, other half the tests if odd.
- reduce the overall test suite to limit time
