### PR TITLE
Add back LCNC test for gptneox in trtllm

### DIFF
--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -229,7 +229,7 @@ jobs:
           python3 llm/client.py no_code mistral-7b
           docker rm -f $(docker ps -aq)
       - name: GPTNeox lmi container
-        if: ${{ matrix.container  == 'lmi' }}
+        if: ${{ matrix.container  == 'lmi'|| matrix.container == "tensorrt-llm" }}
         working-directory: tests/integration
         run: |
           rm -rf models

--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -229,7 +229,6 @@ jobs:
           python3 llm/client.py no_code mistral-7b
           docker rm -f $(docker ps -aq)
       - name: GPTNeox lmi container
-        if: ${{ matrix.container  == 'lmi'|| matrix.container == "tensorrt-llm" }}
         working-directory: tests/integration
         run: |
           rm -rf models


### PR DESCRIPTION
## Description ##

1. Add gptneox test back as v0.9.0 now supports paged kv cache for gptneox