### PR TITLE
[serving] Update python typing to support py38

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -22,6 +22,7 @@ from transformers import (
     AutoModelForQuestionAnswering, StoppingCriteria, StoppingCriteriaList)
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from peft import PeftConfig, PeftModel, PeftModelForCausalLM
+from typing import Tuple, List
 
 from djl_python.encode_decode import encode
 from djl_python.inputs import Input
@@ -214,7 +215,7 @@ class HuggingFaceService(object):
 
     def parse_input(
         self, inputs: Input, tokenizer, output_formatter
-    ) -> tuple[list[str], list[int], list[dict], dict, list]:
+    ) -> Tuple[List[str], List[int], List[dict], dict, list]:
         """
         Preprocessing function that extracts information from Input objects.
 
@@ -222,9 +223,9 @@ class HuggingFaceService(object):
         :param inputs :(Input) a batch of inputs, each corresponding to a new request
         :param tokenizer: the tokenizer used for inference
 
-        :return input_data (list[str]): a list of strings, each string being the prompt in a new request
-        :return input_size (list[int]): a list of ints being the size of each new request
-        :return parameters (list[dict]): parameters pertaining to each request
+        :return input_data (List[str]): a list of strings, each string being the prompt in a new request
+        :return input_size (List[int]): a list of ints being the size of each new request
+        :return parameters (List[dict]): parameters pertaining to each request
         :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
         :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
         """

--- a/engines/python/setup/djl_python/request.py
+++ b/engines/python/setup/djl_python/request.py
@@ -11,7 +11,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import inspect
-from typing import Union, Callable, Any
+from typing import Union, Callable, Any, List
 
 from djl_python.output_formatter import get_output_formatter, _json_output_formatter, sse_response_formatter, \
     adapt_legacy_output_formatter
@@ -94,7 +94,7 @@ class Request(object):
                        next_token: Union[Token, str],
                        last_token: bool = False,
                        finish_reason: str = None,
-                       prompt_tokens_details: list[Token] = None):
+                       prompt_tokens_details: List[Token] = None):
         """
         Sets the newly generated token.
         If the function is called for multiple times, we will append tokens to the token string.

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -175,7 +175,7 @@ class TextGenerationOutput(RequestOutput):
         other_sequences_indices: indices of the sequences other than best_sequence to return to user. For example,
         if best_of=4 and n=3, then we return store the other two sequences' indices in this list.
     """
-    sequences: dict[int, Sequence] = field(default_factory=lambda: {})
+    sequences: Dict[int, Sequence] = field(default_factory=lambda: {})
     best_sequence_index: int = 0
     prompt_tokens_details: List[Token] = field(default_factory=lambda: [])
     other_sequences_indices: List[int] = field(default_factory=lambda: [])

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -11,6 +11,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import logging
+from typing import List
 from collections import OrderedDict, defaultdict
 
 from lmi_dist.api import Request, RequestParams
@@ -137,8 +138,8 @@ class LmiDistRollingBatch(RollingBatch):
 
     @stop_on_any_exception
     def inference(self,
-                  input_data: list[str],
-                  parameters: list[dict],
+                  input_data: List[str],
+                  parameters: List[dict],
                   adapters=None) -> list:
         """
         Adds new requests and gets output tokens from the backend.

--- a/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/neuron_rolling_batch.py
@@ -13,7 +13,7 @@
 
 import torch
 import logging
-from typing import Optional, Any
+from typing import Optional, Any, List
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, FINISH_REASON_MAPPER
 from djl_python.request_io import Token
 from djl_python.transformers_neuronx_scheduler.optimum_neuron_scheduler import NaiveRollingBatchNeuronGenerator, ContinuousBatchingNeuronGenerator
@@ -97,8 +97,8 @@ class NeuronRollingBatch(RollingBatch):
 
     @stop_on_any_exception
     def inference(self,
-                  input_data: list[str],
-                  parameters: list[dict],
+                  input_data: List[str],
+                  parameters: List[dict],
                   adapters=None) -> list:
         """
         Loads new requests and gets output tokens from all currently active requests from

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -101,15 +101,15 @@ class RollingBatch(ABC):
         pass
 
     def get_new_requests(self,
-                         input_data: list[str],
-                         parameters: list[dict],
+                         input_data: List[str],
+                         parameters: List[dict],
                          batch_size: int,
-                         adapters=None) -> list[Request]:
+                         adapters=None) -> List[Request]:
         """
         Adds requests to the batch when there is availability
 
-        :param input_data: (list[str]) List of input prompts.
-        :param parameters: (list[str]) List of settings pertaining to each request.
+        :param input_data: (List[str]) List of input prompts.
+        :param parameters: (List[str]) List of settings pertaining to each request.
         :param batch_size: (int) Maximum number of requests in a batch
         :param adapters: List of adapters inputs for each request in a batch
 
@@ -139,15 +139,15 @@ class RollingBatch(ABC):
         return self.active_requests[total_req_len:]
 
     @abstractmethod
-    def preprocess_requests(self, requests: list[Request]):
+    def preprocess_requests(self, requests: List[Request]):
         """
         Converts requests into specific formats that are required by specific backends.
 
