### PR TITLE
[lcnc] make default rolling batch size 256 for vllm, lmi-dist

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -144,6 +144,26 @@ public final class LmiConfigRecommender {
         }
     }
 
+    static void setRollingBatchSize(Properties lmiProperties) {
+        if (lmiProperties.containsKey("option.max_rolling_batch_size")) {
+            return;
+        }
+        String rollingBatch = lmiProperties.getProperty("option.rolling_batch");
+        int rollingBatchSize = 32;
+        if ("vllm".equals(rollingBatch) || "lmi-dist".equals(rollingBatch)) {
+            rollingBatchSize = 256;
+        }
+        if ("trtllm".equals(rollingBatch)
+                || ("auto".equals(rollingBatch)
+                        && isTrtLLMEnabled(Utils.getEnvOrSystemProperty("SERVING_FEATURES")))) {
+            if (lmiProperties.containsKey("option.max_num_tokens")) {
+                rollingBatchSize = 256;
+            }
+        }
+        lmiProperties.setProperty(
+                "option.max_rolling_batch_size", String.valueOf(rollingBatchSize));
+    }
+
     private static boolean isVLLMEnabled(String features) {
         return features != null && features.contains("vllm");
     }

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
@@ -84,6 +84,11 @@ public final class LmiUtils {
         return false;
     }
 
+    static boolean isRollingBatchEnabled(Properties properties) {
+        String rollingBatch = properties.getProperty("option.rolling_batch");
+        return null != rollingBatch && !"disable".equals(rollingBatch);
+    }
+
     static boolean needConvert(ModelInfo<?, ?> info) {
         Properties properties = info.getProperties();
         return isTrtLLMRollingBatch(info.getProperties())

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -806,6 +806,11 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
         if (engineName == null) {
             engineName = inferEngine();
         }
+        // TODO: capture this in the LmiConfigRecommender.configure method once we refactor that to
+        // run always, not just when engine is missing
+        if (LmiUtils.isRollingBatchEnabled(this.getProperties())) {
+            LmiConfigRecommender.setRollingBatchSize(this.getProperties());
+        }
 
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<Object, Object> entry : prop.entrySet()) {


### PR DESCRIPTION
## Description ##

This is a workaround to set the default rb size for vllm and lmi-dist to 256. 
I would like to capture this in the LmiConfigRecommender.configure api, but that will rely on https://github.com/deepjavalibrary/djl-serving/pull/1727
