### PR TITLE
fix t5 tokenizer and prompt token failures

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -47,6 +47,8 @@ class LmiDistRollingBatch(RollingBatch):
         :param properties (dict): other properties of the model, such as decoder strategy
         """
         self.lmi_dist_config = LmiDistRbProperties(**properties)
+        self.model_type = getattr(kwargs.get("model_config", None),
+                                  "model_type", None)
         super().__init__(self.lmi_dist_config)
         self.supports_speculative_decoding = supports_speculative_decoding()
         engine_kwargs = {}
@@ -83,8 +85,6 @@ class LmiDistRollingBatch(RollingBatch):
             kwargs["warmup_prefill_tokens"] = _WARMUP_PREFILL_TOKENS
         self.engine = engine_from_args(engine_args, **kwargs)
         self.request_cache = OrderedDict()
-        self.model_type = getattr(kwargs.get("model_config", None),
-                                  "model_type", None)
         self.lora_ids = defaultdict(lambda: len(self.lora_ids) + 1)
 
     def reset(self) -> None:
@@ -96,6 +96,8 @@ class LmiDistRollingBatch(RollingBatch):
         super().reset()
 
     def get_tokenizer(self):
+        if "t5" == self.model_type:
+            return self.engine.preprocessor.tokenizer
         return self.engine.preprocessor.tokenizer.tokenizer
 
     def translate_lmi_dist_params(self, parameters: dict):

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -75,6 +75,9 @@ def update_request_cache_with_output(request_cache: OrderedDict,
     if "prompt_tokens_details" not in request_cache[
             request_id] and request_output.prompt_logprobs:
         request_cache[request_id]["prompt_tokens_details"] = []
+        if not isinstance(request_output.prompt_token_ids, list):
+            ## lmi-dist does not return prompt_token_ids for t5
+            request_output.prompt_token_ids = []
         for index, prompt_token_id in enumerate(
                 request_output.prompt_token_ids):
             prompt_token = Token(


### PR DESCRIPTION

1. In `lmi-dist`, t5 model impl is different from other models and preprocessor's tokenizer attribute contains `tokenizer` directly instead of `TokenizerGroup`
2. skip sending prompt token details for t5 as it does not populate those in request output. Current code errors out as `request_output.prompt_token_ids` is an integer of bos token and fails in the for loop enumeration.