### PR TITLE
fix params for from_config model instantiation

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -229,14 +229,11 @@ class DeepSpeedService(object):
                               **kwargs):
         tokenizer = AutoTokenizer.from_pretrained(
             model_id_or_path,
-            trust_remote_code=self.properties.trust_remote_code,
-            revision=self.properties.revision,
-        )
-        model = TASK_TO_MODEL[self.properties.task].from_config(
-            self.model_config,
             trust_remote_code=trust_remote_code,
             revision=revision,
-            **kwargs)
+        )
+        model = TASK_TO_MODEL[self.properties.task].from_config(
+            self.model_config)
         return model, tokenizer
 
     def get_model(self, model_id_or_path, loading_method, **kwargs):


### PR DESCRIPTION
## Description ##

`from_config` does not accept any kwargs except for attn_implementation. removing all kwargs from calls to from_config, which only occurs in ds handler
