### PR TITLE
[BugFix] Fix bug when invalid adapters are passed

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -231,7 +231,8 @@ class HuggingFaceService(object):
         """
 
         parsed_input = parse_input_with_formatter(inputs,
-                                                  self.input_format_configs)
+                                                  self.input_format_configs,
+                                                  self.adapter_registry)
         self.adapters = parsed_input.adapters if parsed_input.found_adapters else None
         return parsed_input.input_data, parsed_input.input_size, parsed_input.parameters, parsed_input.errors, parsed_input.batch
 
@@ -256,15 +257,10 @@ class HuggingFaceService(object):
             if inputs.get_property("reset_rollingbatch"):
                 self.rolling_batch.reset()
             if self.adapters is not None:
-                adapter_data = []
-                for i, a in enumerate(self.adapters):
-                    if a is None or a == "":
-                        adapter_data.append(None)
-                    elif a in self.adapter_registry:
-                        adapter_data.append(self.adapter_registry[a])
-                    else:
-                        adapter_data.append(None)
-                        errors[i] = f"Unknown or invalid adapter {a}"
+                adapter_data = [
+                    self.adapter_registry.get(adapter, None)
+                    for adapter in self.adapters
+                ]
             else:
                 adapter_data = None
             result = self.rolling_batch.inference(input_data,

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -148,5 +148,5 @@ def _fetch_adapters_from_input(input_map: dict, inputs: Input):
 
 def _validate_adapters(adapters_per_item, adapter_registry):
     for adapter_name in adapters_per_item:
-        if adapter_name not in adapter_registry and adapter_name != "":
+        if adapter_name and adapter_name not in adapter_registry:
             raise ValueError(f"Adapter {adapter_name} is not registered")

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -56,8 +56,6 @@ def parse_input_with_formatter(inputs: Input,
             if input_format_configs.is_adapters_supported:
                 adapters_per_item, found_adapter_per_item = _parse_adapters(
                     _inputs, input_map, item, adapter_registry)
-                adapters.extend(adapters_per_item)
-                found_adapters = found_adapter_per_item or found_adapters
         except Exception as e:  # pylint: disable=broad-except
             logging.warning(f"Parse input failed: {i}")
             input_size.append(0)
@@ -66,6 +64,9 @@ def parse_input_with_formatter(inputs: Input,
 
         input_data.extend(_inputs)
         input_size.append(len(_inputs))
+
+        adapters.extend(adapters_per_item)
+        found_adapters = found_adapter_per_item or found_adapters
 
         for _ in range(input_size[i]):
             parameters.append(_param)

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -29,7 +29,7 @@ class InputFormatConfigs:
 
 def parse_input_with_formatter(inputs: Input,
                                input_format_configs: InputFormatConfigs,
-                               adapter_registry: dict) -> ParsedInput:
+                               adapter_registry: dict = {}) -> ParsedInput:
     """
     Preprocessing function that extracts information from Input objects.
     :param input_format_configs: format configurations for the input.
@@ -147,5 +147,5 @@ def _fetch_adapters_from_input(input_map: dict, inputs: Input):
 
 def _validate_adapters(adapters_per_item, adapter_registry):
     for adapter_name in adapters_per_item:
-        if adapter_name not in adapter_registry:
+        if adapter_name not in adapter_registry and adapter_name != "":
             raise ValueError(f"Adapter {adapter_name} is not registered")


### PR DESCRIPTION
## Description ##

There are two cases where the current implementation is buggy for adapters.

* When unregistered adapter is specified in the inference request
* When incorrect number of adapters is specified for client side batching
In both these cases, input is sent to the backend engine and error is populated for the request as well. As a result the model server will send the error response back to the client while the engine still keeps processing the request.

In this change, when an error occurs, the input request will not be sent to the engine. 
