### PR TITLE
Update shm size for trtllm test

### DIFF
--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -27,6 +27,9 @@ elif [[ "$platform" == *"lmi"* || "$platform" == *"trtllm"*  || "$platform" == *
   runtime="nvidia"
   is_llm=true
   shm="12gb"
+  if [[ "$platform" == *"trtllm"* || "$platform" == *"tensorrt-llm"*]]; then
+    shm="20gb"
+  fi
 elif [[ "$platform" == *"inf1"* ]]; then # if the platform is inferentia
   host_device="--device /dev/neuron0"
 elif [[ "$platform" == *"inf2"* ]]; then # inf2: pytorch-inf2-24 24 will be the total devices

--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -26,9 +26,10 @@ if [[ "$platform" == *"-gpu"* ]]; then # if the platform has cuda capabilities
 elif [[ "$platform" == *"lmi"* || "$platform" == *"trtllm"*  || "$platform" == *"tensorrt-llm"* ]]; then # Runs multi-gpu
   runtime="nvidia"
   is_llm=true
-  shm="12gb"
   if [[ "$platform" == *"trtllm"* || "$platform" == *"tensorrt-llm"*]]; then
     shm="20gb"
+  else
+    shm="12gb"
   fi
 elif [[ "$platform" == *"inf1"* ]]; then # if the platform is inferentia
   host_device="--device /dev/neuron0"


### PR DESCRIPTION
## Description ##
1. Noticed during some local runs that, higher MNT value on p4d may cause shm memory OOM, very rare. 
2. This change may help in ruling out role of shm size in intermittent llama2 70b failures we see on p4d for tp8
