### PR TITLE
Refactor output_formatter and include all parameters

### DIFF
--- a/engines/python/setup/djl_python/output_formatter.py
+++ b/engines/python/setup/djl_python/output_formatter.py
@@ -15,33 +15,44 @@ import logging
 import time
 from typing import Union, Callable
 
-from djl_python.request_io import Token
+from djl_python.request_io import Token, TextGenerationOutput, RequestOutput
 
 
-def _json_output_formatter(token: Token, first_token: bool, last_token: bool,
-                           details: dict, generated_text: str, id: int):
+def _json_output_formatter(request_output: RequestOutput):
     """
     json output formatter
 
     :return: formatted output
     """
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+
+    parameters = request_output.input.parameters
+    generated_text = ""
+    if parameters.get("return_full_text"):
+        generated_text = request_output.input.input_text
+    next_token, first_token, last_token = best_sequence.get_next_token()
     json_encoded_str = f"{{\"generated_text\": \"{generated_text}" if first_token else ""
-    tgi_compat = details.pop("tgi_compat", False)
+    tgi_compat = request_output.input.tgi_compat
     if first_token and tgi_compat:
         json_encoded_str = f"[{json_encoded_str}"
-    json_encoded_str = f"{json_encoded_str}{json.dumps(token.text, ensure_ascii=False)[1:-1]}"
+    json_encoded_str = f"{json_encoded_str}{json.dumps(next_token.text, ensure_ascii=False)[1:-1]}"
     if last_token:
-        if details:
+        if parameters.get("details", tgi_compat):
             final_dict = {
-                "finish_reason": details.get("finish_reason", None),
-                "generated_tokens": details.get("generated_tokens", None),
-                "inputs": details.get("inputs", None),
-                "tokens": details.get("tokens", None),
+                "finish_reason": best_sequence.finish_reason,
+                "generated_tokens": len(best_sequence.tokens),
+                "inputs": request_output.input.input_text,
+                "tokens": request_output.get_tokens_as_dict(),
             }
 
-            if "prompt_tokens_details" in details:
-                final_dict["prefill"] = details.get("prompt_tokens_details")
-
+            if parameters.get("decoder_input_details"):
+                final_dict[
+                    "prefill"] = request_output.get_prompt_tokes_as_dict()
+            details_str = f"\"details\": {json.dumps(final_dict, ensure_ascii=False)}"
+            json_encoded_str = f"{json_encoded_str}\", {details_str}}}"
+        elif best_sequence.finish_reason == "error":
+            final_dict = {"finish_reason": best_sequence.finish_reason}
             details_str = f"\"details\": {json.dumps(final_dict, ensure_ascii=False)}"
             json_encoded_str = f"{json_encoded_str}\", {details_str}}}"
         else:
