### PR TITLE
[TRTLLM] Remove gptneox from LCNC trtllm tests

### DIFF
--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -208,6 +208,7 @@ jobs:
           python3 llm/client.py no_code mistral-7b
           docker rm -f $(docker ps -aq)
       - name: GPTNeox lmi container
+        if: ${{ matrix.container  == 'deepspeed' }}
         working-directory: tests/integration
         run: |
           rm -rf models


### PR DESCRIPTION
## Description ##

1. Paged_kv_cache not supported by gpt neox

```
assert default_net(
INFO  LmiUtils convert_py: AssertionError: Paged KV cache is not supported for this model yet, will add in future release
```
2. But if disabled, inflight batcher does not work
```
WARN  PyProcess W-449-model-stderr: [1,0]<stderr>:Arguments: (RuntimeError("error: load model: Invalid argument - load failed for model 'fe19578afd651a19e1a73eddc27c47b677ae5410': version 1 is at UNAVAILABLE state: Internal: unexpected error when creating modelInstanceState: TrtGptModelInflightBatching requires GPT attention plugin with packed input and paged KV cache.;\n"),)
```

It seems this will be supported in next version v0.9.0
