### PR TITLE
Remove libnccl-dev installation in trtllm container

### DIFF
--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y g++ wget unzip openmpi-bin libopenmpi-d
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install latest CUDNN8
-RUN apt-get update && apt-get install -y libcudnn8 libnccl-dev && \
+RUN apt-get update && apt-get install -y libcudnn8 && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install PyTorch


### PR DESCRIPTION
## Description ##

libnccl already ships with libcudnn, explicitly installing it is causing an error - https://github.com/deepjavalibrary/djl-serving/actions/runs/8853249246/job/24313655935#step:10:2048

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