@@ -52,43 +63,56 @@ def _json_output_formatter(token: Token, first_token: bool, last_token: bool,
     return json_encoded_str
 
 
-def _jsonlines_output_formatter(token: Token, first_token: bool,
-                                last_token: bool, details: dict,
-                                generated_text: str, id: int):
+def _jsonlines_output_formatter(request_output: RequestOutput):
     """
     jsonlines output formatter
 
     :return: formatted output
     """
-    tgi_compat = details.pop("tgi_compat", False)
-    if tgi_compat:
-        token_dict = token.as_tgi_dict()
-    else:
-        token_dict = token.as_dict()
+    tgi_compat = request_output.input.tgi_compat
+    parameters = request_output.input.parameters
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+    next_token, _, last_token = best_sequence.get_next_token()
+    token_dict = next_token.as_tgi_dict(
+    ) if tgi_compat else next_token.as_dict()
     final_dict = {"token": token_dict}
     if last_token:
+        generated_text = request_output.input.input_text if parameters.get(
+            "return_full_text") else ""
+        for token in best_sequence.tokens:
+            generated_text += token.text
         final_dict["generated_text"] = generated_text
-        if details:
+        if parameters.get("details", tgi_compat):
             final_dict["details"] = {
-                "finish_reason": details.get("finish_reason", None),
-                "generated_tokens": details.get("generated_tokens", None),
-                "inputs": details.get("inputs", None),
+                "finish_reason": best_sequence.finish_reason,
+                "generated_tokens": len(best_sequence.tokens),
+                "inputs": request_output.input.input_text,
             }
-            if "prompt_tokens_details" in details:
-                final_dict["details"]["prefill"] = details.get(
-                    "prompt_tokens_details")
+            if parameters.get("decoder_input_details"):
+                final_dict["details"][
+                    "prefill"] = request_output.get_prompt_tokes_as_dict()
+        elif best_sequence.finish_reason == "error":
+            final_dict["details"] = {
+                "finish_reason": best_sequence.finish_reason
+            }
     json_encoded_str = json.dumps(final_dict, ensure_ascii=False) + "\n"
     return json_encoded_str
 
 
-def _json_chat_output_formatter(token: Token, first_token: bool,
-                                last_token: bool, details: dict,
-                                generated_text: str, id: int):
+def _json_chat_output_formatter(request_output: RequestOutput):
     """
     json output formatter for chat completions API
 
     :return: formatted output
     """
+    parameters = request_output.input.parameters
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+    generated_text = request_output.input.input_text if parameters.get(
+        "return_full_text") else ""
+    next_token, first_token, last_token = best_sequence.get_next_token()
+
     created = int(time.time())
     choice1 = {
         "index": 0,
@@ -104,35 +128,31 @@ def _json_chat_output_formatter(token: Token, first_token: bool,
         "choices": [choice1]  # Currently only support 1 choice
     }
     json_encoded_str = f"{json.dumps(response1, ensure_ascii=False)[:-5]}" if first_token else ""
-    json_encoded_str = f"{json_encoded_str}{json.dumps(token.text, ensure_ascii=False)[1:-1]}"
+    json_encoded_str = f"{json_encoded_str}{json.dumps(next_token.text, ensure_ascii=False)[1:-1]}"
     if last_token:
         logprobs = None
-        parameters = details.get("parameters", {})
         if parameters.get("logprobs"):
             logprobs = {
                 "content": [{
-                    "token":
-                        t.get("text"),
-                    "logprob":
-                        t.get("log_prob"),
-                    "bytes":
-                        (b := [ord(c)
-                               for c in t.get("text")] if t.get("text") else None),
+                    "token": t.text,
+                    "logprob": t.log_prob,
+                    "bytes": (b := [ord(c)
+                               for c in t.text] if t.text else None),
                     "top_logprobs":  # Currently only support 1 top_logprobs
                         [{
-                            "token": t.get("text"),
-                            "logprob": t.get("log_prob"),
+                            "token": t.text,
+                            "logprob": t.log_prob,
                             "bytes": b
                         }]
-                } for t in details.get("tokens", [])
+                } for t in best_sequence.tokens
                 ]
             }
         choice2 = {
             "logprobs": logprobs,
-            "finish_reason": details.get("finish_reason")
+            "finish_reason": best_sequence.finish_reason
         }
-        prompt_tokens = int(details.get("prompt_tokens", 0))
-        completion_tokens = int(details.get("generated_tokens", 0))
+        prompt_tokens = len(request_output.input.input_ids)
+        completion_tokens = len(best_sequence.tokens)
         response2 = {
             "choices": [choice2],
             "usage": {
@@ -145,32 +165,34 @@ def _json_chat_output_formatter(token: Token, first_token: bool,
     return json_encoded_str
 
 
-def _jsonlines_chat_output_formatter(token: Token, first_token: bool,
-                                     last_token: bool, details: dict,
-                                     generated_text: str, id: int):
+def _jsonlines_chat_output_formatter(request_output: RequestOutput):
     """
     jsonlines output formatter for chat completions API
 
     :return: formatted output
     """
+    parameters = request_output.input.parameters
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+    next_token, first_token, last_token = best_sequence.get_next_token()
+
     created = int(time.time())
-    delta = {"content": token.text}
+    delta = {"content": next_token.text}
     if first_token:
         delta["role"] = "assistant"
 
     logprobs = None
-    parameters = details.get("parameters", {})
     if parameters.get("logprobs"):
         logprobs = {
             "content":
                 [{
-                    "token": token.text,
-                    "logprob": token.log_prob,
-                    "bytes": (b := [ord(c) for c in token.text] if token.text else None),
+                    "token": next_token.text,
+                    "logprob": next_token.log_prob,
+                    "bytes": (b := [ord(c) for c in next_token.text] if next_token.text else None),
                     "top_logprobs":  # Currently only support 1 top_logprobs
                         [{
-                            "token": token.log_prob,
-                            "logprob": token.log_prob,
+                            "token": next_token.log_prob,
+                            "logprob": next_token.log_prob,
                             "bytes": b
                         }]
                 }]
@@ -179,7 +201,7 @@ def _jsonlines_chat_output_formatter(token: Token, first_token: bool,
         "index": 0,
         "delta": delta,
         "logprobs": logprobs,
-        "finish_reason": details.get("finish_reason")
+        "finish_reason": best_sequence.finish_reason
     }
     response = {
         "id": f"chatcmpl-{id}",
@@ -191,12 +213,48 @@ def _jsonlines_chat_output_formatter(token: Token, first_token: bool,
     return json_encoded_str
 
 
-def sse_response_formatter(*args, **kwargs):
+def sse_response_formatter(request_output: RequestOutput):
     """
     Decorator that used to form as SSE
     """
-    output_str = _jsonlines_output_formatter(*args, **kwargs)
+    output_str = _jsonlines_output_formatter(request_output)
     return f"data: {output_str}\n"
+
+
+def adapt_legacy_output_formatter(request_output: TextGenerationOutput):
+    sequence_index = request_output.best_sequence_index
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+    parameters = request_output.input.parameters
+    output_formatter = request_output.input.output_formatter
+    input_text = request_output.input.input_text
+    generated_text = ""
+    if parameters.get("return_full_text"):
+        generated_text = input_text
+    next_token_str = ""
+    while best_sequence.has_next_token():
+        details_dict = {}
+        # making detailed information captured for each token generation
+        if parameters.get("details", False):
+            details_dict["finish_reason"] = best_sequence.finish_reason
+            details_dict["tokens"] = request_output.get_tokens_as_dict(
+                sequence_index)
+            details_dict["generated_tokens"] = len(best_sequence.tokens)
+            details_dict["inputs"] = input_text
+            details_dict["parameters"] = parameters
+            details_dict["prompt_tokens"] = len(request_output.input.input_ids)
+        # Special handling for error case
+        elif best_sequence.finish_reason == "error":
+            details_dict["finish_reason"] = best_sequence.finish_reason
+
+        next_token, first_token, last_token = best_sequence.get_next_token()
+        if last_token:
+            for token in best_sequence.tokens:
+                generated_text += token.text
+        next_token_str += output_formatter(next_token, first_token, last_token,
+                                           details_dict, generated_text,
+                                           request_output.request_id)
+    return next_token_str
 
 
 def get_output_formatter(output_formatter: Union[str, Callable], stream: bool,

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -81,8 +81,7 @@ class Sequence:
     top_tokens: Optional[List[List[Token]]] = field(default_factory=lambda: [])
     cumulative_log_prob: float = 0.0
     finish_reason: str = False
-    last_token: bool = False
-    first_token: bool = True
+    _last_token_index: Optional[int] = None
     stop_reason: Optional[str] = None
     _tokens_iterator: Optional[Iterator] = field(init=False, default=None)
     _top_tokens_iterator: Optional[Iterator] = field(init=False, default=None)
@@ -91,24 +90,27 @@ class Sequence:
         self._tokens_iterator = Iterator()
         self._top_tokens_iterator = Iterator()
 
-    def set_next_token(self, token: Token):
+    def set_next_token(self, token: Token, is_last_token: bool = False):
         self.tokens.append(token)
+        if is_last_token:
+            self._last_token_index = len(self.tokens) - 1
 
     def set_next_top_tokens(self, top_tokens: List[Token]):
         self.top_tokens.append(top_tokens)
 
     def has_next_token(self):
-        return (self._tokens_iterator.get_index() + 1) < len(self.tokens)
+        return self._tokens_iterator.get_index() < len(self.tokens)
 
     def has_next_top_tokens(self):
-        return (self._top_tokens_iterator.next_index() + 1) < len(
-            self.top_tokens)
+        return self._top_tokens_iterator.get_index() < len(self.top_tokens)
 
-    def get_next_token(self):
+    def get_next_token(self) -> (Token, bool, bool):
         if self.has_next_token():
             index = self._tokens_iterator.next_index()
-            return self.tokens[index]
-        return None
+            first_token = index == 0
+            last_token = index == self._last_token_index
+            return self.tokens[index], first_token, last_token
+        return None, False, False
 
     def get_next_top_tokens(self):
         """Returns the next list of top tokens from the top_tokens list, or None if all have been iterated."""
@@ -129,6 +131,7 @@ class RequestInput:
     request_id: int
     output_formatter: Union[Callable, str] = None
     parameters: Dict = field(default_factory=lambda: [])
+    tgi_compat: bool = False
 
 
 @dataclass
@@ -137,12 +140,12 @@ class TextInput(RequestInput):
     Attributes:
         input_text: The input text.
         input_ids: The input tokens ids.
-        adapter: adapter used for the request.
+        adapters: adapter used for the request.
         tokenizer: tokenizer used for the request.
     """
     input_text: str = None
     input_ids: List[int] = field(default_factory=lambda: [])
-    adapter: Optional[Any] = None
+    adapters: Optional[Any] = None
     tokenizer: Optional[Any] = None
 
     def prompt_tokens_length(self) -> int:
@@ -172,15 +175,60 @@ class TextGenerationOutput(RequestOutput):
     """
     sequences: dict[int, Sequence] = field(default_factory=lambda: {})
     best_sequence_index: int = 0
-    prompt_tokens_details: List[dict] = field(default_factory=lambda: {})
+    prompt_tokens_details: List[Token] = field(default_factory=lambda: {})
 
-    def set_next_token(self, token: Token, sequence_index=0):
+    def set_next_token(self,
+                       token: Token,
+                       sequence_index=0,
+                       is_last_token: bool = False):
+        """Adds token to the given index sequence. If not given, adds to the first sequence.
+
+        :param is_last_token: whether the token is the last token of the sequence.
+        :param token: token to add to the given sequence.
+        :param sequence_index: index of the sequence to add the token to.
+        """
         if sequence_index not in self.sequences:
             self.sequences[sequence_index] = Sequence()
-        self.sequences[sequence_index].set_next_token(token)
+        self.sequences[sequence_index].set_next_token(token, is_last_token)
 
     def set_next_top_tokens(self, top_tokens: List[Token], sequence_index):
         self.sequences[sequence_index].top_tokens.append(top_tokens)
 
     def set_best_sequence_index(self, sequence_index):
         self.best_sequence_index = sequence_index
+
+    def set_finish_reason(self, finish_reason: str, sequence_index=0):
+        """Sets the finish reason for the given sequence index. If not given, sets the finish reason for the first.
+
+        :param finish_reason: finish reason for the sequence.
+        :param sequence_index: index of the sequence to set the finish reason.
+        """
+        self.sequences[sequence_index].finish_reason = finish_reason
+
+    def get_tokens_as_dict(self, sequence_index=0):
+        """Returns the tokens of the given sequence index as a dictionary.
+        If not given, returns the tokens of the first sequence index as a dictionary.
+
+        :param sequence_index: index of the sequence to get the tokens from.
+        :return: tokens of the given sequence index as a dictionary.
+        """
+        tokens = []
+        for token in self.sequences[sequence_index].tokens:
+            if self.input.tgi_compat:
+                tokens.append(token.as_tgi_dict())
+            else:
+                tokens.append(token.as_dict())
+        return tokens
+
+    def get_prompt_tokes_as_dict(self):
+        """Returns the prompt tokens as a dictionary.
+
+        :return: prompt tokens as a dictionary.
+        """
+        tokens = []
+        for token in self.prompt_tokens_details:
+            if self.input.tgi_compat:
+                tokens.append(token.as_tgi_dict())
+            else:
+                tokens.append(token.as_dict())
+        return tokens

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -122,18 +122,18 @@ class RollingBatch(ABC):
                 params = parameters[i] if i < len(parameters) else {}
                 adapter = adapters[i] if adapters is not None and i < len(
                     parameters) else None
-                details = params.pop("details", self.configs.tgi_compat)
+                details = params.get("details", self.configs.tgi_compat)
                 request = Request(self.req_id_counter,
                                   data,
                                   params,
-                                  details,
                                   input_ids=self.get_tokenizer().encode(data)
                                   if details else None,
                                   adapter=adapter,
                                   output_formatter=params.pop(
                                       "output_formatter",
                                       self.configs.output_formatter),
-                                  tgi_compat=self.configs.tgi_compat)
+                                  tgi_compat=self.configs.tgi_compat,
+                                  tokenizer=self.get_tokenizer())
                 self.active_requests.append(request)
                 self.req_id_counter += 1
         return self.active_requests[total_req_len:]

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -64,7 +64,7 @@ def update_request_cache_with_output(request_cache: OrderedDict,
                 log_prob=None if index == 0 else
                 request_output.prompt_logprobs[index][prompt_token_id])
             request_cache[request_id]["prompt_tokens_details"].append(
-                prompt_token.as_dict())
+                prompt_token)
     return request_cache
 
 

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -62,8 +62,8 @@ class TestRollingBatch(unittest.TestCase):
                       parameters={
                           "max_new_tokens": 256,
                           "return_full_text": True,
+                          "details": True
                       },
-                      details=True,
                       output_formatter=_json_output_formatter,
                       tgi_compat=True)
 
@@ -231,7 +231,12 @@ class TestRollingBatch(unittest.TestCase):
                 "text": " world",
                 "logprob": -0.567854
             },
-            "generated_text": "Hello world"
+            "generated_text": "Hello world",
+            "details": {
+                "finish_reason": "length",
+                "generated_tokens": 3,
+                "inputs": "This is a wonderful day"
+            }
         }
 
     def test_return_full_text(self):
@@ -285,7 +290,6 @@ class TestRollingBatch(unittest.TestCase):
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      details=True,
                       output_formatter=_json_output_formatter)
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
@@ -329,7 +333,6 @@ class TestRollingBatch(unittest.TestCase):
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      details=True,
                       output_formatter=_jsonlines_output_formatter)
         req.set_next_token(Token(244, "He", -0.334532))
         req.set_next_token(Token(576, "llo", -0.123123))
@@ -357,7 +360,6 @@ class TestRollingBatch(unittest.TestCase):
                           "details": True,
                           "decoder_input_details": True
                       },
