### PR TITLE
best_of support in output formatter

### DIFF
--- a/engines/python/setup/djl_python/output_formatter.py
+++ b/engines/python/setup/djl_python/output_formatter.py
@@ -18,7 +18,7 @@ from typing import Union, Callable
 from typing_extensions import deprecated
 
 from djl_python.request_io import TextGenerationOutput, RequestOutput
-from djl_python.utils import is_best_of, is_beam_search, wait_till_generation_finished
+from djl_python.utils import wait_till_generation_finished
 
 
 def get_generated_text(sequence, request_output):
@@ -74,10 +74,8 @@ def _json_output_formatter_best_of(request_output: RequestOutput):
             other_sequences.append(sequence_details)
 
         if other_sequences:
-            if is_best_of(parameters):
+            if wait_till_generation_finished(parameters):
                 details["best_of_sequences"] = other_sequences
-            elif is_beam_search(parameters):
-                details["beam_sequences"] = other_sequences
         result["details"] = details
         json_encoded_str = json.dumps(result, ensure_ascii=False)
         if request_output.input.tgi_compat:

--- a/engines/python/setup/djl_python/output_formatter.py
+++ b/engines/python/setup/djl_python/output_formatter.py
@@ -17,7 +17,72 @@ from typing import Union, Callable
 
 from typing_extensions import deprecated
 
-from djl_python.request_io import Token, TextGenerationOutput, RequestOutput
+from djl_python.request_io import TextGenerationOutput, RequestOutput
+from djl_python.utils import is_best_of, is_beam_search, wait_till_generation_finished
+
+
+def get_generated_text(sequence, request_output):
+    parameters = request_output.input.parameters
+    generated_text = request_output.input.input_text if parameters.get(
+        "return_full_text") else ""
+    for token in sequence.tokens:
+        generated_text += token.text
+    return generated_text
+
+
+def get_sequence_details(request_output: RequestOutput,
+                         sequence_index: int) -> dict:
+    sequence = request_output.sequences[sequence_index]
+    parameters = request_output.input.parameters
+
+    sequence_details = {
+        "finish_reason": sequence.finish_reason,
+        "generated_tokens": len(sequence.tokens),
+        "tokens": request_output.get_tokens_as_dict(sequence_index),
+    }
+    if parameters.get("decoder_input_details"):
+        sequence_details["prefill"] = request_output.get_prompt_tokens_as_dict(
+        )
+    return sequence_details
+
+
+def _json_output_formatter_best_of(request_output: RequestOutput):
+    """When multiple sequences are generated, then we hold off sending the result until the generation is finished.
+    The is because, in case of best_of or beam_search, we would know the best sequence only at the end of the
+    generation of a request.
+    """
+    json_encoded_str = ""
+    if request_output.finished:
+        parameters = request_output.input.parameters
+        best_sequence = request_output.sequences[
+            request_output.best_sequence_index]
+        result = {
+            "generated_text": get_generated_text(best_sequence, request_output)
+        }
+        details = {"inputs": request_output.input.input_text}
+        details.update(
+            get_sequence_details(request_output,
+                                 request_output.best_sequence_index))
+
+        # other sequences indicate, all other sequences except the best/chosen sequence.
+        other_sequences = []
+        for index in request_output.other_sequences_indices:
+            sequence = request_output.sequences[index]
+            generated_text = get_generated_text(sequence, request_output)
+            sequence_details = get_sequence_details(request_output, index)
+            sequence_details["generated_text"] = generated_text
+            other_sequences.append(sequence_details)
+
+        if other_sequences:
+            if is_best_of(parameters):
+                details["best_of_sequences"] = other_sequences
+            elif is_beam_search(parameters):
+                details["beam_sequences"] = other_sequences
+        result["details"] = details
+        json_encoded_str = json.dumps(result, ensure_ascii=False)
+        if request_output.input.tgi_compat:
+            json_encoded_str = f"[{json_encoded_str}]"
+    return json_encoded_str
 
 
 def _json_output_formatter(request_output: RequestOutput):
