### PR TITLE
[vllm, lmi-dist] Support input log_probs

### DIFF
--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -187,7 +187,8 @@ class TestRollingBatch(unittest.TestCase):
                       "This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
-                          "details": True
+                          "details": True,
+                          "decoder_input_details": True
                       },
                       details=True,
                       output_formatter=_jsonlines_output_formatter)
@@ -209,7 +210,22 @@ class TestRollingBatch(unittest.TestCase):
                 "log_prob": -0.123123
             }
         }
-        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
+        req.set_next_token(Token(4558, " world", -0.567854),
+                           True,
+                           'length',
+                           prompt_tokens_details=[
+                               Token(id=[123], text="This",
+                                     log_prob=None).as_dict(),
+                               Token(id=[456], text="is",
+                                     log_prob=0.456).as_dict(),
+                               Token(id=[789], text="a",
+                                     log_prob=0.789).as_dict(),
+                               Token(id=[124],
+                                     text="wonderful",
+                                     log_prob=0.124).as_dict(),
+                               Token(id=[356], text="day",
+                                     log_prob=0.356).as_dict()
+                           ])
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
             "token": {
@@ -218,9 +234,32 @@ class TestRollingBatch(unittest.TestCase):
                 "log_prob": -0.567854
             },
             'details': {
-                'finish_reason': 'length',
-                'generated_tokens': 3,
-                'inputs': 'This is a wonderful day'
+                'finish_reason':
+                'length',
+                'generated_tokens':
+                3,
+                'inputs':
+                'This is a wonderful day',
+                'prefill': [{
+                    'id': [123],
+                    'text': 'This'
+                }, {
+                    'id': [456],
+                    'log_prob': 0.456,
+                    'text': 'is'
+                }, {
+                    'id': [789],
+                    'log_prob': 0.789,
+                    'text': 'a'
+                }, {
+                    'id': [124],
+                    'log_prob': 0.124,
+                    'text': 'wonderful'
+                }, {
+                    'id': [356],
+                    'log_prob': 0.356,
+                    'text': 'day'
+                }],
             },
             "generated_text": "Hello world"
         }

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -162,6 +162,7 @@ The following parameters are available with every rolling batch backend (vLLM, l
   'details' : boolean (default = false, details only available for rolling batch),
   'return_full_text': boolean (default = false),
   'stop_sequences' : list[str] (default = None)
+  'decoder_input_details' : boolean (default = false, only for vllm, lmi-dist)
 }
 ```
 
@@ -292,6 +293,8 @@ You must specify `details=true` in the input `parameters`.
 | `generated_tokens` | number                    | the number of tokens generated                                                                    | 128                                    |
 | `inputs`           | string                    | the input/prompt used to start generation                                                         | "Deep Learning is"                     |
 | `tokens`           | array of [Tokens](#token) | An array of token objects, one for each token generated. Only returned in non-streaming use-cases | See the [Tokens](#token) documentation |
+| `prefill`          | array of [Tokens](#token) | An array of token objects, one for each prompt token.                                             | See the [Tokens](#token) documentation |
+
 
 Example:
 ```
@@ -300,6 +303,7 @@ Example:
    "generated_tokens": 128,
    "inputs": "Deep Learning is"
    "tokens": [<Token1>, <Token2>, ...]
+   "prefill": [<PromptToken1>, <PromptToken2>, ...]
 }
 ```
 


### PR DESCRIPTION
## Description ##

Support input log_probs in our API. 


If user sends `"decoder_input_details": true` and `details: true`, prefill in details is sent. 
If user sends `decoder_input_details:true` and `details: false`, prefill in details is still sent, but other values would be null. 

Testing:
Tested with vllm gpt2 model, with both  json and jsonline output formatter. 



