### PR TITLE
[fix] initialize sequence dictionary for default sequence index to pr…

### DIFF
--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -178,6 +178,9 @@ class TextGenerationOutput(RequestOutput):
     prompt_tokens_details: List[Token] = field(default_factory=lambda: [])
     other_sequences_indices: List[int] = field(default_factory=lambda: [])
 
+    def __post_init__(self):
+        self.sequences[self.best_sequence_index] = Sequence()
+
     def set_next_token(self,
                        token: Token,
                        sequence_index=0,

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_vllm_rolling_batch.py
@@ -34,7 +34,7 @@ expected_text_30 = {
         3:
         'The capital of France is Paris.\n\n2. The capital of the United States is Washington, D.C.\n\n3. The capital of Canada is Ott',
         4:
-        "The future of AI is bright, and it's not just in the realm of science fiction. Artificial intelligence is already being used in a wide range of industries",
+        "The future of AI is bright, and it's already here. With the help of AI, we can create more personalized experiences, automate repetitive tasks, and even predict the future."
     }
 }
 


### PR DESCRIPTION
… in an output

## Description ##

A previous change caused issues with a corner case. The issue was introduced by https://github.com/deepjavalibrary/djl-serving/commit/06eaa98518bb951ae1d7cad1e8dc6787082d382d#diff-4de063c68933067104c13e58e380b04bb922ca889f070e40bfa743ab33556426.

When we call `LLMEngine.step()` (through vllm or lmi-dist), it's not guaranteed that we receive and output for every active request. If on the first call to step for a request we do not generate a token, we never initialize the sequence dict that is part of TextGenerationOutput. Later in the flow we make a call to `request.get_next_token` https://github.com/deepjavalibrary/djl-serving/blob/1e883d5bae81a20189847cc4b2aff93ac38b8a38/engines/python/setup/djl_python/request.py#L140. For requests that did not generate a new token via step, we never call `set_new_token`, which is where the sequences property of TextGenerationOutput gets initialized.

The simples fix is to ensure that the sequences property of TextGenerationOutput always gets created for the default index so that we never try to access an array index that doesn't exist.

Fixes:
- inf2 unit tests

**Note that for some reason the generated text for one of the inputs has changed. the outputs seem fine, but i cannot figure out why this changed**