### PR TITLE
[tnx] Default to generation.config generation settings

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -28,7 +28,7 @@ from djl_python.utils import InputFormatConfigs, parse_input_with_formatter
 
 model = None
 
-OPTIMUM_CAUSALLM_MODEL_TYPES = {"gpt2", "opt", "bloom", "llama", "mistral"}
+OPTIMUM_CAUSALLM_MODEL_TYPES = {"gpt2", "opt", "bloom"}
 OPTIMUM_CAUSALLM_CONTINUOUS_BATCHING_MODELS = {"llama", "mistral"}
 
 


### PR DESCRIPTION
## Description ##

Updates behavior to default to the generation.config eos token list when loading instruct type models. Changing the default loading strategy for llama and mistral to support multiple eos tokens in generation.config. (Llama3 / Instruct fine tuned models)

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
