### PR TITLE
[tnx] update default neuron rolling batch for correct mpi mode config

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -87,6 +87,8 @@ public final class LmiConfigRecommender {
         } else if (!isTextGenerationModel(modelConfig)) {
             // Non text-generation use-cases are not compatible with rolling batch
             rollingBatch = "disable";
+        } else if (isTnxEnabled(features)) {
+            rollingBatch = "tnx";
         } else if (isLmiDistEnabled(features)
                 && "lmi-dist".equals(MODEL_TO_ROLLING_BATCH.get(modelType))) {
             rollingBatch = "lmi-dist";
@@ -173,6 +175,10 @@ public final class LmiConfigRecommender {
 
     private static boolean isTrtLlmEnabled(String features) {
         return features != null && features.contains("trtllm");
+    }
+
+    private static boolean isTnxEnabled(String features) {
+        return features != null && features.contains("tnx");
     }
 
     private static boolean isT5TrtLlm(


### PR DESCRIPTION
## Description ##

If tnx is available in serving features only use Python mode for now.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
