### PR TITLE
[trtllm] Fix way to determine trtllm rolling batch

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiUtils.java
@@ -75,12 +75,7 @@ public final class LmiUtils {
         if ("trtllm".equals(rollingBatch)) {
             return true;
         }
-        if (rollingBatch == null || "auto".equals(rollingBatch)) {
-            // FIXME: find a better way to set default rolling batch for trtllm
-            String features = Utils.getEnvOrSystemProperty("SERVING_FEATURES");
-            return features != null && features.contains("trtllm");
-        }
-        return false;
+        return !"disable".equals(rollingBatch);
     }
 
     static boolean needConvert(ModelInfo<?, ?> info) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix way to determine trtllm rolling batch. Currently since the dockerfile always set SERVING_FEATURES to trtllm, so rolling batch is always true. This will falsely enable partition script even using java engine.