### PR TITLE
[cherry-pick] fix bug with duplicate models when HF_MODEL_ID points to model store …

### DIFF
--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -505,7 +505,7 @@ public class ModelServer {
         Path path = Paths.get(modelId);
         if (Files.exists(path)) {
             // modelId point to a local file
-            return modelId;
+            return mapModelUrl(path);
         }
 
         // TODO: Download the full model from HF


### PR DESCRIPTION
…(#2054)

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
