### PR TITLE
[tnx][ci] add resnet test w/o requirements.txt

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -74,7 +74,7 @@ jobs:
         working-directory: tests/integration
         run: |
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-1 \
-          serve -m test::Python:nc0=file:/opt/ml/model/resnet18_inf2_2_4.tar.gz
+          serve -m test::Python:nc0=file:/opt/ml/model/resnet18_no_reqs_inf2_2_4.tar.gz
           ./test_client.sh image/jpg models/kitten.jpg
           docker rm -f $(docker ps -aq)
       - name: Test transformers-neuronx gpt2 with handler

--- a/tests/integration/download_models.sh
+++ b/tests/integration/download_models.sh
@@ -24,6 +24,7 @@ aarch_models_urls=(
 
 inf2_models_urls=(
   "https://resources.djl.ai/test-models/pytorch/resnet18_inf2_2_4.tar.gz"
+  "https://resources.djl.ai/test-models/pytorch/resnet18_no_reqs_inf2_2_4.tar.gz"
 )
 
 download() {


### PR DESCRIPTION
## Description ##

Update Python mode test to utilize torchvision installed on the container.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
