### PR TITLE
Stop the model server when model download fails

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -459,6 +459,9 @@ public class ModelServer {
                                     });
             if (configManager.waitModelLoading()) {
                 f.join();
+                if (stopped.get()) {
+                    throw new BadWorkflowException("Model server is stopped.");
+                }
             }
             startupModels.add(modelName);
         }

--- a/serving/src/test/java/ai/djl/serving/ModelServerTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerTest.java
@@ -443,6 +443,19 @@ public class ModelServerTest {
         }
     }
 
+    @Test
+    public void testServerInitFailure() throws ParseException {
+        String[] args = {"-m", "s3://djl-llm/gpt-invalid"}; // model download failure
+        Arguments arguments = ConfigManagerTest.parseArguments(args);
+        assertFalse(arguments.hasHelp());
+
+        ConfigManager.init(arguments);
+        configManager = ConfigManager.getInstance();
+
+        ModelServer server = new ModelServer(configManager);
+        Assert.assertThrows(ServerStartupException.class, server::start);
+    }
+
     private ModelServer initTestServer(String configFile)
             throws ParseException, ServerStartupException, GeneralSecurityException, IOException,
                     InterruptedException {


### PR DESCRIPTION
## Description ##

If the error occurs at model initialization is failed, we handle the exception at CompletableFuture `exceptionally`, to wait for 3 seconds and then stop the model server. Then we before even checking whether model server is stopped or not, we bind to the 8080 address, and then we check for model server is stopped or not. 

This causes problems with SageMaker, since it receives the ping HTTP Status as 200, they mark the endpoint as `InService`.


