### PR TITLE
[docs][lmi] update input/output schema docs with error response details

### DIFF
--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -83,6 +83,45 @@ Example response:
 }
 ```
 
+#### Error Responses
+
+When rolling batch is enabled, errors are returned with HTTP response code 200.
+Error details are returned in the response content.
+
+If the request is poorly formatted (i.e. invalid json in the request body), the response content will be:
+
+```
+{
+    "error": "<error details>",
+    "code": 424
+}
+```
+
+If there is an issue with the request (such as bad generation parameter value), or an error occurs during generation, the response content will be:
+
+When not using streaming:
+
+```
+{
+    "generated_text": "", 
+    "details": {
+        "finish_reason": "error", 
+        "generated_tokens": null, 
+        "inputs": null, 
+        "tokens": null
+    }
+}
+```
+
+When using streaming:
+
+```
+{
+    "token": {"id": -1, "text": "", "log_prob": -1, "special_token": true}, 
+    "generated_text": "", 
+    "details": {"finish_reason": "error", "generated_tokens": null, "inputs": null}}
+}
+```
 ## Dynamic Batch/Static Batch Schema
 
 ### Request Schema
@@ -141,6 +180,19 @@ Example response:
 {"outputs": ["is"]}
 ...more outputs until the last one
 ```
+
+#### Error Responses
+
+When using dynamic batching, errors are returned with HTTP response code 424 and content:
+
+``` 
+{
+    "code": 424,
+    "message": "prediction failure",
+    "error": "<error details"
+}
+```
+
 
 ## API Object Schemas
 


### PR DESCRIPTION
## Description ##

Adding error response schema details to the lmi docs. **Note: this is the state of 0.28.0**

This should cover the most common error scenarios when using LMI with the different modes (streaming/non-streaming, rolling-batch/dynamic-batch).

I've tested all the scenarios and validated that this is what the responses look like for various scenarios.

I don't think we have docs for the inference api error responses (at least I can't find them). I've left those out of scope for now as it probably deserves its own doc if we want to add those details.
