### PR TITLE
[fix] inf2 pipeline fix for adapter unsupported

### DIFF
--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -65,8 +65,9 @@ def parse_input_with_formatter(inputs: Input,
         input_data.extend(_inputs)
         input_size.append(len(_inputs))
 
-        adapters.extend(adapters_per_item)
-        found_adapters = found_adapter_per_item or found_adapters
+        if input_format_configs.is_adapters_supported:
+            adapters.extend(adapters_per_item)
+            found_adapters = found_adapter_per_item or found_adapters
 
         for _ in range(input_size[i]):
             parameters.append(_param)


### PR DESCRIPTION
## Description ##

Add logic to ensure that when adapters are not supported that parse input still passes

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
