### PR TITLE
fix bug with duplicate models when HF_MODEL_ID points to model store

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -505,7 +505,7 @@ public class ModelServer {
         Path path = Paths.get(modelId);
         if (Files.exists(path)) {
             // modelId point to a local file
-            return modelId;
+            return mapModelUrl(path);
         }
 
         // TODO: Download the full model from HF


### PR DESCRIPTION
## Description ##

If customer has mounted model artifacts to /opt/ml/model, and also specified HF_MODEL_ID=/opt/ml/model, then the container fails to startup with
```
ERROR ModelServer Invalid configuration
ai.djl.serving.http.BadRequestException: Workflow model is already registered.
	at ai.djl.serving.models.ModelManager.registerWorkflow(ModelManager.java:92) ~[serving-0.28.0.jar:?]
	at ai.djl.serving.ModelServer.initModelStore(ModelServer.java:444) ~[serving-0.28.0.jar:?]
	at ai.djl.serving.ModelServer.start(ModelServer.java:208) ~[serving-0.28.0.jar:?]
	at ai.djl.serving.ModelServer.startAndWait(ModelServer.java:174) ~[serving-0.28.0.jar:?]
	at ai.djl.serving.ModelServer.main(ModelServer.java:143) [serving-0.28.0.jar:?]
```

Issue is that when adding to the list or urls, we returned the local path which is different than the url so it looks like 2 different models, but at workflow register level they are the same