### PR TITLE
[docker] Upgrade pytorch to 2.2.2

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -15,8 +15,8 @@ ARG cuda_version=cu121
 ARG djl_version=0.28.0~SNAPSHOT
 # Base Deps
 ARG python_version=3.10
-ARG torch_version=2.2.1
-ARG torch_vision_version=0.17.1
+ARG torch_version=2.2.2
+ARG torch_vision_version=0.17.2
 ARG onnx_version=1.17.1
 ARG pydantic_version=2.6.1
 # HF Deps

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -13,7 +13,7 @@ ARG version=12.2.2-devel-ubuntu22.04
 FROM nvidia/cuda:$version
 ARG cuda_version=cu122
 ARG python_version=3.10
-ARG TORCH_VERSION=2.2.1
+ARG TORCH_VERSION=2.2.2
 ARG djl_version=0.28.0~SNAPSHOT
 ARG transformers_version=4.40.0
 ARG accelerate_version=0.29.3


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Upgrade pytorch to 2.2.2 to fix the error:

```
ERROR ModelServer Failed register workflow
java.util.concurrent.CompletionException: java.lang.ExceptionInInitializerError
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) [?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770) [?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) [?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) [?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) [?:?]
Caused by: java.lang.ExceptionInInitializerError
	at ai.djl.onnxruntime.engine.OrtEngine.newBaseManager(OrtEngine.java:134) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.newModel(OrtEngine.java:122) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.Model.newInstance(Model.java:99) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.createModel(BaseModelLoader.java:196) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.loadModel(BaseModelLoader.java:159) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.Criteria.loadModel(Criteria.java:172) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.ModelInfo.load(ModelInfo.java:264) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:196) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:179) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.initWorkers(ModelManager.java:233) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.lambda$registerWorkflow$2(ModelManager.java:147) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	... 6 more
Caused by: ai.djl.engine.EngineException: Cannot download jni files: https://publish.djl.ai/pytorch/2.2.1/jnilib/0.28.0/linux-x86_64/cu121-precxx11/libdjl_torch.so
	at ai.djl.pytorch.jni.LibUtils.downloadJniLib(LibUtils.java:542) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.jni.LibUtils.findJniLibrary(LibUtils.java:276) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.jni.LibUtils.loadLibrary(LibUtils.java:84) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.engine.PtEngine.newInstance(PtEngine.java:53) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.engine.PtEngineProvider.getEngine(PtEngineProvider.java:41) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.engine.Engine.getEngine(Engine.java:190) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.engine.Engine.getInstance(Engine.java:145) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.getAlternativeEngine(OrtEngine.java:75) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.ndarray.BaseNDManager.<init>(BaseNDManager.java:64) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<init>(OrtNDManager.java:42) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<init>(OrtNDManager.java:35) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager$SystemManager.<init>(OrtNDManager.java:177) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<clinit>(OrtNDManager.java:37) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.newBaseManager(OrtEngine.java:134) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.newModel(OrtEngine.java:122) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.Model.newInstance(Model.java:99) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.createModel(BaseModelLoader.java:196) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.loadModel(BaseModelLoader.java:159) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.Criteria.loadModel(Criteria.java:172) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.ModelInfo.load(ModelInfo.java:264) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:196) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:179) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.initWorkers(ModelManager.java:233) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.lambda$registerWorkflow$2(ModelManager.java:147) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	... 6 more
Caused by: java.io.FileNotFoundException: https://publish.djl.ai/pytorch/2.2.1/jnilib/0.28.0/linux-x86_64/cu121-precxx11/libdjl_torch.so
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:2018) ~[?:?]
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1611) ~[?:?]
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:224) ~[?:?]
	at ai.djl.util.Utils.openUrl(Utils.java:519) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.util.Utils.openUrl(Utils.java:498) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.util.Utils.openUrl(Utils.java:487) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.jni.LibUtils.downloadJniLib(LibUtils.java:536) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.jni.LibUtils.findJniLibrary(LibUtils.java:276) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.jni.LibUtils.loadLibrary(LibUtils.java:84) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.engine.PtEngine.newInstance(PtEngine.java:53) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.pytorch.engine.PtEngineProvider.getEngine(PtEngineProvider.java:41) ~[pytorch-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.engine.Engine.getEngine(Engine.java:190) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.engine.Engine.getInstance(Engine.java:145) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.getAlternativeEngine(OrtEngine.java:75) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.ndarray.BaseNDManager.<init>(BaseNDManager.java:64) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<init>(OrtNDManager.java:42) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<init>(OrtNDManager.java:35) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager$SystemManager.<init>(OrtNDManager.java:177) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtNDManager.<clinit>(OrtNDManager.java:37) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.newBaseManager(OrtEngine.java:134) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.onnxruntime.engine.OrtEngine.newModel(OrtEngine.java:122) ~[onnxruntime-engine-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.Model.newInstance(Model.java:99) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.createModel(BaseModelLoader.java:196) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.BaseModelLoader.loadModel(BaseModelLoader.java:159) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.repository.zoo.Criteria.loadModel(Criteria.java:172) ~[api-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.ModelInfo.load(ModelInfo.java:264) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:196) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.wlm.WorkerPool.initWorkers(WorkerPool.java:179) ~[wlm-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.initWorkers(ModelManager.java:233) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at ai.djl.serving.models.ModelManager.lambda$registerWorkflow$2(ModelManager.java:147) ~[serving-0.28.0-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	... 6 more
```