### PR TITLE
Refactor tgi compat and removed token_id as list

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -57,8 +57,7 @@ class Properties(BaseModel):
     output_formatter: Optional[Union[str, Callable]] = None
     waiting_steps: Optional[int] = None
     is_mpi: bool = False
-    tgi_compat: Optional[bool] = os.environ.get("OPTION_TGI_COMPAT",
-                                                "false").lower() == "true"
+    tgi_compat: Optional[bool] = False
 
     # Spec_dec
     draft_model_id: Optional[str] = None

--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -57,6 +57,8 @@ class Properties(BaseModel):
     output_formatter: Optional[Union[str, Callable]] = None
     waiting_steps: Optional[int] = None
     is_mpi: bool = False
+    tgi_compat: Optional[bool] = os.environ.get("OPTION_TGI_COMPAT",
+                                                "false").lower() == "true"
 
     # Spec_dec
     draft_model_id: Optional[str] = None

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -46,9 +46,7 @@ class LmiDistRollingBatch(RollingBatch):
         :param properties (dict): other properties of the model, such as decoder strategy
         """
         self.lmi_dist_config = LmiDistRbProperties(**properties)
-        super().__init__(
-            waiting_steps=self.lmi_dist_config.waiting_steps,
-            output_formatter=self.lmi_dist_config.output_formatter)
+        super().__init__(self.lmi_dist_config)
         self.supports_speculative_decoding = supports_speculative_decoding()
         engine_kwargs = {}
         if self.supports_speculative_decoding:

--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -16,7 +16,7 @@ import logging
 from typing import Optional, Any
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, Token, FINISH_REASON_MAPPER
 from djl_python.transformers_neuronx_scheduler.optimum_neuron_scheduler import NaiveRollingBatchNeuronGenerator, ContinuousBatchingNeuronGenerator
-from djl_python.properties_manager.tnx_properties import TnXGenerationStrategy
+from djl_python.properties_manager.tnx_properties import TnXGenerationStrategy, TransformerNeuronXProperties
 
 
 class NeuronRollingBatch(RollingBatch):
@@ -24,12 +24,10 @@ class NeuronRollingBatch(RollingBatch):
     def __init__(self,
                  model,
                  tokenizer,
-                 batch_size: int,
-                 n_positions: int,
                  strategy: str = TnXGenerationStrategy.continuous_batching,
+                 tnx_config: TransformerNeuronXProperties = None,
                  draft_model: Optional[Any] = None,
-                 spec_length: Optional[int] = None,
-                 **kwargs) -> None:
+                 spec_length: Optional[int] = None) -> None:
         """
         Initializes the NeuronRollingBatch.
 
@@ -43,11 +41,11 @@ class NeuronRollingBatch(RollingBatch):
         if draft_model or self.strategy == TnXGenerationStrategy.naive_rolling_batch:
             self._scheduler_class = NaiveRollingBatchNeuronGenerator
 
-        super().__init__(**kwargs)
+        super().__init__(tnx_config)
         self.scheduler = self._scheduler_class(model,
                                                tokenizer,
-                                               batch_size,
-                                               n_positions,
+                                               tnx_config.batch_size,
+                                               tnx_config.n_positions,
                                                draft_model=draft_model,
                                                spec_length=spec_length)
 

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -62,9 +62,7 @@ class SchedulerRollingBatch(RollingBatch):
         """
 
         self.scheduler_configs = SchedulerRbProperties(**properties)
-        super().__init__(
-            waiting_steps=self.scheduler_configs.waiting_steps,
-            output_formatter=self.scheduler_configs.output_formatter)
+        super().__init__(self.scheduler_configs)
         self._init_model_and_tokenizer()
         self._init_scheduler()
 

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -11,6 +11,8 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import tensorrt_llm_toolkit
+
+from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, Token
 
 
@@ -22,19 +24,19 @@ class TRTLLMRollingBatch(RollingBatch):
     """
 
     def __init__(self, model_id_or_path: str, properties: dict,
-                 **kwargs) -> None:
+                 configs: TensorRtLlmProperties) -> None:
         """
         Initializes the TRTLLMRollingBatch
 
         :param model_id_or_path: model id or path
         :param properties: other properties of the model, such as decoder strategy
         """
