### PR TITLE
[fix] Fix for neuron rolling batch CI error

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
@@ -162,8 +162,6 @@ class NeuronGenerator(ABC):
                 generated_tokens=slot_request.slot.generated_tokens,
                 finish_reason=finish_reason,
                 seed=slot_request.slot.seed)
-            # mark the slot as available
-            slot_request.slot.clear()
         generation = Generation(
             request_id=slot_request.slot.request_id,
             prefill_tokens=None,
@@ -174,6 +172,9 @@ class NeuronGenerator(ABC):
                               in slot_request.slot.special_tokens),
             generated_text=generated_text,
             speculated_generations=SpeculatedGenerationsQueue())
+        if finish_reason is not None:
+            # mark the slot as available
+            slot_request.slot.clear()
         return generation, finish_reason
 
     def _generate_token(self, inputs: GenerationInputs) -> List[Generation]:


### PR DESCRIPTION
## Description ##

Fixing CI failures for inferentia integration tests. Slot was being cleared before completing the generation so rolling batch completions resulted in error messages.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
