### PR TITLE
[lmi] infer entry point for lmi models in LmiConfigRecommender

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -166,7 +166,8 @@ public class PyModel extends BaseModel {
                     entryPoint = "djl_python.transformers_neuronx";
                 } else if ("trtllm".equals(features)) {
                     entryPoint = "djl_python.tensorrt_llm";
-                } else if (pyEnv.getInitParameters().containsKey("model_id")) {
+                } else if (pyEnv.getInitParameters().containsKey("model_id")
+                        || Files.exists(modelPath.resolve("config.json"))) {
                     entryPoint = "djl_python.huggingface";
                 } else {
                     throw new FileNotFoundException(".py file not found in: " + modelPath);


### PR DESCRIPTION
## Description ##

Adds infer entry point logic to LmiConfigRecommender, and removes the duplicate logic from PyModel.

This will also address a couple of issues:
- this will now infer the correct entrypoint when djl-serving is only provided with raw model files (previously this did not work)
- this will now infer the correct entrypoint when HF_MODEL_ID=<s3_uri>. This did work previously, but some of the previous refactor around HF_MODEL_ID to fix other issues exposed some of the issues in the PyModel entry point logic
