### PR TITLE
Updates default management port

### DIFF
--- a/plugins/management-console/src/main/java/ai/djl/serving/console/ConsoleRequestHandler.java
+++ b/plugins/management-console/src/main/java/ai/djl/serving/console/ConsoleRequestHandler.java
@@ -298,7 +298,7 @@ public class ConsoleRequestHandler implements RequestHandler<Void> {
         String inferenceAddress =
                 configManager.getProperty("inference_address", "http://127.0.0.1:8080");
         String managementAddress =
-                configManager.getProperty("management_address", "http://127.0.0.1:8080");
+                configManager.getProperty("management_address", "http://127.0.0.1:8081");
         String origin = configManager.getProperty("cors_allowed_origin", "");
         String methods = configManager.getProperty("cors_allowed_methods", "");
         String headers = configManager.getProperty("cors_allowed_headers", "");

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -180,7 +180,7 @@ public final class ConfigManager {
     public Connector getConnector(Connector.ConnectorType type) {
         String binding;
         if (type == Connector.ConnectorType.MANAGEMENT) {
-            binding = prop.getProperty(MANAGEMENT_ADDRESS, "http://127.0.0.1:8080");
+            binding = prop.getProperty(MANAGEMENT_ADDRESS, "http://127.0.0.1:8081");
         } else {
             binding = prop.getProperty(INFERENCE_ADDRESS, "http://127.0.0.1:8080");
         }


### PR DESCRIPTION
This updates the default management port to be 8081 to match the documented behavior in
https://docs.djl.ai/docs/serving/serving/docs/configurations_global.html#configure-listening-port.
