### PR TITLE
[fix] mpi mode check in trtllm

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -146,7 +146,7 @@ class HuggingFaceService(object):
 
         if is_rolling_batch_enabled(self.hf_configs.rolling_batch):
             _rolling_batch_cls = get_rolling_batch_class_from_str(
-                self.hf_configs.rolling_batch.value, self.hf_configs.is_mpi,
+                self.hf_configs.rolling_batch.value, self.hf_configs.mpi_mode,
                 self.model_config)
             self.hf_configs.kwargs["model_config"] = self.model_config
             self.rolling_batch = _rolling_batch_cls(

--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -156,6 +156,6 @@ class HuggingFaceProperties(Properties):
     @model_validator(mode='after')
     def set_device_mpi(self):
         if self.rolling_batch.value != RollingBatchEnum.disable.value:
-            if self.is_mpi:
+            if self.mpi_mode:
                 self.device = str(os.getenv("LOCAL_RANK", 0))
         return self

--- a/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
@@ -52,7 +52,7 @@ class LmiDistRbProperties(Properties):
 
     @model_validator(mode='after')
     def validate_mpi(self):
-        if not self.is_mpi:
+        if not self.mpi_mode:
             raise AssertionError(
                 f"Need MPI engine to start lmi-dist RollingBatcher")
         return self

--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -56,7 +56,7 @@ class Properties(BaseModel):
     revision: Optional[str] = None
     output_formatter: Optional[Union[str, Callable]] = None
     waiting_steps: Optional[int] = None
-    is_mpi: bool = False
+    mpi_mode: bool = False
     tgi_compat: Optional[bool] = False
 
     # Spec_dec
@@ -66,11 +66,6 @@ class Properties(BaseModel):
     # model_config is for pydantic configurations for BaseModel.
     model_config = ConfigDict(arbitrary_types_allowed=True,
                               protected_namespaces=())
-
-    @model_validator(mode='before')
-    def calculate_is_mpi(cls, properties):
-        properties['is_mpi'] = properties.get("mpi_mode") == "true"
-        return properties
 
     @field_validator('enable_streaming', mode='before')
     def validate_enable_streaming(cls, enable_streaming: str) -> str:

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -32,7 +32,7 @@ class TRTLLMRollingBatch(RollingBatch):
         :param properties: other properties of the model, such as decoder strategy
         """
         super().__init__(configs)
-        if configs.is_mpi:
+        if not configs.mpi_mode:
             raise AssertionError(
                 f"Need mpi_mode to start tensorrt llm RollingBatcher")
         self.model = tensorrt_llm_toolkit.init_inference(

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -270,7 +270,7 @@ class TestConfigManager(unittest.TestCase):
         self.assertTrue(hf_configs.low_cpu_mem_usage)
         self.assertFalse(hf_configs.disable_flash_attn)
         self.assertIsNone(hf_configs.device_map)
-        self.assertTrue(hf_configs.is_mpi)
+        self.assertTrue(hf_configs.mpi_mode)
         self.assertDictEqual(hf_configs.kwargs, {
             'trust_remote_code': False,
             "low_cpu_mem_usage": True,
@@ -300,7 +300,7 @@ class TestConfigManager(unittest.TestCase):
         self.assertTrue(hf_configs.low_cpu_mem_usage)
         self.assertFalse(hf_configs.disable_flash_attn)
         self.assertEqual(hf_configs.device_map, properties['device_map'])
-        self.assertTrue(hf_configs.is_mpi)
+        self.assertTrue(hf_configs.mpi_mode)
         self.assertDictEqual(
             hf_configs.kwargs, {
                 'trust_remote_code': True,
@@ -419,7 +419,7 @@ class TestConfigManager(unittest.TestCase):
             self.assertEqual(lmi_configs.load_format, 'auto')
             self.assertEqual(lmi_configs.dtype, 'auto')
             self.assertEqual(lmi_configs.gpu_memory_utilization, 0.9)
-            self.assertTrue(lmi_configs.is_mpi)
+            self.assertTrue(lmi_configs.mpi_mode)
 
         def test_with_most_properties():
             properties = {
@@ -444,7 +444,7 @@ class TestConfigManager(unittest.TestCase):
                 lmi_configs.max_rolling_batch_prefill_tokens,
                 int(properties['max_rolling_batch_prefill_tokens']))
             self.assertEqual(lmi_configs.dtype, 'fp32')
-            self.assertTrue(lmi_configs.is_mpi)
+            self.assertTrue(lmi_configs.mpi_mode)
             self.assertTrue(lmi_configs.trust_remote_code)
 
         def test_invalid_quantization():


### PR DESCRIPTION
## Description ##

1. In TensorLLM,  instead of `if not config.mpi_mode`, it was `if config.mpi_mode` 
2. In properties,  we dont need `is_mpi` property, it should be `mpi_mode`. 

## Testing
Tested with docker env HF_MODEL_ID and OPTION_TGI_COMPAT