### PR TITLE
 [fix] fix custom input and output formatting

### DIFF
--- a/engines/python/setup/djl_python/deepspeed.py
+++ b/engines/python/setup/djl_python/deepspeed.py
@@ -127,7 +127,8 @@ class DeepSpeedService(object):
                 "max_batch_size":
                 int(properties.get("max_rolling_batch_size", 4)),
                 "max_seq_len": int(properties.get("max_tokens", 1024)),
-                "tokenizer": self.tokenizer
+                "tokenizer": self.tokenizer,
+                "output_formatter": self.properties.output_formatter,
             }
             self.rolling_batch = DeepSpeedRollingBatch(self.model, properties,
                                                        **kwargs)

--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -99,8 +99,6 @@ class HuggingFaceProperties(Properties):
 
         # TODO remove this after refactor of all handlers
         if properties['rolling_batch'].value != RollingBatchEnum.disable.value:
-            if properties['output_formatter']:
-                kwargs["output_formatter"] = properties['output_formatter']
             if properties['waiting_steps']:
                 kwargs["waiting_steps"] = properties['waiting_steps']
 

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -46,7 +46,9 @@ class LmiDistRollingBatch(RollingBatch):
         :param properties (dict): other properties of the model, such as decoder strategy
         """
         self.lmi_dist_config = LmiDistRbProperties(**properties)
-        super().__init__(waiting_steps=self.lmi_dist_config.waiting_steps)
+        super().__init__(
+            waiting_steps=self.lmi_dist_config.waiting_steps,
+            output_formatter=self.lmi_dist_config.output_formatter)
         self.supports_speculative_decoding = supports_speculative_decoding()
         engine_kwargs = {}
         if self.supports_speculative_decoding:

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -62,7 +62,9 @@ class SchedulerRollingBatch(RollingBatch):
         """
 
         self.scheduler_configs = SchedulerRbProperties(**properties)
-        super().__init__(waiting_steps=self.scheduler_configs.waiting_steps)
+        super().__init__(
+            waiting_steps=self.scheduler_configs.waiting_steps,
+            output_formatter=self.scheduler_configs.output_formatter)
         self._init_model_and_tokenizer()
         self._init_scheduler()
 

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -42,7 +42,8 @@ class VLLMRollingBatch(RollingBatch):
         :param properties: other properties of the model, such as decoder strategy
         """
         self.vllm_configs = VllmRbProperties(**properties)
-        super().__init__(waiting_steps=self.vllm_configs.waiting_steps)
+        super().__init__(waiting_steps=self.vllm_configs.waiting_steps,
+                         output_formatter=self.vllm_configs.output_formatter)
         args = EngineArgs(
             model=self.vllm_configs.model_id_or_path,
             tensor_parallel_size=self.vllm_configs.tensor_parallel_degree,

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -31,6 +31,7 @@ class TRTLLMService(object):
         self.initialized = False
         self.trt_configs = None
         self.rolling_batch = None
+        self.parse_input = parse_input
 
     def initialize(self, properties: dict):
         self.trt_configs = TensorRtLlmProperties(**properties)
@@ -50,7 +51,7 @@ class TRTLLMService(object):
         """
         outputs = Output()
 
-        input_data, input_size, parameters, errors, batch = parse_input(
+        input_data, input_size, parameters, errors, batch = self.parse_input(
             inputs, self.rolling_batch.get_tokenizer(),
             self.trt_configs.output_formatter)
         if len(input_data) == 0:

--- a/engines/python/setup/djl_python/tensorrt_llm_python.py
+++ b/engines/python/setup/djl_python/tensorrt_llm_python.py
@@ -84,6 +84,7 @@ class TRTLLMPythonService:
         self.model = None
         self.trt_configs = None
         self.initialized = False
+        self.parse_input = parse_input
 
     def initialize(self, properties: dict):
         self.trt_configs = TensorRtLlmProperties(**properties)
@@ -101,7 +102,7 @@ class TRTLLMPythonService:
         """
         outputs = Output()
 
-        input_data, input_size, parameters, errors, batch = parse_input(
+        input_data, input_size, parameters, errors, batch = self.parse_input(
             inputs, None, self.trt_configs.output_formatter)
         if len(input_data) == 0:
             for i in range(len(batch)):

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -401,7 +401,6 @@ class TestConfigManager(unittest.TestCase):
                 "device_map": 'cpu',
                 "load_in_8bit": True,
                 "waiting_steps": 12,
-                "output_formatter": "jsonlines",
                 "torch_dtype": torch.bfloat16
             })
 

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -98,6 +98,8 @@ class TransformersNeuronXService(object):
 
     def set_rolling_batch(self):
         if self.config.rolling_batch != "disable":
+            self.rolling_batch_config[
+                "output_formatter"] = self.config.output_formatter
             self.rolling_batch = NeuronRollingBatch(
                 self.model, self.tokenizer, self.config.batch_size,
                 self.config.n_positions, **self.rolling_batch_config)


### PR DESCRIPTION
## Description ##

Two fixes related to providing custom input/output formatters. While not a fully supported use-case, there are currently users relying on this behavior that we need to maintain support for.

1. custom input formatting for tensorrtllm handlers. Users of previous versions rely on overriding `parse_input` method of the Service object. the static parse_input method no longer works for overriding, so i've made `self.parse_input` accessible again so that users can override this default implementation the same way they do in previous releases.

2. custom output formatting by providing `option.output_formatter` no longer works. We probably missed this when making the changes to per request output_formatter. This also adds back that logic
