### PR TITLE
Updated s3url gpt4all lora adapter_config.json

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -63,7 +63,7 @@ hf_handler_list = {
         "option.enable_streaming": True,
     },
     "gpt4all-lora": {
-        "option.model_id": "nomic-ai/gpt4all-lora",
+        "option.model_id": "s3://djl-llm/gpt4all-lora/",
         "option.tensor_parallel_degree": 4,
         "option.task": "text-generation",
         "option.dtype": "fp16"


### PR DESCRIPTION
## Description ##

In peft>=0.6.0 version, they did make a change that breaks the backward compatibility of old adapters. They no longer support `enable_lora` and `merge_weights` configurations` in `adapter_config.json`. 

Issue Link https://github.com/huggingface/peft/issues/1087

I tried the solution that is suggested in the above issue. Manually downloaded the model and removed the `enable_lora` and `merge_weights` configurations. Peft was able to load the adapter weights. Checked the inference output, and it was generated the same outputs as before, no garbage. 

So here, uploaded the adpater model in our s3 bucket and updated the url in our testing. 

Leaving another note here, https://github.com/huggingface/peft/issues/379 - Issue which requries retraining. So if we stick with peft, we might need to suggest the users about this peft version update and inform them older adapters would not work. 