-        :param requests (list[Request]): requests that will be sent to the backend after preprocessing
+        :param requests (List[Request]): requests that will be sent to the backend after preprocessing
         """
         pass
 
-    def postprocess_results(self) -> list[dict]:
+    def postprocess_results(self) -> List[dict]:
         """
         Returns most recent produced token by each request in a list of dicts
 

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -68,8 +68,8 @@ class SchedulerRollingBatch(RollingBatch):
 
     @stop_on_any_exception
     def inference(self,
-                  input_text: list[str],
-                  parameters: list[dict],
+                  input_text: List[str],
+                  parameters: List[dict],
                   adapters=None) -> list:
         """
         Performs prefill and decode operations for the batch.
@@ -328,11 +328,11 @@ class SchedulerRollingBatch(RollingBatch):
         return self.tokenizer
 
 
-def _get_request_ids_tensor(request_ids: list[int]) -> torch.Tensor:
+def _get_request_ids_tensor(request_ids: List[int]) -> torch.Tensor:
     """
     Converts a list of request ids into a 2-d pytorch tensor.
 
-    :param request_ids (list[int]): List of request IDs
+    :param request_ids (List[int]): List of request IDs
 
     :return: 2-D torch Tensor
     """

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -15,6 +15,7 @@ import tensorrt_llm_toolkit
 from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception
 from djl_python.request_io import Token
+from typing import List
 
 
 class TRTLLMRollingBatch(RollingBatch):
@@ -86,8 +87,8 @@ class TRTLLMRollingBatch(RollingBatch):
 
     @stop_on_any_exception
     def inference(self,
-                  input_data: list[str],
-                  parameters: list[dict],
+                  input_data: List[str],
+                  parameters: List[dict],
                   adapters=None) -> list:
         """
         Loads new requests into the batch when there is availability, and gets output tokens from the backend

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -22,6 +22,7 @@ from djl_python.rolling_batch.rolling_batch_vllm_utils import (
     update_request_cache_with_output, get_lora_request_params, DTYPE_MAPPER,
     FINISH_REASON_MAPPER, get_engine_args_from_config)
 from djl_python.properties_manager.vllm_rb_properties import VllmRbProperties
+from typing import List
 
 VLLM_GENERATION_PARAMS = set(SamplingParams().__dict__.keys())
 
@@ -94,8 +95,8 @@ class VLLMRollingBatch(RollingBatch):
 
     @stop_on_any_exception
     def inference(self,
-                  input_data: list[str],
-                  parameters: list[dict],
+                  input_data: List[str],
+                  parameters: List[dict],
                   adapters=None) -> list:
         """
         Adds new requests and gets output tokens from the backend.

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -17,6 +17,7 @@ from djl_python.rolling_batch.trtllm_rolling_batch import TRTLLMRollingBatch
 from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
 from djl_python.tensorrt_llm_python import TRTLLMPythonService
 from djl_python.utils import parse_input_with_formatter, InputFormatConfigs
+from typing import List, Tuple
 
 
 class TRTLLMService(object):
@@ -47,7 +48,7 @@ class TRTLLMService(object):
     # Backward compatibility.
     def parse_input(
         self, inputs: Input, tokenizer, output_formatter
-    ) -> tuple[list[str], list[int], list[dict], dict, list]:
+    ) -> Tuple[List[str], List[int], List[dict], dict, list]:
         """
         Preprocessing function that extracts information from Input objects.
 
@@ -55,9 +56,9 @@ class TRTLLMService(object):
         :param inputs :(Input) a batch of inputs, each corresponding to a new request
         :param tokenizer: the tokenizer used for inference
 
