### PR TITLE
[ib] fix docker env file write location

### DIFF
--- a/tests/integration/instant_benchmark.py
+++ b/tests/integration/instant_benchmark.py
@@ -218,7 +218,7 @@ def write_model_artifacts(properties, requirements=None, env=None):
         with open(os.path.join(model_path, "requirements.txt"), "w") as f:
             f.write('\n'.join(requirements) + '\n')
     if env and len(env) > 0:
-        with open(os.path.join(model_path, "docker_env"), "w") as f:
+        with open(os.path.join(os.getcwd(), "docker_env"), "w") as f:
             f.write('\n'.join(env) + '\n')
 
 


### PR DESCRIPTION
## Description ##

Fix issue where env variables passed using IB are not being added to the container when running IB.

Current implementation will add the `docker_env` file to `./model/test` relative to the current working directory, however, the `docker_env` needs to be in the same directory as the `./launch_container.sh` when it is run in order to add the env variables to the container. Since the paths were already relative in the script I updated the file right to current working directory `./` rather than `./model/test`
