### PR TITLE
[lcnc] add starcoder2 model type to auto configure list

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -50,7 +50,8 @@ public final class LmiConfigRecommender {
                     Map.entry("qwen", "vllm"),
                     Map.entry("qwen2", "vllm"),
                     Map.entry("stablelm", "vllm"),
-                    Map.entry("dbrx", "lmi-dist"));
+                    Map.entry("dbrx", "lmi-dist"),
+                    Map.entry("starcoder2", "lmi-dist"));
 
     private static final Set<String> OPTIMIZED_TASK_ARCHITECTURES =
             Set.of("ForCausalLM", "LMHeadModel", "ForConditionalGeneration");


### PR DESCRIPTION
## Description ##

missed this one in the initial model mapping list. tested with both vllm and lmi-dist
