### PR TITLE
[ci][fix] don't use env vars for llm integ test as it causes issues w…

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -551,8 +551,9 @@ jobs:
         working-directory: tests/integration
         run: |
           rm -rf models
-          echo -en "OPTION_MAX_ROLLING_BATCH_SIZE=2\nOPTION_OUTPUT_FORMATTER=jsonlines\nTENSOR_PARALLEL_DEGREE=1\nHF_MODEL_ID=gpt2\nOPTION_TASK=text-generation\nOPTION_ROLLING_BATCH=lmi-dist" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG nocode lmi
+          python3 llm/prepare.py lmi_dist gpt2
+          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models lmi \
+            serve -m test=file:/opt/ml/model/test/
           python3 llm/client.py lmi_dist gpt2
           docker rm -f $(docker ps -aq)
       - name: Test mpt-7b


### PR DESCRIPTION
…ith later tests

## Description ##
 
Moving the gpt2 test to serving.properties - using environment variables persists to following tests and causes multiple models to be loaded.

We already have a gpt2 config that matches the env vars, so just using that.

See this test run https://github.com/deepjavalibrary/djl-serving/actions/runs/9518222203/job/26238764686. The mpt test is loading gpt2 model first, causing oom when mpt test runs
