### PR TITLE
[docs] fix wrong hf token env var in doc

### DIFF
--- a/serving/docs/lmi/tutorials/tnx_aot_tutorial.md
+++ b/serving/docs/lmi/tutorials/tnx_aot_tutorial.md
@@ -109,7 +109,7 @@ Run the container and run the model partitioning script.
 The command below assumes that we are using a `serving.properties` in the `~/` directory and that we will be downloading the model artifacts from s3. If you need to download the model from HuggingFace using an access token you would add the following line to the `docker run` command:
 
 ```
-  -e HUGGING_FACE_HUB_TOKEN="hf_YOUR_TOKEN_VALUE" \
+  -e HF_TOKEN="hf_YOUR_TOKEN_VALUE" \
 ```
 
 Tutorial `docker run` for our example model compilation.


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
