### PR TITLE
fix naming of some inconsistent fields in output formatters

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -57,20 +57,20 @@ class Token(object):
 
 
 def _json_output_formatter(token: Token, first_token: bool, last_token: bool,
-                           details: dict, generated_tokens: str, id: int):
+                           details: dict, generated_text: str, id: int):
     """
     json output formatter
 
     :return: formatted output
     """
-    json_encoded_str = f"{{\"generated_text\": \"{generated_tokens}" if first_token else ""
+    json_encoded_str = f"{{\"generated_text\": \"{generated_text}" if first_token else ""
     json_encoded_str = f"{json_encoded_str}{json.dumps(token.text, ensure_ascii=False)[1:-1]}"
     if last_token:
         if details:
             final_dict = {
                 "finish_reason": details.get("finish_reason", None),
                 "generated_tokens": details.get("generated_tokens", None),
-                "input_text": details.get("input_text", None),
+                "inputs": details.get("inputs", None),
                 "tokens": details.get("tokens", None)
             }
             details_str = f"\"details\": {json.dumps(final_dict, ensure_ascii=False)}"
@@ -83,7 +83,7 @@ def _json_output_formatter(token: Token, first_token: bool, last_token: bool,
 
 def _jsonlines_output_formatter(token: Token, first_token: bool,
                                 last_token: bool, details: dict,
-                                generated_tokens: str, id: int):
+                                generated_text: str, id: int):
     """
     jsonlines output formatter
 
@@ -92,12 +92,12 @@ def _jsonlines_output_formatter(token: Token, first_token: bool,
     token_dict = token.as_dict()
     final_dict = {"token": token_dict}
     if last_token:
-        final_dict["generated_text"] = generated_tokens
+        final_dict["generated_text"] = generated_text
         if details:
             final_dict["details"] = {
                 "finish_reason": details.get("finish_reason", None),
                 "generated_tokens": details.get("generated_tokens", None),
-                "input_text": details.get("input_text", None)
+                "inputs": details.get("inputs", None)
             }
     json_encoded_str = json.dumps(final_dict, ensure_ascii=False) + "\n"
     return json_encoded_str
@@ -105,7 +105,7 @@ def _jsonlines_output_formatter(token: Token, first_token: bool,
 
 def _json_chat_output_formatter(token: Token, first_token: bool,
                                 last_token: bool, details: dict,
-                                generated_tokens: str, id: int):
+                                generated_text: str, id: int):
     """
     json output formatter for chat completions API
 
@@ -116,7 +116,7 @@ def _json_chat_output_formatter(token: Token, first_token: bool,
         "index": 0,
         "message": {
             "role": "assistant",
-            "content": generated_tokens
+            "content": generated_text
         }
     }
     response1 = {
@@ -169,7 +169,7 @@ def _json_chat_output_formatter(token: Token, first_token: bool,
 
 def _jsonlines_chat_output_formatter(token: Token, first_token: bool,
                                      last_token: bool, details: dict,
-                                     generated_tokens: str, id: int):
+                                     generated_text: str, id: int):
     """
     jsonlines output formatter for chat completions API
 
@@ -342,7 +342,7 @@ class Request(object):
             details_dict["finish_reason"] = finish_reason
             details_dict["tokens"] = self.token_cache
             details_dict["generated_tokens"] = len(self.token_cache)
-            details_dict["input_text"] = self.input_text
+            details_dict["inputs"] = self.input_text
             details_dict["parameters"] = self.original_params
             details_dict["prompt_tokens"] = len(self.input_ids)
         generated_text = self.full_text_prefix

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -134,7 +134,7 @@ class TestRollingBatch(unittest.TestCase):
         assert final_json == {
             "generated_text": "Hello world",
             "details": {
-                'input_text':
+                'inputs':
                 'This is a wonderful day',
                 "finish_reason":
                 "length",
@@ -176,7 +176,7 @@ class TestRollingBatch(unittest.TestCase):
             },
             "generated_text": "Hello world",
             "details": {
-                'input_text': 'This is a wonderful day',
+                'inputs': 'This is a wonderful day',
                 "finish_reason": "length",
                 "generated_tokens": 3,
             }
@@ -220,7 +220,7 @@ class TestRollingBatch(unittest.TestCase):
             'details': {
                 'finish_reason': 'length',
                 'generated_tokens': 3,
-                'input_text': 'This is a wonderful day'
+                'inputs': 'This is a wonderful day'
             },
             "generated_text": "Hello world"
         }
@@ -322,7 +322,7 @@ class TestRollingBatch(unittest.TestCase):
         assert json.loads(req.get_next_token()) == {
             'finish_reason': None,
             'generated_tokens': 1,
-            'input_text': 'This is a wonderful day',
+            'inputs': 'This is a wonderful day',
             'tokens': [{
                 'id': [244],
                 'log_prob': -0.334532,
@@ -341,7 +341,7 @@ class TestRollingBatch(unittest.TestCase):
             None,
             'generated_tokens':
             2,
-            'input_text':
+            'inputs':
             'This is a wonderful day',
             'tokens': [
                 {
@@ -369,7 +369,7 @@ class TestRollingBatch(unittest.TestCase):
             'length',
             'generated_tokens':
             3,
-            'input_text':
+            'inputs':
             'This is a wonderful day',
             'tokens': [{
                 'id': [244],

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -54,7 +54,7 @@ Example response:
     "details": {
         "finish reason": "length",
         "generated_tokens": 8,
-        "input_text": "What is Deep Learning?",
+        "inputs": "What is Deep Learning?",
         "tokens": [<Token1>, <Token2>, ...]
     }
 }
@@ -79,7 +79,7 @@ Example response:
 {
     "token": {"id": [5972], "text": " field.", "log_prob": -0.6950479745864868}, 
     "generated_text": "Deep Learning is a really cool field.", 
-    "details": {"finish_reason": "length", "generated_tokens": 100, "input_text": "What is Deep Learning?"}
+    "details": {"finish_reason": "length", "generated_tokens": 100, "inputs": "What is Deep Learning?"}
 }
 ```
 
@@ -290,7 +290,7 @@ You must specify `details=true` in the input `parameters`.
 |--------------------|---------------------------|---------------------------------------------------------------------------------------------------|----------------------------------------|
 | `finish_reason`    | string enum               | the reason for concluding generation                                                              | `length`, `eos_token`, `stop_sequence` |
 | `generated_tokens` | number                    | the number of tokens generated                                                                    | 128                                    |
-| `input_text`       | string                    | the input/prompt used to start generation                                                         | "Deep Learning is"                     |
+| `inputs`           | string                    | the input/prompt used to start generation                                                         | "Deep Learning is"                     |
 | `tokens`           | array of [Tokens](#token) | An array of token objects, one for each token generated. Only returned in non-streaming use-cases | See the [Tokens](#token) documentation |
 
 Example:
@@ -298,7 +298,7 @@ Example:
 "details": {
    "finish_reason": "length",
    "generated_tokens": 128,
-   "input_text": "Deep Learning is"
+   "inputs": "Deep Learning is"
    "tokens": [<Token1>, <Token2>, ...]
 }
 ```


### PR DESCRIPTION
## Description ##

2 changes:

1. in details, return "inputs" instead of "input_text" to match the request body "inputs"
2. change generated_tokens -> generated_text in the output formatter method signatures
