### PR TITLE
[tnx] add mixtral test to neuron ci

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -262,17 +262,6 @@ jobs:
           python3 llm/client.py neuron-stable-diffusion stable-diffusion-xl-neuron
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
-      - name: Test load split model with llama2 7B in handler
-        working-directory: tests/integration
-        run: |
-          rm -rf models
-          python3 llm/prepare.py transformers_neuronx llama-7b-split
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-2 \
-          serve
-          curl http://127.0.0.1:8080/models
-          python3 llm/client.py transformers_neuronx llama-7b-split
-          docker rm -f $(docker ps -aq)
-          sudo rm -rf models
       - name: Test mistral 7B with handler
         working-directory: tests/integration
         run: |
@@ -335,6 +324,17 @@ jobs:
           serve
           curl http://127.0.0.1:8080/models
           python3 llm/client.py transformers_neuronx_rolling_batch llama-7b-rb
+          docker rm -f $(docker ps -aq)
+          sudo rm -rf models
+      - name: Test transformers-neuronx mixtral-8x-7b rolling batch
+        working-directory: tests/integration
+        run: |
+          rm -rf models
+          python3 llm/prepare.py transformers_neuronx mixtral-8x7b-rb
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models pytorch-inf2-4 \
+          serve
+          curl http://127.0.0.1:8080/models
+          python3 llm/client.py transformers_neuronx_rolling_batch mixtral-8x7b-rb
           docker rm -f $(docker ps -aq)
           sudo rm -rf models
       - name: On fail step

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -115,7 +115,7 @@ total_retries=24
 if $is_llm; then
   total_retries=60
   if [[ "$platform" == *"inf2"* ]]; then
-    total_retries=80
+    total_retries=160
   fi
   if [[ "$platform" == *"trtllm"* || "$platform" == *"tensorrt-llm"* ]]; then
     total_retries=150

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -182,6 +182,11 @@ transformers_neuronx_model_spec = {
         "seq_length": [256],
         "tokenizer": "mistralai/Mistral-7B-v0.1"
     },
+    "mixtral-8x7b-rb": {
+        "batch_size": [4],
+        "seq_length": [256],
+        "tokenizer": "mistralai/Mixtral-8x7B-v0.1"
+    },
     "llama-7b-rb": {
         "batch_size": [1, 4],
         "seq_length": [256],

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -184,15 +184,6 @@ transformers_neuronx_handler_list = {
         "option.dtype": "fp16",
         "option.model_loading_timeout": 900
     },
-    "open-llama-7b": {
-        "option.model_id": "s3://djl-llm/open-llama-7b/",
-        "batch_size": 4,
-        "option.tensor_parallel_degree": 4,
-        "option.n_positions": 512,
-        "option.dtype": "fp16",
-        "option.neuron_optimize_level": 1,
-        "option.model_loading_timeout": 1200
-    },
     "bloom-7b1": {
         "option.model_id": "s3://djl-llm/bloom-7b1/",
         "batch_size": 4,
@@ -200,15 +191,6 @@ transformers_neuronx_handler_list = {
         "option.n_positions": 256,
         "option.dtype": "fp16",
         "option.model_loading_timeout": 1200
-    },
-    "llama-7b-split": {
-        "option.model_id": "s3://djl-llm/llama-2-7b-split-inf2/split-model/",
-        "batch_size": 1,
-        "option.tensor_parallel_degree": 4,
-        "option.n_positions": 512,
-        "option.model_loading_timeout": 2400,
-        "option.load_split_model": True,
-        "option.context_length_estimate": '256, 512, 1024'
     },
     "mistral-7b": {
         "option.model_id": "s3://djl-llm/mistral-7b/",
@@ -276,6 +258,15 @@ transformers_neuronx_handler_list = {
         "option.max_rolling_batch_size": 4,
         "option.rolling_batch": 'auto',
         "option.model_loading_timeout": 2400,
+        "option.output_formatter": "jsonlines"
+    },
+    "mixtral-8x7b-rb": {
+        "option.model_id": "s3://djl-llm/mixtral-8x7b/",
+        "option.tensor_parallel_degree": 8,
+        "option.n_positions": 1024,
+        "option.max_rolling_batch_size": 4,
+        "option.rolling_batch": 'auto',
+        "option.model_loading_timeout": 3600,
         "option.output_formatter": "jsonlines"
     }
 }


### PR DESCRIPTION
## Description ##

Adds mixtral to neuron CI, removes duplicate testing for split model loading, and increases timeout for long loading models like mixtral.
