### PR TITLE
[python] Set do_sample from temperature in chat completions

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/chat_utils.py
@@ -29,9 +29,11 @@ def parse_chat_completions_request(inputs: map, is_rolling_batch: bool,
             f"Cannot provide chat completion for tokenizer: {tokenizer.__class__}, "
             f"please ensure that your tokenizer supports chat templates.")
     chat_params = ChatProperties(**inputs)
-    _param = chat_params.model_dump(by_alias=True, exclude_unset=True)
+    _param = chat_params.model_dump(by_alias=True, exclude_none=True)
     _messages = _param.pop("messages")
     _inputs = tokenizer.apply_chat_template(_messages, tokenize=False)
+    _param[
+        "do_sample"] = chat_params.temperature is not None and chat_params.temperature > 0.0
     _param["details"] = True  # Enable details for chat completions
     _param[
         "output_formatter"] = "jsonlines_chat" if chat_params.stream else "json_chat"


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

In chat completions, there's no do_sample parameter. And in rolling batch handlers, if do_sample is not set, temperature will be reset to 0. So set do_sample parameter in chat_completions.

https://github.com/deepjavalibrary/djl-serving/blob/master/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py#L112

https://github.com/deepjavalibrary/djl-serving/blob/master/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py#L93

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
