### PR TITLE
Add tensorrt_llm libs to LD_LIBRARY_PATH

### DIFF
--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -46,7 +46,7 @@ ENV DJL_CACHE_DIR=/tmp/.djl.ai
 ENV HF_HOME=/tmp/.cache/huggingface
 ENV PYTORCH_KERNEL_CACHE_PATH=/tmp/.cache
 ENV BITSANDBYTES_NOWELCOME=1
-ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:/usr/local/lib/python${python_version}/dist-packages/tensorrt_libs:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:/usr/local/lib/python${python_version}/dist-packages/tensorrt_libs:/usr/local/lib/python${python_version}/dist-packages/tensorrt_llm/libs/:${LD_LIBRARY_PATH}
 ENV SERVING_FEATURES=trtllm
 
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]


### PR DESCRIPTION
## Description ##

1. Currently, on the container, the `libtriton_tensorrtllm_common.so` is not correctly linked to `libtensorrt_llm.so`:
```
root@1255f90326fc:/opt/tritonserver/backends/tensorrtllm# ldd libtriton_tensorrtllm_common.so
        linux-vdso.so.1 (0x00007fff9a34c000)
        libtensorrt_llm.so => not found
        libtritonserver.so => /opt/tritonserver/lib/libtritonserver.so (0x00007f14ad69f000)
        libmpi_cxx.so.40 => /usr/lib/x86_64-linux-gnu/libmpi_cxx.so.40 (0x00007f14ad685000)
....
```
2. Adding the path to tensorrt_llm libs from dist-packages to fix this. After fix:
```
root@1255f90326fc:/opt/tritonserver/backends/tensorrtllm# ldd libtriton_tensorrtllm_common.so
        linux-vdso.so.1 (0x00007ffc8d976000)
        libtensorrt_llm.so => /usr/local/lib/python3.10/dist-packages/tensorrt_llm/libs/libtensorrt_llm.so (0x00007ff0f7764000)
        libtritonserver.so => /opt/tritonserver/lib/libtritonserver.so (0x00007ff0f724c000)
        libmpi_cxx.so.40 => /usr/lib/x86_64-linux-gnu/libmpi_cxx.so.40 (0x00007ff0f7229000)
```
3. Could also be related to flaky segfault, not being able to link to certain *.so at runtime...