-        super().__init__(**kwargs)
-        if properties.get("mpi_mode") != "true":
+        super().__init__(configs)
+        if configs.is_mpi:
             raise AssertionError(
                 f"Need mpi_mode to start tensorrt llm RollingBatcher")
         self.model = tensorrt_llm_toolkit.init_inference(
-            model_id_or_path, **kwargs)
+            model_id_or_path, **properties)
         self.request_cache = {}
 
     def get_tokenizer(self):

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -42,8 +42,7 @@ class VLLMRollingBatch(RollingBatch):
         :param properties: other properties of the model, such as decoder strategy
         """
         self.vllm_configs = VllmRbProperties(**properties)
-        super().__init__(waiting_steps=self.vllm_configs.waiting_steps,
-                         output_formatter=self.vllm_configs.output_formatter)
+        super().__init__(self.vllm_configs)
         args = EngineArgs(
             model=self.vllm_configs.model_id_or_path,
             tensor_parallel_size=self.vllm_configs.tensor_parallel_degree,

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -37,7 +37,7 @@ class TRTLLMService(object):
         self.trt_configs = TensorRtLlmProperties(**properties)
 
         self.rolling_batch = TRTLLMRollingBatch(
-            self.trt_configs.model_id_or_path, properties, **properties)
+            self.trt_configs.model_id_or_path, properties, self.trt_configs)
         self.input_format_configs = InputFormatConfigs(
             is_rolling_batch=True,
             is_adapters_supported=False,

--- a/engines/python/setup/djl_python/tests/rolling_batch/fake_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/rolling_batch/fake_rolling_batch.py
@@ -13,6 +13,8 @@
 import random
 from collections import OrderedDict
 from transformers import AutoTokenizer
+
+from djl_python.properties_manager.properties import Properties
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, Token
 
 
@@ -23,7 +25,8 @@ class FakeRollingBatch(RollingBatch):
         """
         Initializes the FakeRollingBatch.
         """
-        super().__init__(**kwargs)
+        configs = Properties(**properties)
+        super().__init__(configs)
         self.sample_text = (
             "DJL-Serving is a powerful and user-friendly deep learning model serving solution "
             "that enables developers to easily deploy and serve their trained deep learning models."

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 
 import djl_python.rolling_batch.rolling_batch
@@ -56,8 +57,6 @@ class TestRollingBatch(unittest.TestCase):
             assert req.get_next_token() == ' world"}'
 
     def test_fmt_hf_compat(self):
-        djl_python.rolling_batch.rolling_batch.TGI_COMPAT = True
-
         req = Request(0,
                       "This is a wonderful day",
                       parameters={
@@ -65,7 +64,8 @@ class TestRollingBatch(unittest.TestCase):
                           "return_full_text": True,
                       },
                       details=True,
-                      output_formatter=_json_output_formatter)
+                      output_formatter=_json_output_formatter,
+                      tgi_compat=True)
 
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
@@ -102,7 +102,6 @@ class TestRollingBatch(unittest.TestCase):
                 }]
             }
         }]
-        djl_python.rolling_batch.rolling_batch.TGI_COMPAT = False
 
     def test_jsonlines_fmt(self):
         req1 = Request(0,
@@ -120,7 +119,7 @@ class TestRollingBatch(unittest.TestCase):
             print(req.get_next_token(), end='')
             assert json.loads(req.get_next_token()) == {
                 "token": {
-                    "id": [244],
+                    "id": 244,
                     "text": "He",
                     "log_prob": -0.334532
                 }
@@ -130,7 +129,7 @@ class TestRollingBatch(unittest.TestCase):
             print(req.get_next_token(), end='')
             assert json.loads(req.get_next_token()) == {
                 "token": {
-                    "id": [576],
+                    "id": 576,
                     "text": "llo",
                     "log_prob": -0.123123
                 }
@@ -141,7 +140,7 @@ class TestRollingBatch(unittest.TestCase):
             print(req.get_next_token(), end='')
             assert json.loads(req.get_next_token()) == {
                 "token": {
-                    "id": [4558],
+                    "id": 4558,
                     "text": " world",
                     "log_prob": -0.567854
                 },
@@ -185,7 +184,7 @@ class TestRollingBatch(unittest.TestCase):
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token().splitlines()[-1]) == {
             "token": {
-                "id": [4558],
+                "id": 4558,
                 "text": " world",
                 "log_prob": -0.567854
             },
@@ -222,15 +221,15 @@ class TestRollingBatch(unittest.TestCase):
                 "generated_tokens":
                 3,
                 "tokens": [{
-                    "id": [244],
+                    "id": 244,
                     "text": "He",
                     "log_prob": -0.334532
                 }, {
-                    "id": [576],
+                    "id": 576,
                     "text": "llo",
                     "log_prob": -0.123123
                 }, {
-                    "id": [4558],
+                    "id": 4558,
                     "text": " world",
                     "log_prob": -0.567854
                 }]
@@ -251,7 +250,7 @@ class TestRollingBatch(unittest.TestCase):
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token().splitlines()[-1]) == {
             "token": {
-                "id": [4558],
+                "id": 4558,
                 "text": " world",
                 "log_prob": -0.567854
             },
@@ -277,7 +276,7 @@ class TestRollingBatch(unittest.TestCase):
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
             "token": {
-                "id": [244],
+                "id": 244,
                 "text": "He",
                 "log_prob": -0.334532
             }
@@ -287,7 +286,7 @@ class TestRollingBatch(unittest.TestCase):
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
             "token": {
-                "id": [576],
+                "id": 576,
                 "text": "llo",
                 "log_prob": -0.123123
             }
@@ -297,22 +296,21 @@ class TestRollingBatch(unittest.TestCase):
                            True,
                            'length',
                            prompt_tokens_details=[
-                               Token(id=[123], text="This",
+                               Token(id=123, text="This",
                                      log_prob=None).as_dict(),
-                               Token(id=[456], text="is",
+                               Token(id=456, text="is",
                                      log_prob=0.456).as_dict(),
-                               Token(id=[789], text="a",
+                               Token(id=789, text="a",
                                      log_prob=0.789).as_dict(),
-                               Token(id=[124],
-                                     text="wonderful",
+                               Token(id=124, text="wonderful",
                                      log_prob=0.124).as_dict(),
-                               Token(id=[356], text="day",
+                               Token(id=356, text="day",
                                      log_prob=0.356).as_dict()
                            ])
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
             "token": {
-                "id": [4558],
+                "id": 4558,
                 "text": " world",
                 "log_prob": -0.567854
             },
@@ -324,22 +322,22 @@ class TestRollingBatch(unittest.TestCase):
                 'inputs':
                 'This is a wonderful day',
                 'prefill': [{
-                    'id': [123],
+                    'id': 123,
                     'text': 'This'
                 }, {
-                    'id': [456],
+                    'id': 456,
                     'log_prob': 0.456,
                     'text': 'is'
                 }, {
-                    'id': [789],
+                    'id': 789,
                     'log_prob': 0.789,
                     'text': 'a'
                 }, {
-                    'id': [124],
+                    'id': 124,
                     'log_prob': 0.124,
                     'text': 'wonderful'
                 }, {
-                    'id': [356],
+                    'id': 356,
                     'log_prob': 0.356,
                     'text': 'day'
                 }],
@@ -416,7 +414,7 @@ class TestRollingBatch(unittest.TestCase):
             'generated_tokens': 1,
             'inputs': 'This is a wonderful day',
             'tokens': [{
-                'id': [244],
+                'id': 244,
                 'log_prob': -0.334532,
                 'text': 'He'
             }],
@@ -438,12 +436,12 @@ class TestRollingBatch(unittest.TestCase):
             'This is a wonderful day',
             'tokens': [
                 {
-                    'id': [244],
+                    'id': 244,
                     'text': 'He',
                     'log_prob': -0.334532,
                 },
                 {
-                    'id': [576],
+                    'id': 576,
                     'text': 'llo',
                     'log_prob': -0.123123,
                 },
@@ -466,15 +464,15 @@ class TestRollingBatch(unittest.TestCase):
             'inputs':
             'This is a wonderful day',
             'tokens': [{
-                'id': [244],
+                'id': 244,
                 'text': 'He',
                 'log_prob': -0.334532,
             }, {
-                'id': [576],
+                'id': 576,
                 'text': 'llo',
                 'log_prob': -0.123123,
             }, {
-                'id': [4558],
+                'id': 4558,
                 'text': ' world',
                 'log_prob': -0.567854,
             }],

--- a/engines/python/setup/djl_python/tests/test_test_model.py
+++ b/engines/python/setup/djl_python/tests/test_test_model.py
@@ -71,6 +71,8 @@ class TestTestModel(unittest.TestCase):
                          envs["OPTION_MODEL_ID"])
         self.assertEqual(handler.serving_properties["rolling_batch"],
                          envs["OPTION_ROLLING_BATCH"])
+        self.assertEqual(handler.serving_properties["tgi_compat"],
+                         envs["OPTION_TGI_COMPAT"])
         inputs = [{
             "inputs": "The winner of oscar this year is",
             "parameters": {
@@ -91,7 +93,7 @@ class TestTestModel(unittest.TestCase):
         self.assertTrue(json.loads(result[1]), list)
 
         for key in envs.keys():
-            os.environ[key] = ""
+            del os.environ[key]
 
     def test_all_code_chat(self):
         model_id = "TheBloke/Llama-2-7B-Chat-fp16"

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -114,16 +114,13 @@ class TransformersNeuronXService(object):
 
     def set_rolling_batch(self):
         if self.config.rolling_batch != "disable":
-            self.rolling_batch_config[
-                "output_formatter"] = self.config.output_formatter
             if self.draft_model:
                 self.rolling_batch_config["draft_model"] = self.draft_model
                 self.rolling_batch_config[
                     "spec_length"] = self.config.speculative_length
             self.rolling_batch = NeuronRollingBatch(
-                self.model, self.tokenizer, self.config.batch_size,
-                self.config.n_positions, self.config.rolling_batch_strategy,
-                **self.rolling_batch_config)
+                self.model, self.tokenizer, self.config.rolling_batch_strategy,
+                self.config, **self.rolling_batch_config)
 
     def set_model_loader(self):
         self.model_loader = self._model_loader_class(


### PR DESCRIPTION
## Description ##
In this PR:
1. option.tgi_compat in serving.properties and OPTION_TGI_COMPAT env both should work
2. Refactored rolling_batch class to accept Configs(parsed properties) instead of kwargs. 
3. [Breaks backward compatibility] token_id won't be list anymore. Since, now speculative decoding, we are adding multiple tokens. 


Testing:
Tested with scheduler rolling batch with env and serving.properties for bloom-560m model. 