### PR TITLE
[ci][vllm] reduce max seq len for gemma vllm

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -742,7 +742,7 @@ vllm_model_list = {
         "option.trust_remote_code": True,
         "option.tensor_parallel_degree": 1,
         "option.max_rolling_batch_size": 4,
-        "option.max_model_len": 3480,
+        "option.max_model_len": 3280,
     },
     "llama2-7b-chat": {
         "option.model_id": "s3://djl-llm/meta-llama-Llama-2-7b-chat-hf/",


### PR DESCRIPTION
## Description ##

We updated the AMI around the same time that this test started failing. This AMI brought in a new cuda driver (old:  535.54.03, new: 535.161.08).

That's the only change during the timeframe where this behavior changed that makes sense as the cause. None of the source changes we have made are relevant to this change in behavior.