-                      details=True,
                       output_formatter=_jsonlines_output_formatter)
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
@@ -383,16 +385,11 @@ class TestRollingBatch(unittest.TestCase):
                            True,
                            'length',
                            prompt_tokens_details=[
-                               Token(id=123, text="This",
-                                     log_prob=None).as_dict(),
-                               Token(id=456, text="is",
-                                     log_prob=0.456).as_dict(),
-                               Token(id=789, text="a",
-                                     log_prob=0.789).as_dict(),
-                               Token(id=124, text="wonderful",
-                                     log_prob=0.124).as_dict(),
-                               Token(id=356, text="day",
-                                     log_prob=0.356).as_dict()
+                               Token(id=123, text="This", log_prob=None),
+                               Token(id=456, text="is", log_prob=0.456),
+                               Token(id=789, text="a", log_prob=0.789),
+                               Token(id=124, text="wonderful", log_prob=0.124),
+                               Token(id=356, text="day", log_prob=0.356)
                            ])
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
@@ -441,7 +438,6 @@ class TestRollingBatch(unittest.TestCase):
                           "details": True,
                           "logprobs": True
                       },
-                      details=True,
                       output_formatter=_json_chat_output_formatter)
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
@@ -513,7 +509,6 @@ class TestRollingBatch(unittest.TestCase):
                           "decoder_input_details": True,
                           "logprobs": True
                       },
