### PR TITLE
[tnx] Read-only Neuron cache workaround for SM

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -48,7 +48,8 @@ class ModelLoader(ABC):
         default_cache_dir = "/var/tmp/neuron-compile-cache"
         if cache_dir:
             cache_dir = os.path.abspath(cache_dir)
-            if not os.access(cache_dir, os.W_OK):
+            if os.access(cache_dir,
+                         os.R_OK) and not os.access(cache_dir, os.W_OK):
                 logging.info(
                     f"Neuron cache directory is set to an unwriteable location: {cache_dir}"
                 )

--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -33,6 +33,33 @@ class ModelLoader(ABC):
     def __init__(self, *args, **kwargs) -> None:
         self.config = kwargs.get("config")
         self.model_config = kwargs.get("model_config", None)
+        self.move_read_only_neuron_cache()
+
+    def move_read_only_neuron_cache(self) -> None:
+        """
+        If the currently set Neuron cache directory is read-only,
+        change the Neuron cache directory to the default: /var/tmp/neuron-compile-cache.
+        Copies the graphs from the original location to the default location.
+
+        This is a workaround for passing the Neuron cache with the model on SM.
+        Enables reading a Neuron cache located in the read-only dir /opt/ml/model.
+        """
+        cache_dir = os.environ.get("NEURON_COMPILE_CACHE_URL")
+        default_cache_dir = "/var/tmp/neuron-compile-cache"
+        if cache_dir:
+            cache_dir = os.path.abspath(cache_dir)
+            if not os.access(cache_dir, os.W_OK):
+                logging.info(
+                    f"Neuron cache directory is set to an unwriteable location: {cache_dir}"
+                )
+                start = time.perf_counter()
+                shutil.copytree(cache_dir, default_cache_dir)
+                os.environ["NEURON_COMPILE_CACHE_URL"] = default_cache_dir
+                duration = time.perf_counter() - start
+                logging.info(
+                    f"Copied neuron cache to the default location: {default_cache_dir}. "
+                    "Using this directory as the Neuron cache."
+                    f"\nCopying took: {duration} seconds")
 
     def init_load_path(self) -> str:
         """


### PR DESCRIPTION
## Description ##

This PR adds the following logic: When loading a Neuron model, if the currently set Neuron cache directory is read-only, the model loader will copy the contents of this read-only directory to the default Neuron cache location and use the default Neuron cache location for compiling the model. 

This enables the ability for users to pass in a Neuron cache directory with pre-prepared graphs in the input model location (`/opt/ml/model`) on a SageMaker endpoint, which is read-only.

### Current Behavior
Currently, if a user attempts to pass a Neuron cache in the input model directory they will encounter an error like:
```
[WARN ] PyProcess - W-100-model-stderr: File "/usr/local/lib/python3.9/dist-packages/libneuronxla/neuron_cc_cache.py", line 118, in __enter__
[WARN ] PyProcess - W-100-model-stderr: self.lock_fd = open(self.lock_path, 'w')
[WARN ] PyProcess - W-100-model-stderr: OSError: [Errno 30] Read-only file system: '/opt/ml/model/neuron_cache/lock'
```
Where the Neuron compiler attempts to write a lock file to the cache directory. This occurs even if the correct graphs are passed, where if they were read in, no additional compilation would have been required.

### Security
The logic would allow a user to copy any read-only directory to exactly `/var/tmp/neuron-compile-cache` when using the LMI container. However, I believe a user would already be able to do this when using a custom inference handler.

### Testing
In each of the following test cases, I tested deploying TinyLlama to a SageMaker endpoint through the JIT compilation workflow. I made a successful request to the endpoint after deployment.
1. Using an S3 location as the Neuron cache location on SM. Want to ensure that these changes are not interfering with S3 flow.
```
[INFO ] PyProcess -   W-78-model-stdout: 2024-05-07 23:40:44.000543:  187    INFO ||NEURON_CACHE||: Compile cache path: s3://<redacted>
--
[INFO ] PyProcess - W-78-model-stdout:   2024-05-07 23:40:45.000207:  187  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at s3://<redacted>/neuronxcc-2.13.72.0+78a426937/MODULE_fefbaedf6fbc82fc61a8+ede6753c/model.neff.   Exiting with a successfully compiled graph.
[INFO ] PyProcess - W-78-model-stdout:   2024-05-07 23:40:45.000367:  186  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at s3://<redacted>/neuronxcc-2.13.72.0+78a426937/MODULE_50a122f44c378e1567a4+ede6753c/model.neff.   Exiting with a successfully compiled graph.
```
4. Optimum ModelLoader, passing complete Neuron cache in /opt/ml/model. Testing that both cached NEFFs are read in from the copied directory.
Logs:
```
[INFO ] PyProcess - W-80-model-stdout: Loading model using OptimumModelLoader...
[INFO ] PyProcess - W-80-model-stdout: Neuron cache directory is set to an unwriteable location: /opt/ml/model/PRE_COMPILED_NEURON_GRAPH_INFER
[INFO ] PyProcess - W-80-model-stdout: Copied neuron cache to the default location: /var/tmp/neuron-compile-cache. Using this directory as the Neuron cache.
[INFO ] PyProcess - W-80-model-stdout: Copying took: 0.008435249999990901 seconds
[INFO ] PyProcess - W-80-model-stdout: Start loading the model /opt/ml/model...
...
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:29:59.000762:  80  INFO ||NEURON_CACHE||: Compile cache path: /var/tmp/neuron-compile-cache
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:30:11.000864:  190  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_50a122f44c378e1567a4+ede6753c/model.neff. Exiting with a successfully compiled graph.
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:30:11.000959:  191  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_fefbaedf6fbc82fc61a8+ede6753c/model.neff. Exiting with a successfully compiled graph.
...
[INFO ] PyProcess - Model [model] initialized.
```
5. Optimum ModelLoader, passing partial Neuron cache in /opt/ml/model. Testing that compilation still works after the cache directory is copied. One cached NEFF is read, one is compiled.
Log:
```
[INFO ] PyProcess - W-79-model-stdout: Loading model using OptimumModelLoader...
[INFO ] PyProcess - W-79-model-stdout: Neuron cache directory is set to an unwriteable location: /opt/ml/model/PRE_COMPILED_NEURON_GRAPH_INFER
[INFO ] PyProcess - W-79-model-stdout: Copied neuron cache to the default location: /var/tmp/neuron-compile-cache. Using this directory as the Neuron cache.
[INFO ] PyProcess - W-79-model-stdout: Copying took: 0.003946090999988883 seconds
[INFO ] PyProcess - W-79-model-stdout: Start loading the model /opt/ml/model...
...
[INFO ] PyProcess - W-79-model-stdout: 2024-05-08 00:37:02.000607:  79  INFO ||NEURON_CACHE||: Compile cache path: /var/tmp/neuron-compile-cache
[INFO ] PyProcess - W-79-model-stdout: 2024-05-08 00:37:14.000925:  189  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_50a122f44c378e1567a4+ede6753c/model.neff. Exiting with a successfully compiled graph.
[WARN ] PyProcess - W-79-model-stderr: neuronxcc-2.13.72.0+78a426937/MODULE_fefbaedf6fbc82fc61a8+ede6753c/model.neff not found in aws-neuron/optimum-neuron-cache: the corresponding graph will be recompiled. This may take up to one hour for large models.
[INFO ] PyProcess - W-79-model-stdout: 2024-05-08 00:37:15.000344:  190  INFO ||NEURON_CC_WRAPPER||: Call compiler with cmd: neuronx-cc compile --target=trn1 --framework=XLA /tmp/no-user/neuroncc_compile_workdir/61ae79cf-f70e-4912-afac-316293bbb3d8/model.MODULE_fefbaedf6fbc82fc61a8+ede6753c.hlo_module.pb --output /tmp/no-user/neuroncc_compile_workdir/61ae79cf-f70e-4912-afac-316293bbb3d8/model.MODULE_fefbaedf6fbc82fc61a8+ede6753c.neff --logfile /tmp/compile.log --temp-dir=/tmp --model-type=transformer --auto-cast=none --verbose=35
[INFO ] PyProcess - W-79-model-stdout: performing partition vectorization on AG_2[[0, 774, 0, 0, 0]]{3 nodes (1 sources, 0 stops)}. dags covered: {dag_774_TRANSPOSE_DST, dag_775_TRANSPOSE_DST, dag_776_TC_SRC}
...
[INFO ] PyProcess - W-79-model-stdout: Compiler status PASS
...
[INFO ] PyProcess - Model [model] initialized.
```
6. TNX ModelLoader, passing complete Neuron cache in /opt/ml/model. Analogous to (4). Testing that both cached NEFFs are read in from the copied directory.
```
[INFO ] PyProcess - W-80-model-stdout: Loading model using TNXModelLoader...
[INFO ] PyProcess - W-80-model-stdout: Neuron cache directory is set to an unwriteable location: /opt/ml/model/PRE_COMPILED_NEURON_GRAPH_INFER
[INFO ] PyProcess - W-80-model-stdout: Copied neuron cache to the default location: /var/tmp/neuron-compile-cache. Using this directory as the Neuron cache.
[INFO ] PyProcess - W-80-model-stdout: Copying took: 0.008574059000011403 seconds
[INFO ] PyProcess - W-80-model-stdout: Start loading the model /opt/ml/model using NeuronAutoModel...
...
[INFO ] PyProcess - W-80-model-stdout: LLM sharding and compiling started...
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:46:45.000102:  185  INFO ||NEURON_CACHE||: Compile cache path: /var/tmp/neuron-compile-cache
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:46:45.000120:  185  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_50a122f44c378e1567a4+ede6753c/model.neff. Exiting with a successfully compiled graph.
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:46:45.000197:  186  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_fefbaedf6fbc82fc61a8+ede6753c/model.neff. Exiting with a successfully compiled graph.
...
[INFO ] PyProcess - W-80-model-stdout: SysHealth: LLM sharding and compilation latency: 12.408979654312134 secs
[INFO ] PyProcess - Model [model] initialized.
```
7. TNX ModelLoader, passing partial Neuron cache in /opt/ml/model. Analogous to (5) Testing that compilation still works after the cache directory is copied. One cached NEFF is read, one is compiled.
Log:
```
[INFO ] PyProcess - W-80-model-stdout: Loading model using TNXModelLoader...
[INFO ] PyProcess - W-80-model-stdout: Neuron cache directory is set to an unwriteable location: /opt/ml/model/PRE_COMPILED_NEURON_GRAPH_INFER
[INFO ] PyProcess - W-80-model-stdout: Copied neuron cache to the default location: /var/tmp/neuron-compile-cache. Using this directory as the Neuron cache.
[INFO ] PyProcess - W-80-model-stdout: Copying took: 0.005142976000001909 seconds
[INFO ] PyProcess - W-80-model-stdout: Start loading the model /opt/ml/model using NeuronAutoModel...
...
[INFO ] PyProcess - W-80-model-stdout: LLM sharding and compiling started...
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:54:16.000764:  186  INFO ||NEURON_CACHE||: Compile cache path: /var/tmp/neuron-compile-cache
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:54:16.000767:  186  INFO ||NEURON_CC_WRAPPER||: Call compiler with cmd: neuronx-cc compile --target=trn1 --framework=XLA /tmp/no-user/neuroncc_compile_workdir/5400466e-c2b2-43df-b593-27e38e731cf0/model.MODULE_50a122f44c378e1567a4+ede6753c.hlo_module.pb --output /tmp/no-user/neuroncc_compile_workdir/5400466e-c2b2-43df-b593-27e38e731cf0/model.MODULE_50a122f44c378e1567a4+ede6753c.neff --logfile /tmp/compile.log --temp-dir=/tmp --model-type=transformer --auto-cast=none --verbose=35
[INFO ] PyProcess - W-80-model-stdout: 2024-05-08 00:54:16.000831:  187  INFO ||NEURON_CC_WRAPPER||: Using a cached neff at /var/tmp/neuron-compile-cache/neuronxcc-2.13.72.0+78a426937/MODULE_fefbaedf6fbc82fc61a8+ede6753c/model.neff. Exiting with a successfully compiled graph.
[INFO ] PyProcess - W-80-model-stdout: ..performing partition vectorization on AG_2[[0, 9, 0, 0]]{2 nodes (1 sources, 0 stops)}. dags covered: {dag_9_TC_DST, dag_10_TRANSPOSE_SRC}
...
[INFO ] PyProcess - W-80-model-stdout: Compiler status PASS
...
[INFO ] PyProcess - W-80-model-stdout: SysHealth: LLM sharding and compilation latency: 83.32264924049377 secs
[INFO ] PyProcess - Model [model] initialized.
```
8. TNX & Optimum ModelLoader, base partitioning workflow. Tested model partitioning through Neo script & deploying the partitioned model.
