### PR TITLE
[T5] TRTLLM python repo model check

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -594,7 +594,12 @@ trtllm_handler_list = {
         "engine": "MPI",
         "option.model_id": "s3://djl-llm/flan-t5-xxl-trtllm-compiled/v0.8.0/",
         "option.rolling_batch": "disable",
-        "option.entryPoint": "djl_python.tensorrt_llm"
+        "option.entryPoint": "djl_python.tensorrt_llm",
+        "batch_size": 32,
+        "option.max_input_len": 1024,
+        "option.max_output_len": 1024,
+        "option.dtype": "fp32",
+        "option.tensor_parallel_degree": 4
     },
     "flan-t5-xl": {
         "option.model_id": "s3://djl-llm/flan-t5-xl/"

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -592,7 +592,7 @@ trtllm_handler_list = {
     },
     "flan-t5-xxl": {
         "engine": "MPI",
-        "option.model_id": "s3://djl-llm/flan-t5-xxl-trtllm-compiled/v0.8.0/",
+        "option.model_id": "s3://djl-llm/flan-t5-xxl-trtllm-compiled/v0.9.0/",
         "option.rolling_batch": "disable",
         "option.entryPoint": "djl_python.tensorrt_llm",
         "batch_size": 32,


### PR DESCRIPTION
## Description ##

To check whether model is already converted or not for TRTLLM python repo. In TrtLLM 0.10.0, Triton support for T5 is getting released. Once it is released, we will be removing TRTLLM python support in our handlers and toolkit. 