### PR TITLE
Resolve protected_namespaces warning for pydantic

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -14,7 +14,7 @@ import logging
 import os
 from enum import Enum
 from typing import Optional, Union, Callable, Any
-from pydantic import BaseModel, field_validator, model_validator, ValidationInfo, Field
+from pydantic import BaseModel, field_validator, model_validator, ValidationInfo, ConfigDict
 
 
 class RollingBatchEnum(str, Enum):
@@ -62,8 +62,9 @@ class Properties(BaseModel):
     draft_model_id: Optional[str] = None
     spec_length: Optional[int] = 0
 
-    class Config:
-        arbitrary_types_allowed = True
+    # model_config is for pydantic configurations for BaseModel.
+    model_config = ConfigDict(arbitrary_types_allowed=True,
+                              protected_namespaces=())
 
     @model_validator(mode='before')
     def calculate_is_mpi(cls, properties):


### PR DESCRIPTION
## Description ##

In Pydantic v2, the default protected namespace is model_, causing warnings in logs when properties like model_id_or_path are used. However, model_id_or_path doesn't conflict with any Pydantic BaseModel configurations.

This issue also suppresses errors when overriding Pydantic configurations like model_validate. The Machine Learning community has raised concerns, suggesting that Pydantic shouldn't restrict users from using model_, hinting at potential changes in Pydantic v3.

Currently, we're addressing this by setting properties_namespaces to an empty tuple, eliminating warnings since model_id_or_path doesn't override any core Pydantic methods.


