### PR TITLE
[CI] Creates nightly benchmark

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -1,7 +1,6 @@
 name: Benchmark Nightly
 
 on:
-  pull_request:
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -14,6 +14,6 @@ jobs:
     uses: ./.github/workflows/instant_benchmark.yml
     secrets: inherit
     with:
-      running_template: tests/benchmark/nightly/g5-2xl.txt
+      running_template: ./benchmark/nightly/g5-2xl.txt
       instance: g5.2xlarge
       record: cloudwatch

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -1,0 +1,19 @@
+name: Benchmark Nightly
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  g5-2xl:
+    uses: ./.github/workflows/instant_benchmark.yml
+    secrets: inherit
+    with:
+      running_template: tests/benchmark/nightly/g5-2xl.txt
+      instance: g5.2xlarge
+      record: cloudwatch

--- a/.github/workflows/instant_benchmark.yml
+++ b/.github/workflows/instant_benchmark.yml
@@ -37,16 +37,20 @@ on:
   workflow_call:
     inputs:
       running_template:
+        description: 'A json file that contains benchmark plans'
         required: true
         type: string
       instance:
+        description: 'Instance used for benchmark'
         required: true
         type: string
       container:
+        description: 'The container used to run benchmark (overrides the template). Should be a full docker path such as deepjavalibrary/djl-serving:0.27.0-deepspeed'
         required: false
         type: string
         default: ''
       record:
+        description: 'Whether to record the results'
         required: false
         type: string
         default: 'none'

--- a/.github/workflows/instant_benchmark.yml
+++ b/.github/workflows/instant_benchmark.yml
@@ -34,6 +34,22 @@ on:
           - none
           - table
           - cloudwatch
+  workflow_call:
+    inputs:
+      running_template:
+        required: true
+        type: string
+      instance:
+        required: true
+        type: string
+      container:
+        required: false
+        type: string
+        default: ''
+      record:
+        required: false
+        type: string
+        default: 'none'
 
 permissions:
   id-token: write

--- a/.github/workflows/instant_benchmark.yml
+++ b/.github/workflows/instant_benchmark.yml
@@ -71,12 +71,12 @@ jobs:
           https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
           --fail \
           | jq '.token' | tr -d '"' )
-          ./start_instance.sh action_ib_${{ github.event.inputs.instance }} $token djl-serving
+          ./start_instance.sh action_ib_${{ inputs.instance }} $token djl-serving
     outputs:
       gpu_instance_id: ${{ steps.create_instance.outputs.action_ib_instance_id }}
 
   environment-setup:
-    runs-on: [ self-hosted, "${{ github.event.inputs.instance }}" ]
+    runs-on: [ self-hosted, "${{ inputs.instance }}" ]
     timeout-minutes: 15
     needs: [ create-runners ]
     steps:
@@ -102,14 +102,14 @@ jobs:
         working-directory: tests/integration
         id: generate_matrix
         run: |
-          python3 instant_benchmark.py --parse ${{ github.event.inputs.running_template }} \
-          --container "${{ github.event.inputs.container }}"
+          python3 instant_benchmark.py --parse ${{ inputs.running_template }} \
+          --container "${{ inputs.container }}"
     outputs:
       jobs: ${{ steps.generate_matrix.outputs.jobs }}
       template: ${{ steps.generate_matrix.outputs.template }}
 
   benchmark_run:
-    runs-on: [ self-hosted, "${{ github.event.inputs.instance }}" ]
+    runs-on: [ self-hosted, "${{ inputs.instance }}" ]
     timeout-minutes: 30
     needs: [ environment-setup ]
     strategy:
@@ -136,7 +136,7 @@ jobs:
         run: |
           echo "${{ needs.environment-setup.outputs.template }}" >> template.json
           python3 instant_benchmark.py --template template.json \
-          --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }}
+          --job ${{ matrix.job }} --instance ${{ inputs.instance }}
           
           bash instant_benchmark.sh
       - name: Configure AWS Credentials
@@ -145,12 +145,12 @@ jobs:
           role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
           aws-region: us-east-1
       - name: Record benchmark job
-        if: ${{ github.event.inputs.record == 'table' || github.event.inputs.record == 'cloudwatch' }}
+        if: ${{ inputs.record == 'table' || inputs.record == 'cloudwatch' }}
         working-directory: tests/integration
         run: |
           python3 record_benchmark.py --template template.json \
-          --job ${{ matrix.job }} --instance ${{ github.event.inputs.instance }} \
-          --model models/test --record ${{ github.event.inputs.record }}
+          --job ${{ matrix.job }} --instance ${{ inputs.instance }} \
+          --model models/test --record ${{ inputs.record }}
       - name: Get serving logs
         if: always()
         working-directory: tests/integration

--- a/tests/benchmark/nightly/g5-2xl.txt
+++ b/tests/benchmark/nightly/g5-2xl.txt
@@ -1,0 +1,16 @@
+[test_name]
+mistral
+[container]
+deepjavalibrary/djl-serving:0.27.0-deepspeed
+[vars]
+CONCURRENCY={1,16,32}
+[serving_properties]
+engine=Python
+option.rolling_batch=vllm
+option.model_id=mistralai/Mistral-7B-v0.1
+[aws_curl]
+TOKENIZER=mistralai/Mistral-7B-v0.1 ./awscurl -c $CONCURRENCY -N 10 \
+-X POST http://127.0.0.1:8080/invocations   \
+--connect-timeout 60   -H "Content-type: application/json"   \
+-d '{"inputs":"The new movie that got Oscar this year","parameters":{"max_new_tokens":256, "do_sample":true}}'   \
+-t -o /tmp/output.txt

--- a/tests/integration/benchmark/nightly/g5-2xl.txt
+++ b/tests/integration/benchmark/nightly/g5-2xl.txt
@@ -1,15 +1,15 @@
 [test_name]
-mistral
+mistral-vllm
 [container]
-deepjavalibrary/djl-serving:0.27.0-deepspeed
-[vars]
-CONCURRENCY={1,16,32}
+deepjavalibrary/djl-serving:deepspeed-nightly
 [serving_properties]
 engine=Python
 option.rolling_batch=vllm
-option.model_id=mistralai/Mistral-7B-v0.1
+option.model_id=NousResearch/Hermes-2-Pro-Mistral-7B
+option.tensor_parallel_degree=max
+option.max_model_len=8192
 [aws_curl]
-TOKENIZER=mistralai/Mistral-7B-v0.1 ./awscurl -c $CONCURRENCY -N 10 \
+TOKENIZER=NousResearch/Hermes-2-Pro-Mistral-7B ./awscurl -c 32 -N 10 \
 -X POST http://127.0.0.1:8080/invocations   \
 --connect-timeout 60   -H "Content-type: application/json"   \
 -d '{"inputs":"The new movie that got Oscar this year","parameters":{"max_new_tokens":256, "do_sample":true}}'   \


### PR DESCRIPTION
This creates a new nightly benchmark action. Right now, it only contains a single mistral test for a POC. Later, this config file can be replaced with a more intentional suite to track.

Sample Run: https://github.com/deepjavalibrary/djl-serving/actions/runs/8792872806/job/24129825770?pr=1787