### PR TITLE
[docs][lmi] add warning to deepspeed user guide indicating deprecated…

### DIFF
--- a/serving/docs/lmi/user_guides/deepspeed_user_guide.md
+++ b/serving/docs/lmi/user_guides/deepspeed_user_guide.md
@@ -1,5 +1,9 @@
 # DeepSpeed Engine User Guide
 
+> [!WARNING]
+> DeepSpeed support has been removed starting with LMI container release 0.28.0.
+> You should migrate to one of the other supported backends. 
+
 ## Model Artifacts Structure
 
 DeepSpeed expects the model to be in the [standard HuggingFace format](../deployment_guide/model-artifacts.md).


### PR DESCRIPTION
… support

## Description ##

I don't know if `[!WARNING]` renders correctly with the docs site, so i'm happy to remove it. It does look nice on github.

We can remove this user guide in the next release, but i think maintaining it with this disclaimer for at least 1 release makes sense. We could add a migration guide as well.
