### PR TITLE
[fix] match serving option with properties for draft model download

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -1130,11 +1130,11 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
     }
 
     private void downloadDraftModel() throws ModelException, IOException {
-        String draftModelId = prop.getProperty("option.speculative_draft_model");
+        String draftModelId = prop.getProperty("option.draft_model_id");
         if (draftModelId != null && draftModelId.startsWith("s3://")) {
             Path draftDownloadDir = downloadS3ToDownloadDir(draftModelId);
             prop.setProperty(
-                    "option.speculative_draft_model", draftDownloadDir.toAbsolutePath().toString());
+                    "option.draft_model_id", draftDownloadDir.toAbsolutePath().toString());
         }
     }
 


### PR DESCRIPTION
## Description ##

Fix the download option consumption for s3 downloads for draft models.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
