### PR TITLE
[TRTLLM Python backend]Fix the output format for client side batching in dynamic batch 

### DIFF
--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -4,12 +4,13 @@ from djl_python.encode_decode import encode, decode
 from djl_python.chat_completions.chat_utils import is_chat_completions_request, parse_chat_completions_request
 
 
-def parse_input(
-        inputs: Input, tokenizer, output_formatter
-) -> tuple[list[str], list[int], list[dict], dict, list]:
+def parse_input_with_client_batch(
+    inputs: Input, tokenizer, output_formatter
+) -> tuple[list[str], list[int], list[dict], dict, list, list]:
     """
     Preprocessing function that extracts information from Input objects.
 
+    :param output_formatter: output formatter for the request
     :param inputs :(Input) a batch of inputs, each corresponding to a new request
     :param tokenizer: the tokenizer used for inference
 
@@ -18,12 +19,15 @@ def parse_input(
     :return parameters (list[dict]): parameters pertaining to each request
     :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
     :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
+    :return is_client_size_batch (list): list of boolean value representing whether the input is a client side batch
     """
     input_data = []
     input_size = []
     parameters = []
     errors = {}
     batch = inputs.get_batches()
+    # only for dynamic batch
+    is_client_size_batch = [False for _ in range(len(batch))]
     for i, item in enumerate(batch):
         try:
             content_type = item.get_property("Content-Type")
@@ -43,6 +47,8 @@ def parse_input(
             _param["stream"] = input_map.pop("stream", False)
         if not isinstance(_inputs, list):
             _inputs = [_inputs]
+        else:
+            is_client_size_batch[i] = True
         input_data.extend(_inputs)
         input_size.append(len(_inputs))
 
@@ -58,4 +64,25 @@ def parse_input(
         for _ in range(input_size[i]):
             parameters.append(_param)
 
+    return input_data, input_size, parameters, errors, batch, is_client_size_batch
+
+
+def parse_input(
+        inputs: Input, tokenizer, output_formatter
+) -> tuple[list[str], list[int], list[dict], dict, list]:
+    """
+    Preprocessing function that extracts information from Input objects.
+
+    :param output_formatter: output formatter for the request
+    :param inputs :(Input) a batch of inputs, each corresponding to a new request
+    :param tokenizer: the tokenizer used for inference
+
+    :return input_data (list[str]): a list of strings, each string being the prompt in a new request
+    :return input_size (list[int]): a list of ints being the size of each new request
+    :return parameters (list[dict]): parameters pertaining to each request
+    :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
+    :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
+    """
+    input_data, input_size, parameters, errors, batch, _ = parse_input_with_client_batch(
+        inputs, tokenizer, output_formatter)
     return input_data, input_size, parameters, errors, batch

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -618,7 +618,8 @@ trtllm_model_spec = {
     "flan-t5-xl": {
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "google/flan-t5-xl"
+        "tokenizer": "google/flan-t5-xl",
+        "details": True
     }
 }
 
@@ -1160,6 +1161,8 @@ def test_handler(model, model_spec):
             if spec.get("adapters", []):
                 req["adapters"] = spec.get("adapters")
             params = {"max_new_tokens": seq_length}
+            if spec.get("details", False):
+                params["details"] = True
             req["parameters"] = params
             logging.info(f"req {req}")
             res = send_json(req)

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -897,9 +897,7 @@ trtllm_handler_list = {
         "option.output_formatter": "jsonlines"
     },
     "flan-t5-xl": {
-        "option.model_id": "s3://djl-llm/flan-t5-xl/",
-        "option.rolling_batch": "disable",
-        "option.entryPoint": "djl_python.tensorrt_llm"
+        "option.model_id": "s3://djl-llm/flan-t5-xl/"
     }
 }
 


### PR DESCRIPTION
## Description ##

If the user sends, client side batch then the result is json array. If the user sends single input, then we send back json object. 

Examples:
Request : `"inputs":["The new movie that got Oscar this year"]`
Response : 
```
[
  {
    "generated_text":"The new movie that got Oscar this year is The Shape of Water."
  }
]
```

Request: `"inputs":"The new movie that got Oscar this year"`
Response:
```
{
  "generated_text":"The new movie that got Oscar this year is The Shape of Water."
}
```
