### PR TITLE
bump up trtllm to 0.10.0

### DIFF
--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -9,22 +9,22 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-ARG version=12.2.2-cudnn8-devel-ubuntu22.04
+ARG version=12.4.1-devel-ubuntu22.04
 FROM nvidia/cuda:$version
-ARG cuda_version=cu122
+ARG cuda_version=cu124
 ARG python_version=3.10
-ARG TORCH_VERSION=2.2.1
+ARG TORCH_VERSION=2.2.2
 ARG djl_version=0.28.0~SNAPSHOT
 ARG transformers_version=4.40.0
 ARG accelerate_version=0.29.3
-ARG tensorrtlibs_version=9.3.0.post12.dev1
+ARG tensorrtlibs_version=10.0.1
 ARG trtllm_toolkit_version=nightly
-ARG trtllm_version=v0.9.0
-ARG cuda_python_version=12.2.0
+ARG trtllm_version=v0.10.0_dryrun
+ARG cuda_python_version=12.4
 ARG peft_version=0.10.0
 ARG triton_version=r24.04
 ARG trtllm_toolkit_wheel="https://publish.djl.ai/tensorrt-llm/toolkit/tensorrt_llm_toolkit-${trtllm_toolkit_version}-py3-none-any.whl"
-ARG trtllm_wheel="https://djl-ai.s3.amazonaws.com/publish/tensorrt-llm/${trtllm_version}/tensorrt_llm-0.9.0-cp310-cp310-linux_x86_64.whl"
+ARG trtllm_wheel="https://djl-ai.s3.amazonaws.com/publish/tensorrt-llm/${trtllm_version}/tensorrt_llm-0.10.0-cp310-cp310-linux_x86_64.whl"
 ARG triton_toolkit_wheel="https://publish.djl.ai/tritonserver/${triton_version}/tritontoolkit-24.4-py310-none-any.whl"
 ARG pydantic_version=2.6.1
 ARG ammo_version=0.7.0
@@ -60,8 +60,12 @@ RUN mkdir -p /opt/djl/conf && \
 COPY config.properties /opt/djl/conf/config.properties
 COPY partition /opt/djl/partition
 
+
 COPY distribution[s]/ ./
 RUN mv *.deb djl-serving_all.deb || true
+
+# Install CUDNN 8
+RUN apt-get update && apt-get install -y --no-install-recommends libcudnn8 libcudnn8-dev && rm -rf /var/lib/apt/lists/*
 
 # Install OpenMPI and other deps
 ARG DEBIAN_FRONTEND=noninteractive
@@ -107,7 +111,7 @@ RUN scripts/install_djl_serving.sh $djl_version && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Add CUDA-Compat
-RUN apt-get update && apt-get install -y cuda-compat-12-2 && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cuda-compat-12-4 && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 LABEL maintainer="djl-dev@amazon.com"
 LABEL dlc_major_version="1"
@@ -119,4 +123,4 @@ LABEL djl-version=$djl_version
 LABEL trtllm-version=$trtllm_version
 LABEL cuda-version=$cuda_version
 # To use the 535 CUDA driver
-LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.2
+LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.4

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -30,6 +30,7 @@ ARG pydantic_version=2.6.1
 ARG modelopt_version=0.11.2
 ARG janus_version=1.0.0
 ARG pynvml_verison=11.5.0
+ARG numpy_version=1.26.4
 
 EXPOSE 8080
 
@@ -107,6 +108,7 @@ RUN scripts/install_djl_serving.sh $djl_version && \
     useradd -m -d /home/djl djl && \
     chown -R djl:djl /opt/djl && \
     rm -rf scripts && \
+    pip3 install numpy==${numpy_version} && \
     pip3 cache purge && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -19,7 +19,7 @@ ARG transformers_version=4.40.0
 ARG accelerate_version=0.29.3
 ARG tensorrtlibs_version=10.0.1
 ARG trtllm_toolkit_version=nightly
-ARG trtllm_version=v0.10.0_dryrun
+ARG trtllm_version=v0.10.0
 ARG cuda_python_version=12.4
 ARG peft_version=0.10.0
 ARG triton_version=r24.04
@@ -27,7 +27,7 @@ ARG trtllm_toolkit_wheel="https://publish.djl.ai/tensorrt-llm/toolkit/tensorrt_l
 ARG trtllm_wheel="https://djl-ai.s3.amazonaws.com/publish/tensorrt-llm/${trtllm_version}/tensorrt_llm-0.10.0-cp310-cp310-linux_x86_64.whl"
 ARG triton_toolkit_wheel="https://publish.djl.ai/tritonserver/${triton_version}/tritontoolkit-24.4-py310-none-any.whl"
 ARG pydantic_version=2.6.1
-ARG ammo_version=0.7.0
+ARG modelopt_version=0.11.2
 ARG janus_version=1.0.0
 ARG pynvml_verison=11.5.0
 
@@ -65,7 +65,7 @@ COPY distribution[s]/ ./
 RUN mv *.deb djl-serving_all.deb || true
 
 # Install CUDNN 8
-RUN apt-get update && apt-get install -y --no-install-recommends libcudnn8 libcudnn8-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libcudnn8 && rm -rf /var/lib/apt/lists/*
 
 # Install OpenMPI and other deps
 ARG DEBIAN_FRONTEND=noninteractive
@@ -82,7 +82,7 @@ RUN pip install torch==${TORCH_VERSION} transformers==${transformers_version} ac
     pip3 cache purge
 
 # Install TensorRT and TRT-LLM Deps
-RUN pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com tensorrt==${tensorrtlibs_version} nvidia-ammo~=${ammo_version} janus==${janus_version} && \
+RUN pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com tensorrt==${tensorrtlibs_version} janus==${janus_version} nvidia-modelopt==${modelopt_version} && \
     pip install --no-deps ${trtllm_wheel} && \
     pyver=$(echo $python_version | awk -F. '{print $1$2}') && \
     pip3 cache purge
@@ -123,4 +123,4 @@ LABEL djl-version=$djl_version
 LABEL trtllm-version=$trtllm_version
 LABEL cuda-version=$cuda_version
 # To use the 535 CUDA driver
-LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.4
+LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.2

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -770,7 +770,7 @@ trtllm_handler_list = {
         "option.output_formatter": "jsonlines",
     },
     "falcon-7b": {
-        "option.model_id": "s3://djl-llm/triton/0.9.0/falcon-7b-tp1-bs16/",
+        "option.model_id": "s3://djl-llm/triton/0.10.0/falcon-7b-tp1-bs16/",
         "option.tensor_parallel_degree": 1,
         "option.max_input_len": 1024,
         "option.max_output_len": 512,


### PR DESCRIPTION
## Description ##

Checklist

- [x] Dry run test and see if 0.10.0 works as expected
- [x] Update the CI model to the 0.10.0 version
- [x] Merge the change on trtllm toolkit

Notes: 
- I have found that transformers 4.40 is compatible with the container.
- Running another build on this container after the changes to see if there are any errors (done)


 