-        :return input_data (list[str]): a list of strings, each string being the prompt in a new request
-        :return input_size (list[int]): a list of ints being the size of each new request
-        :return parameters (list[dict]): parameters pertaining to each request
+        :return input_data (List[str]): a list of strings, each string being the prompt in a new request
+        :return input_size (List[int]): a list of ints being the size of each new request
+        :return parameters (List[dict]): parameters pertaining to each request
         :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
         :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
         """

--- a/engines/python/setup/djl_python/tensorrt_llm_python.py
+++ b/engines/python/setup/djl_python/tensorrt_llm_python.py
@@ -6,6 +6,7 @@ import tensorrt_llm_toolkit
 from tensorrt_llm_toolkit.utils import utils as toolkit_utils
 
 from transformers import AutoConfig
+from typing import Tuple, List
 
 from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
 from djl_python.encode_decode import encode
@@ -65,7 +66,7 @@ def _get_generation_result_from_python_backend(generations, inputs_size):
     return prediction_results
 
 
-def _get_accept_and_content_type(batch_item) -> tuple[str, str]:
+def _get_accept_and_content_type(batch_item) -> Tuple[str, str]:
     content_type = batch_item.get_property("Content-Type")
     accept = batch_item.get_property("Accept")
     if not accept:
@@ -100,7 +101,7 @@ class TRTLLMPythonService:
 
     def parse_input(
         self, inputs: Input, tokenizer, output_formatter
-    ) -> tuple[list[str], list[int], list[dict], dict, list]:
+    ) -> Tuple[List[str], List[int], List[dict], dict, list]:
         """
         Preprocessing function that extracts information from Input objects.
 
@@ -108,9 +109,9 @@ class TRTLLMPythonService:
         :param inputs :(Input) a batch of inputs, each corresponding to a new request
         :param tokenizer: the tokenizer used for inference
 
-        :return input_data (list[str]): a list of strings, each string being the prompt in a new request
-        :return input_size (list[int]): a list of ints being the size of each new request
-        :return parameters (list[dict]): parameters pertaining to each request
+        :return input_data (List[str]): a list of strings, each string being the prompt in a new request
+        :return input_size (List[int]): a list of ints being the size of each new request
+        :return parameters (List[dict]): parameters pertaining to each request
         :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
         :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
         """

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -26,6 +26,7 @@ from djl_python.properties_manager.properties import StreamingEnum, is_rolling_b
 from djl_python.neuron_utils.model_loader import TNXModelLoader, OptimumModelLoader
 from djl_python.neuron_utils.utils import task_from_config, build_vllm_rb_properties
 from djl_python.utils import InputFormatConfigs, parse_input_with_formatter
+from typing import Tuple, List
 
 model = None
 
@@ -203,7 +204,7 @@ class TransformersNeuronXService(object):
 
     def parse_input(
         self, inputs: Input, tokenizer, output_formatter
-    ) -> tuple[list[str], list[int], list[dict], dict, list]:
+    ) -> Tuple[List[str], List[int], List[dict], dict, list]:
         """
         Preprocessing function that extracts information from Input objects.
 
@@ -211,9 +212,9 @@ class TransformersNeuronXService(object):
         :param inputs :(Input) a batch of inputs, each corresponding to a new request
         :param tokenizer: the tokenizer used for inference
 
-        :return input_data (list[str]): a list of strings, each string being the prompt in a new request
-        :return input_size (list[int]): a list of ints being the size of each new request
-        :return parameters (list[dict]): parameters pertaining to each request
+        :return input_data (List[str]): a list of strings, each string being the prompt in a new request
+        :return input_size (List[int]): a list of ints being the size of each new request
+        :return parameters (List[dict]): parameters pertaining to each request
         :return errors (dict): a dictionary mapping int indices to corresponding error strings if any
         :return batch (list): a list of Input objects contained in inputs (each one corresponds to a request)
         """

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -21,9 +21,9 @@ from dataclasses import dataclass, field
 
 @dataclass
 class ParsedInput:
-    input_data: list[str]
-    input_size: list[int]
-    parameters: list[dict]
+    input_data: List[str]
+    input_size: List[int]
+    parameters: List[dict]
     errors: dict
     batch: list
     is_client_side_batch: list = field(default_factory=lambda: [])


### PR DESCRIPTION
## Description ##

Updating typing nomenclature to support py38, python types are not sub-scriptable in py38 and we should instead use the typing class associated with the type. This will avoid build problems for users using ubuntu 20.04 and below.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
