### PR TITLE
codeql for python

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        language: [ 'java', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed


### PR DESCRIPTION
## Description ##

Adding codeql for python as well.

Sample wf https://github.com/deepjavalibrary/djl-serving/actions/runs/9569675600.

I can see that it did scan the python, but I don't know where to find the results (there are logs in the wf run).