### PR TITLE
pin numpy to <2 in ci/docker

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: install Python Dependencies
-        run: pip3 install numpy yapf
+        run: pip3 install "numpy<2" yapf
       # Enable gradle cache: https://github.com/actions/cache/blob/master/examples.md#java---gradle
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy pillow wheel
+        run: pip3 install requests "numpy<2" pillow wheel
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh pytorch-inf2 ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -109,7 +109,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy pillow
+        run: pip3 install requests "numpy<2" pillow
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh pytorch-inf2 ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -267,7 +267,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy pillow
+        run: pip3 install requests "numpy<2" pillow
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh pytorch-inf2 ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -365,7 +365,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy pillow
+        run: pip3 install requests "numpy<2" pillow
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh pytorch-inf2 ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers

--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh ${{ matrix.arch }} ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -176,7 +176,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh tensorrt-llm ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -290,7 +290,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh tensorrt-llm ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -504,7 +504,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download docker
@@ -595,7 +595,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy
+        run: pip3 install requests "numpy<2"
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download docker
@@ -713,7 +713,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download docker
@@ -823,7 +823,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download docker
@@ -914,7 +914,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download docker

--- a/.github/workflows/llm_integration_p4d.yml
+++ b/.github/workflows/llm_integration_p4d.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy
+        run: pip3 install requests "numpy<2"
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy
+        run: pip3 install requests "numpy<2"
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh tensorrt-llm ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -185,7 +185,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy
+        run: pip3 install requests "numpy<2"
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers

--- a/.github/workflows/lmi-dist-deps-build.yml
+++ b/.github/workflows/lmi-dist-deps-build.yml
@@ -45,7 +45,7 @@ jobs:
           python -m venv venv
           . ./venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install numpy cmake awscli packaging wheel setuptools ninja git-remote-codecommit \
+          python -m pip install "numpy<2" cmake awscli packaging wheel setuptools ninja git-remote-codecommit \
                                 torch==2.3.0 --extra-index-url https://download.pytorch.org/whl/cu121
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy
+        run: pip3 install requests "numpy<2"
       - name: Install s5cmd
         working-directory: serving/docker
         run: sudo scripts/install_s5cmd.sh x64
@@ -188,7 +188,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy huggingface_hub
+        run: pip3 install requests "numpy<2" huggingface_hub
       - name: Install s5cmd
         working-directory: serving/docker
         run: sudo scripts/install_s5cmd.sh x64

--- a/.github/workflows/lmic_performance.yml
+++ b/.github/workflows/lmic_performance.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy datetime
+        run: pip3 install requests "numpy<2" datetime
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -89,7 +89,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy datetime
+        run: pip3 install requests "numpy<2" datetime
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -125,7 +125,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy datetime
+        run: pip3 install requests "numpy<2" datetime
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -161,7 +161,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy datetime
+        run: pip3 install requests "numpy<2" datetime
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers
@@ -197,7 +197,7 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install requests numpy datetime
+        run: pip3 install requests "numpy<2" datetime
       - name: Build container name
         run: ./serving/docker/scripts/docker_name_builder.sh lmi ${{ github.event.inputs.djl-version }}
       - name: Download models and dockers

--- a/engines/python/setup/setup.py
+++ b/engines/python/setup/setup.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     requirements = ['psutil', 'packaging', 'wheel']
 
     test_requirements = [
-        'numpy', 'requests', 'Pillow', 'transformers', 'torch', 'einops',
+        'numpy<2', 'requests', 'Pillow', 'transformers', 'torch', 'einops',
         'accelerate', 'sentencepiece', 'protobuf', "peft", 'yapf',
         'pydantic>=2.0', "objgraph"
     ]

--- a/engines/python/src/test/resources/accumulate/requirements.txt
+++ b/engines/python/src/test/resources/accumulate/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy<2

--- a/serving/docker/pytorch-gpu.Dockerfile
+++ b/serving/docker/pytorch-gpu.Dockerfile
@@ -19,6 +19,7 @@ ARG torch_version=2.2.2
 ARG torch_vision_version=0.17.2
 ARG onnx_version=1.17.1
 ARG python_version=3.10
+ARG numpy_version=1.26.4
 
 RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/ml/model
@@ -56,7 +57,7 @@ RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh && \
     curl -o $(ls -d /usr/local/djl-serving-*/)lib/onnxruntime_gpu-$onnx_version.jar https://publish.djl.ai/onnxruntime/$onnx_version/onnxruntime_gpu-$onnx_version.jar && \
     scripts/install_python.sh ${python_version} && \
     scripts/install_s5cmd.sh x64 && \
-    pip3 install numpy && pip3 install torch==${torch_version} torchvision==${torch_vision_version} --extra-index-url https://download.pytorch.org/whl/cu121 && \
+    pip3 install numpy==${numpy_version} && pip3 install torch==${torch_version} torchvision==${torch_vision_version} --extra-index-url https://download.pytorch.org/whl/cu121 && \
     scripts/patch_oss_dlc.sh python && \
     scripts/security_patch.sh pytorch-gpu && \
     useradd -m -d /home/djl djl && \

--- a/serving/docker/scripts/install_python.sh
+++ b/serving/docker/scripts/install_python.sh
@@ -20,5 +20,5 @@ else
   rm -rf get-pip.py
 fi
 python3 -m pip --no-cache-dir install -U pip
-python3 -m pip --no-cache-dir install -U numpy awscli
+python3 -m pip --no-cache-dir install -U "numpy<2" awscli
 ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Description ##

pinning the numpy version across ci/docker to <2. nump 2.x is released, and causing issues across ci/docker.

I will wait to merge this until reviewing with team on monday