@@ -26,10 +91,13 @@ def _json_output_formatter(request_output: RequestOutput):
 
     :return: formatted output
     """
-    best_sequence = request_output.sequences[
-        request_output.best_sequence_index]
 
     parameters = request_output.input.parameters
+    if wait_till_generation_finished(parameters):
+        return _json_output_formatter_best_of(request_output)
+
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
     generated_text = ""
     if parameters.get("return_full_text"):
         generated_text = request_output.input.input_text
@@ -50,7 +118,7 @@ def _json_output_formatter(request_output: RequestOutput):
 
             if parameters.get("decoder_input_details"):
                 final_dict[
-                    "prefill"] = request_output.get_prompt_tokes_as_dict()
+                    "prefill"] = request_output.get_prompt_tokens_as_dict()
             details_str = f"\"details\": {json.dumps(final_dict, ensure_ascii=False)}"
             json_encoded_str = f"{json_encoded_str}\", {details_str}}}"
         elif best_sequence.finish_reason == "error":
@@ -80,10 +148,7 @@ def _jsonlines_output_formatter(request_output: RequestOutput):
     ) if tgi_compat else next_token.as_dict()
     final_dict = {"token": token_dict}
     if last_token:
-        generated_text = request_output.input.input_text if parameters.get(
-            "return_full_text") else ""
-        for token in best_sequence.tokens:
-            generated_text += token.text
+        generated_text = get_generated_text(best_sequence, request_output)
         final_dict["generated_text"] = generated_text
         if parameters.get("details", tgi_compat):
             final_dict["details"] = {
@@ -93,7 +158,7 @@ def _jsonlines_output_formatter(request_output: RequestOutput):
             }
             if parameters.get("decoder_input_details"):
                 final_dict["details"][
-                    "prefill"] = request_output.get_prompt_tokes_as_dict()
+                    "prefill"] = request_output.get_prompt_tokens_as_dict()
         elif best_sequence.finish_reason == "error":
             final_dict["details"] = {
                 "finish_reason": best_sequence.finish_reason

--- a/engines/python/setup/djl_python/request.py
+++ b/engines/python/setup/djl_python/request.py
@@ -16,6 +16,7 @@ from typing import Union, Callable, Any
 from djl_python.output_formatter import get_output_formatter, _json_output_formatter, sse_response_formatter, \
     adapt_legacy_output_formatter
 from djl_python.request_io import Token, TextGenerationOutput, TextInput, RequestOutput
+from djl_python.utils import wait_till_generation_finished
 
 
 class Request(object):
@@ -110,10 +111,12 @@ class Request(object):
             next_token = Token(-1, next_token)
         next_token.request_id = self.id
         self.request_output.set_next_token(next_token,
-                                           is_last_token=last_token)
-        self.request_output.set_finish_reason(finish_reason)
+                                           is_last_token=last_token,
+                                           finish_reason=finish_reason)
         self.request_output.prompt_tokens_details = prompt_tokens_details
         self.last_token = last_token
+        if last_token:
+            self.request_output.finished = True
 
     def get_next_token(self) -> str:
         """
@@ -127,6 +130,11 @@ class Request(object):
             # TODO: Remove this support when all of our customers onboard.
             if self.legacy_formatter:
                 self.next_token_str = adapt_legacy_output_formatter(
+                    self.request_output)
+            elif wait_till_generation_finished(
+                    self.request_output.input.parameters):
+                # there is no need for iterators for best_of and num_beams.
+                self.next_token_str = self.output_formatter(
                     self.request_output)
             else:
                 best_sequence = self.request_output.sequences[

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -203,14 +203,15 @@ def is_best_of(parameters: dict) -> bool:
     return "best_of" in parameters.keys() and parameters.get("best_of") > 1
 
 
-def is_beam_search(parameters: dict) -> bool:
+def is_multiple_sequences(parameters: dict) -> bool:
     """
-    Returns whether the parameters indicate beam search decoding to be used.
+    Returns whether the parameters indicate number of output sequences to return is more than 1.
+    When the user give us n, best_of is automatically applied in vllm and lmi-dist.
     :param parameters: parameters dictionary
     :return: boolean
     """
-    return "num_beams" in parameters.keys() and parameters.get("num_beams") > 1
+    return "n" in parameters.keys() and parameters.get("n") > 1
 
 
 def wait_till_generation_finished(parameters):
-    return is_best_of(parameters) or is_beam_search(parameters)
+    return is_best_of(parameters) or is_multiple_sequences(parameters)

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -192,3 +192,25 @@ def profile_objects(func):
         return result
 
     return apply_profiling
+
+
+def is_best_of(parameters: dict) -> bool:
+    """
+    Returns whether parameters indicate best_of should be applied.
+    :param parameters: parameters dictionary
+    :return: boolean
+    """
+    return "best_of" in parameters.keys() and parameters.get("best_of") > 1
+
+
+def is_beam_search(parameters: dict) -> bool:
+    """
+    Returns whether the parameters indicate beam search decoding to be used.
+    :param parameters: parameters dictionary
+    :return: boolean
+    """
+    return "num_beams" in parameters.keys() and parameters.get("num_beams") > 1
+
+
+def wait_till_generation_finished(parameters):
+    return is_best_of(parameters) or is_beam_search(parameters)


### PR DESCRIPTION
## Description ##

For best_of, we wait for the whole generation is finished, because we would not know which of the multiple sequences has the highest cumulative probability until the end of the generation. This is the reason, TGI supports best_of only during non streaming case. 

This PR, introduces best_of support in json_output_formatter. 

Unit test case:
Added unit test case to validate the output formatter. 

Integration tests:
In order to test this in integration test, vllm/lmi-dist handler should support this. Will create a new PR for this, as the changes are a lot. Meanwhile, this PR changes should not fail any integration tests. 