### PR TITLE
Remove docker daemon restarts from p4d workflow

### DIFF
--- a/.github/workflows/llm_integration_p4d.yml
+++ b/.github/workflows/llm_integration_p4d.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Clean env
         run: |
-          sudo systemctl restart docker
           yes | docker system prune -a --volumes
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
           echo "wait dpkg lock..."
@@ -65,7 +64,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py lmi_dist_aiccl mixtral-8x7b-aiccl
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Test Llama-2-70B
         working-directory: tests/integration
         run: |
@@ -74,7 +73,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py lmi_dist_aiccl llama-2-70b-aiccl
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Test codellama/CodeLlama-34b-hf
         working-directory: tests/integration
         run: |
@@ -83,7 +82,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py lmi_dist_aiccl codellama-34b-aiccl
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Test tiiuae/falcon-40b
         working-directory: tests/integration
         run: |
@@ -92,7 +91,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py lmi_dist_aiccl falcon-40b-aiccl
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Remove models dir
         working-directory: tests/integration
         run: |
@@ -118,7 +117,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Clean env
         run: |
-          sudo systemctl restart docker
           yes | docker system prune -a --volumes
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
           echo "wait dpkg lock..."
@@ -143,7 +141,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
           serve
           python3 llm/client.py trtllm llama2-70b
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq) 
       - name: Test mixtral-8x7b with with TP8
         working-directory: tests/integration
         run: |
@@ -152,7 +150,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
           serve
           python3 llm/client.py trtllm mixtral-8x7b
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Remove models dir
         working-directory: tests/integration
         run: |
@@ -178,7 +176,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Clean env
         run: |
-          sudo systemctl restart docker
           yes | docker system prune -a --volumes
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
           echo "wait dpkg lock..."
@@ -203,7 +200,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py vllm llama2-70b
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Test mixtral-8x7b with with TP8
         working-directory: tests/integration
         run: |
@@ -212,7 +209,7 @@ jobs:
           ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
           serve
           python3 llm/client.py vllm mixtral-8x7b
-          docker rm -f $(docker ps -aq) || sudo systemctl restart docker
+          docker rm -f $(docker ps -aq)
       - name: Remove models dir
         working-directory: tests/integration
         run: |


### PR DESCRIPTION
## Description ##

1. Currently, when the command `docker rm -f $(docker ps -aq) ` fails with an error such as `https://github.com/deepjavalibrary/djl-serving/actions/runs/8987762857/job/24687145016#step:11:185` i.e. `Error response from daemon: cannot remove container "/magical_proskuriakova": could not kill: tried to kill container, but did not receive an exit event` - in this case, we do a `|| sudo systemctl restart docker`. However, this second command itself also fails leading to further error - `Job for docker.service failed because the control process exited with error code.
See "systemctl status docker.service" and "journalctl -xe" for details.`. The `||` solution isn't really working. We perhaps need multi-level cleanup in a script such as `terminate_container.sh`
2. Revert change to restart docker daemon, as it causes cascading failure for all future docker commands.
3. Will send another PR to perform multi-level docker cleanup if we still see failures.