### PR TITLE
[fix] Set tokenizer on output_formatter for TRT-LLM Handlers

### DIFF
--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -42,7 +42,8 @@ class TRTLLMService(object):
         self.input_format_configs = InputFormatConfigs(
             is_rolling_batch=True,
             is_adapters_supported=False,
-            output_formatter=self.trt_configs.output_formatter)
+            output_formatter=self.trt_configs.output_formatter,
+            tokenizer=self.rolling_batch.get_tokenizer())
         self.initialized = True
         return
 

--- a/engines/python/setup/djl_python/tensorrt_llm_python.py
+++ b/engines/python/setup/djl_python/tensorrt_llm_python.py
@@ -95,7 +95,8 @@ class TRTLLMPythonService:
         self.input_formatter = InputFormatConfigs(
             is_rolling_batch=False,
             is_adapters_supported=False,
-            output_formatter=self.trt_configs.output_formatter)
+            output_formatter=self.trt_configs.output_formatter,
+            tokenizer=self.model.tokenizer)
         self.initialized = True
         return
 


### PR DESCRIPTION
## Description ##

Fixes #2070

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
