### PR TITLE
[vllm 0.4.2] prompt log probs changes

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -62,7 +62,7 @@ def update_request_cache_with_output(request_cache: OrderedDict,
                 id=prompt_token_id,
                 text=tokenizer.decode([prompt_token_id]),
                 log_prob=None if index == 0 else
-                request_output.prompt_logprobs[index][prompt_token_id])
+                request_output.prompt_logprobs[index][prompt_token_id].logprob)
             request_cache[request_id]["prompt_tokens_details"].append(
                 prompt_token.as_dict())
     return request_cache


### PR DESCRIPTION
## Description ##

vllm changed the PromptLogProbs dataclass in 0.4.2

in vllm 0.3.3
```
PromptLogprobs = List[Optional[Dict[int, float]]]
```

in vllm 0.4.2
```
@dataclass
class Logprob:
    logprob: float
    rank: Optional[int] = None
    decoded_token: Optional[str] = None

PromptLogprobs = List[Optional[Dict[int, Logprob]]]
```

Will test it with vllm 0.4.2, once it is ready. 