### PR TITLE
[tnx] add torchvision for resnet tests

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -12,6 +12,7 @@
 FROM ubuntu:20.04
 ARG djl_version=0.28.0~SNAPSHOT
 ARG torch_version=2.1.2
+ARG torchvision_version=0.16.2
 ARG python_version=3.9
 ARG neuronsdk_version=2.18.1
 ARG torch_neuronx_version=2.1.2.2.1.0
@@ -73,6 +74,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     neuronx_distributed==${neuronx_distributed_version} protobuf==${protobuf_version} sentencepiece jinja2 \
     diffusers==${diffusers_version} opencv-contrib-python-headless  Pillow --extra-index-url=https://pip.repos.neuron.amazonaws.com \
     pydantic==${pydantic_version} optimum optimum-neuron==${optimum_neuron_version} tiktoken blobfile && \
+    torchvision=${torchvision_version} && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \
     useradd -m -d /home/djl djl && \


### PR DESCRIPTION
## Description ##

Add torchvision to the docker image, this will replace the need for a requirements.txt in the python integration test and allow us to use just one traced model artifact rather than one per version of pytorch.