### PR TITLE
[Neo] Fix Neo Quantization properties output. Add some additional configuration.

### DIFF
--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -38,13 +38,14 @@ class NeoQuantizationService():
         self.INPUT_MODEL_DIRECTORY: Final[str] = env[1]
         self.OUTPUT_MODEL_DIRECTORY: Final[str] = env[2]
         self.COMPILATION_ERROR_FILE: Final[str] = env[3]
-        self.COMPILER_CACHE_LOCATION: Final[str] = env[4]
+        self.HF_CACHE_LOCATION: Final[str] = env[5]
+        self.TARGET_INSTANCE_TYPE: Final[str] = env[6]
 
     def update_dataset_cache_location(self):
         logging.info(
-            f"Updating HuggingFace Datasets cache directory to: {self.COMPILER_CACHE_LOCATION}"
+            f"Updating HuggingFace Datasets cache directory to: {self.HF_CACHE_LOCATION}"
         )
-        os.environ['HF_DATASETS_CACHE'] = self.COMPILER_CACHE_LOCATION
+        os.environ['HF_DATASETS_CACHE'] = self.HF_CACHE_LOCATION
         #os.environ['HF_DATASETS_OFFLINE'] = "1"
 
     def initialize_partition_args_namespace(self):

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -62,7 +62,8 @@ def main():
     compilation_error_file = None
     try:
         (compiler_options, input_model_directory, compiled_model_directory,
-         compilation_error_file, neo_cache_dir) = get_neo_env_vars()
+         compilation_error_file, neo_cache_dir, neo_hf_cache_dir,
+         neo_deployment_instance_type) = get_neo_env_vars()
 
         # Neo requires that serving.properties is in same dir as model files
         serving_properties = load_properties(input_model_directory)

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -62,8 +62,8 @@ def main():
     compilation_error_file = None
     try:
         (compiler_options, input_model_directory, compiled_model_directory,
-         compilation_error_file, neo_cache_dir, neo_hf_cache_dir,
-         neo_deployment_instance_type) = get_neo_env_vars()
+         compilation_error_file, neo_cache_dir,
+         neo_hf_cache_dir) = get_neo_env_vars()
 
         # Neo requires that serving.properties is in same dir as model files
         serving_properties = load_properties(input_model_directory)

--- a/serving/docker/partition/sm_neo_utils.py
+++ b/serving/docker/partition/sm_neo_utils.py
@@ -30,16 +30,21 @@ def write_error_to_file(error_message, error_file):
 def get_neo_env_vars():
     """
     Get environment variables required by the SageMaker Neo interface
+
+    TODO: Update the return type to a dictionary to allow for easier changes
     """
     try:
         compiler_options = os.environ.get("COMPILER_OPTIONS")
         input_model_directory = os.environ["SM_NEO_INPUT_MODEL_DIR"]
         compiled_model_directory = os.environ["SM_NEO_COMPILED_MODEL_DIR"]
         compilation_error_file = os.environ["SM_NEO_COMPILATION_ERROR_FILE"]
-        neo_cache_dir = os.environ["SM_NEO_CACHE_DIR"]
+        neo_cache_dir = os.environ.get("SM_NEO_CACHE_DIR")
+        neo_hf_cache_dir = os.environ.get("SM_NEO_HF_CACHE_DIR")
+        neo_deployment_instance_type = os.environ.get(
+            "SM_NEO_DEPLOYMENT_INSTANCE_TYPE")
         return (compiler_options, input_model_directory,
                 compiled_model_directory, compilation_error_file,
-                neo_cache_dir)
+                neo_cache_dir, neo_hf_cache_dir, neo_deployment_instance_type)
     except KeyError as exc:
         raise InputConfiguration(
             f"SageMaker Neo environment variable '{exc.args[0]}' expected but not found"

--- a/serving/docker/partition/sm_neo_utils.py
+++ b/serving/docker/partition/sm_neo_utils.py
@@ -40,11 +40,9 @@ def get_neo_env_vars():
         compilation_error_file = os.environ["SM_NEO_COMPILATION_ERROR_FILE"]
         neo_cache_dir = os.environ.get("SM_NEO_CACHE_DIR")
         neo_hf_cache_dir = os.environ.get("SM_NEO_HF_CACHE_DIR")
-        neo_deployment_instance_type = os.environ.get(
-            "SM_NEO_DEPLOYMENT_INSTANCE_TYPE")
         return (compiler_options, input_model_directory,
                 compiled_model_directory, compilation_error_file,
-                neo_cache_dir, neo_hf_cache_dir, neo_deployment_instance_type)
+                neo_cache_dir, neo_hf_cache_dir)
     except KeyError as exc:
         raise InputConfiguration(
             f"SageMaker Neo environment variable '{exc.args[0]}' expected but not found"


### PR DESCRIPTION
## Description ##
## Neo serving.properties output
Currently, the Neo Quantization script will always quantize at `tensor_parallel_degree=8` and output `tensor_parallel_degree=8` in serving.properties. This is often not compatible with serving, so we will avoid outputting this value. 

Specifically, with AWQ quantized small models like Llama-2-7b, they can not be served with tp=8. This is because the intermediate_size / tp_degree must be divisible by the quantization group size (128). In this case, intermediate_size after quantization is 5632, so valid tp_degrees are 1,2, and 4.

**New behavior**: Neo still quantizes with `tensor_parallel_degree=8` but the output will depend on customer input to Neo.
- If a customer passes `tensor_parallel_degree` in serving.properties or through the environment variable (but not both):
    - The inputted `tensor_parallel_degree` will be passed through to the output.
- If a customer passes `tensor_parallel_degree` in serving.properties AND the environment variable:
    - The ENVVAR `tensor_parallel_degree` will be passed through to the output.
- If a customer does not pass either:
    - `tensor_parallel_degree` will not be included in the outputted serving.properties. Customer can update serving.properties manually, or pass an environment variable during serving.

## Neo environment variables updates
We will accept `SM_NEO_HF_CACHE_DIR` as the quantization dataset cache directory for forward-compatibility. This is in case future containers have both a compilation cache dir and HF/datasets cache dir.
  