### PR TITLE
fix issue with duplicate model loading for local hf model on sagemaker

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -479,6 +479,18 @@ public class ModelServer {
                 return null;
             }
 
+            // workaround to prevent duplicate loading when HF_MODEL_ID points to a path we already
+            // loaded
+            // we use HF_MODEL_ID to load the model since we create serving.properties on the fly
+            String huggingFaceModelId = Utils.getEnvOrSystemProperty("HF_MODEL_ID");
+            if (huggingFaceModelId != null && path.startsWith(huggingFaceModelId)) {
+                logger.debug(
+                        "HF_MODEL_ID points to the same path {}. Will load model via HF_MODEL_ID"
+                                + " handling",
+                        path);
+                return null;
+            }
+
             path = Utils.getNestedModelDir(path);
             String url = path.toUri().toURL().toString();
             String modelName = ModelInfo.inferModelNameFromUrl(url);


### PR DESCRIPTION
## Description ##

This is a quick fix for when user has local model artifacts in /opt/ml/model, and also sets HF_MODEL_ID=/opt/ml/model.

Previously, we attempt to load this model twice, which can cause issues. Now, we will just load it once via HF_MODEL_ID. 

This is a very simple check that probably doesn't address all cases, but should for the common case
