### PR TITLE
pass trust_remote_code and revision to from_pretrained methods that a…

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -179,7 +179,11 @@ class SchedulerRollingBatch(RollingBatch):
                     **self.scheduler_configs.kwargs)
 
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.scheduler_configs.model_id_or_path, padding_side="left")
+            self.scheduler_configs.model_id_or_path,
+            padding_side="left",
+            trust_remote_code=self.scheduler_configs.trust_remote_code,
+            revision=self.scheduler_configs.revision,
+        )
         if not self.tokenizer.pad_token:
             self.tokenizer.pad_token = self.tokenizer.eos_token
 

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -79,7 +79,9 @@ class TransformersNeuronXService(object):
             self.config.batch_size = self.config.max_rolling_batch_size
 
         self.model_config = AutoConfig.from_pretrained(
-            self.config.model_id_or_path, revision=self.config.revision)
+            self.config.model_id_or_path,
+            revision=self.config.revision,
+            trust_remote_code=self.config.trust_remote_code)
 
         self.set_model_loader_class()
         if not self.config.task:


### PR DESCRIPTION
…e config

## Description #

Add revision and trust_remote_code properties to `from_pretrained` methods that are missing them.

Notes:
- Tested across DS/Scheduler/VLLM/LMI-Dist/TRTLLM.
- It's hard to make sense of what we're passing where. sometimes we use properties, sometimes kwargs, sometimes nothing. This needs to be refactored, but given that we're close to release I don't want to make big sweeping changes without sufficient time to test everything. I am working on a refactor separately
