### PR TITLE
[ci] fix nightly wheel pip installs

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -35,7 +35,8 @@ ARG autoawq_version=0.2.5
 # LMI-Dist Deps
 ARG vllm_wheel="https://publish.djl.ai/vllm/cu124-pt230/vllm-0.4.2%2Bcu124-cp310-cp310-linux_x86_64.whl"
 ARG flash_attn_2_wheel="https://publish.djl.ai/flash_attn/cu124-pt230/flash_attn-2.5.8-cp310-cp310-linux_x86_64.whl"
-ARG lmi_dist_wheel="https://publish.djl.ai/lmi_dist/lmi_dist-nightly-py3-none-any.whl"
+# %2B is the url escape for the '+' character
+ARG lmi_dist_wheel="https://publish.djl.ai/lmi_dist/lmi_dist-11.0.0%2Bnightly-py3-none-any.whl"
 ARG seq_scheduler_wheel="https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl"
 ARG peft_version=0.11.1
 

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -25,7 +25,8 @@ ARG accelerate_version=0.23.0
 ARG diffusers_version=0.26.1
 ARG pydantic_version=2.6.1
 ARG optimum_neuron_version=0.0.22
-ARG vllm_wheel="https://publish.djl.ai/neuron_vllm/vllm-nightly-py3-none-any.whl"
+# %2B is the url escape for the '+' character
+ARG vllm_wheel="https://publish.djl.ai/neuron_vllm/vllm-0.4.2%2Bnightly-py3-none-any.whl"
 EXPOSE 8080
 
 # Sets up Path for Neuron tools


### PR DESCRIPTION
## Description ##

This PR moves our nightly wheels to a new format that is consistent with the newest version of pip. The proposed versioning of our nightly wheels would be as follows:
`package-0.0.0+nightly-py3-none-any.whl`

I am leaving this in draft until we confirm the naming as acceptable.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