-                      details=True,
                       output_formatter=_jsonlines_chat_output_formatter)
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
@@ -615,7 +610,6 @@ class TestRollingBatch(unittest.TestCase):
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      details=True,
                       output_formatter=custom_fmt)
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
@@ -655,7 +649,6 @@ class TestRollingBatch(unittest.TestCase):
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      details=True,
                       input_ids=[101, 1188, 1110, 170, 7310, 1285, 102],
                       output_formatter=custom_fmt)
         req.set_next_token(Token(244, "He", -0.334532))

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -117,6 +117,12 @@ def _parse_inputs_params(input_map, item, input_format_configs):
     if not "output_formatter" in _param:
         _param["output_formatter"] = input_format_configs.output_formatter
 
+    if not is_chat_completions_request(input_map):
+        extra_fields = {}
+        for key, value in input_map.items():
+            extra_fields[key] = value
+        _param["extra_fields"] = extra_fields
+
     if isinstance(_inputs, list):
         return _inputs, _param, True
     else:

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -231,7 +231,10 @@ lmi_dist_model_spec = {
         "max_memory_per_gpu": [23.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "TheBloke/Llama-2-13B-fp16"
+        "tokenizer": "TheBloke/Llama-2-13B-fp16",
+        "parameters": {
+            "decoder_input_details": True
+        }
     },
     "mistral-7b": {
         "max_memory_per_gpu": [23.0],
@@ -243,7 +246,10 @@ lmi_dist_model_spec = {
         "max_memory_per_gpu": [23.0],
         "batch_size": [1, 4],
         "seq_length": [1024],
-        "tokenizer": "TheBloke/Llama-2-13B-fp16"
+        "tokenizer": "TheBloke/Llama-2-13B-fp16",
+        "parameters": {
+            "decoder_input_details": True
+        }
     },
     "mistral-7b-128k-awq": {
         "max_memory_per_gpu": [23.0],
@@ -295,7 +301,10 @@ vllm_model_spec = {
         "max_memory_per_gpu": [23.0],
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "amazon/MegaBeam-Mistral-7B-300k"
+        "tokenizer": "amazon/MegaBeam-Mistral-7B-300k",
+        "parameters": {
+            "decoder_input_details": True
+        }
     },
     "phi-2": {
         "max_memory_per_gpu": [23.0],
@@ -887,6 +896,8 @@ def test_handler_rolling_batch(model, model_spec):
     seq_length = 100
     params = {"do_sample": True, "max_new_tokens": seq_length, "details": True}
     req["parameters"] = params
+    if "parameters" in spec:
+        req["parameters"].update(spec["parameters"])
     if "adapters" in spec:
         req["adapters"] = spec.get("adapters")[0]
     logging.info(f"req {req}")


### PR DESCRIPTION
## Description ##

This PR refactors all the output formatter signature to support RequestOutput. The changes include

- TextGenerationOutput and TextInput is initialized in Request class. When we reset Request, all these data should be reset as well. 
- Request constructor now also receives tokenizer. 
- While parsing the input, all the extra fields in the payload are fused into `parameters`. 
- Added `tgi_compat` as one of the data variable of RequestInput. 
- prompt_token_details, now we expect the individual handlers to set it as list of tokens, now it can support token as dict with tgi compatibility. 
- Added integration tests to test for `decoder_input_details` for lmi and vllm 
- Output formatter, if the customer uses old signature, it should work with that as well. 
