### PR TITLE
[serving] introduce interface to customize http response status retur…

### DIFF
--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -84,6 +84,7 @@ public final class ConfigManager {
     private static final String ERROR_RATE_SERVER = "error_rate_server";
     private static final String ERROR_RATE_MODEL = "error_rate_model";
     private static final String ERROR_RATE_ANY = "error_rate_any";
+    private static final String HTTP_RESPONSE_MAPPER = "http_response_mapper";
 
     // Configuration which are not documented or enabled through environment variables
     private static final String USE_NATIVE_IO = "use_native_io";
@@ -554,6 +555,15 @@ public final class ConfigManager {
      */
     public int getMaxRequestSize() {
         return getIntProperty(MAX_REQUEST_SIZE, DEF_MAX_REQUEST_SIZE);
+    }
+
+    /**
+     * Returns the name of the HttpResponseMapper to use.
+     *
+     * @return the name of the http response provider.
+     */
+    public String getHttpResponseMapper() {
+        return getProperty(HTTP_RESPONSE_MAPPER, "default");
     }
 
     private int getIntProperty(String key, int def) {

--- a/serving/src/main/java/ai/djl/serving/util/DefaultHttpResponseStatusMapper.java
+++ b/serving/src/main/java/ai/djl/serving/util/DefaultHttpResponseStatusMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.util;
+
+import ai.djl.serving.http.BadRequestException;
+import ai.djl.serving.wlm.util.WlmException;
+import ai.djl.translate.TranslateException;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Default converter translating exception to HttpResponseStatus. */
+public class DefaultHttpResponseStatusMapper implements HttpResponseStatusMapper {
+
+    /** {@inheritDoc} */
+    @Override
+    public HttpResponseStatus getHttpStatusForException(Throwable t) {
+        HttpResponseStatus status;
+        if (t instanceof TranslateException || t instanceof BadRequestException) {
+            status = HttpResponseStatus.BAD_REQUEST;
+        } else if (t instanceof WlmException) {
+            status = HttpResponseStatus.SERVICE_UNAVAILABLE;
+        } else {
+            status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        }
+        return status;
+    }
+}

--- a/serving/src/main/java/ai/djl/serving/util/HttpResponseStatusMapper.java
+++ b/serving/src/main/java/ai/djl/serving/util/HttpResponseStatusMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.util;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/** An interface that allows customizing the HttpResponseStatus to return to the client. */
+public interface HttpResponseStatusMapper {
+
+    /**
+     * Returns the HttpResponseStatus to be returned to the client based on the exception
+     *
+     * <p>This method is called by the InferenceRequestHandler on exceptions received during
+     * inference.
+     *
+     * @param throwable the exception received from executing inference.
+     * @return the HttpResponseStatus that should be returned for the given exception.
+     */
+    HttpResponseStatus getHttpStatusForException(Throwable throwable);
+}

--- a/serving/src/main/java/ai/djl/serving/util/HttpResponseStatusMapperProvider.java
+++ b/serving/src/main/java/ai/djl/serving/util/HttpResponseStatusMapperProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Utility class that provides the HttpResponseStatusMapper to use in the InferenceRequestHandler.
+ */
+public final class HttpResponseStatusMapperProvider {
+
+    private static final Map<String, Supplier<HttpResponseStatusMapper>> MAPPERS =
+            new ConcurrentHashMap<>();
+
+    private HttpResponseStatusMapperProvider() {}
+
+    /**
+     * Register a {@code HttpResponseStatusMapper} that can then be retrieved and used by the
+     * InferenceRequestHandler.
+     *
+     * @param name the name of the mapper.
+     * @param mapper the supplier used to construct an instance of the mapper.
+     */
+    public static void registerMapper(String name, Supplier<HttpResponseStatusMapper> mapper) {
+        MAPPERS.put(name, mapper);
+    }
+
+    /**
+     * Get the {@code HttpResponseStatusMapper} registered with the name.
+     *
+     * @param name the name the mapper was registered with.
+     * @return the mapper to use in the InferenceRequestHandler.
+     */
+    public static HttpResponseStatusMapper getMapper(String name) {
+        if (!MAPPERS.containsKey(name)) {
+            return new DefaultHttpResponseStatusMapper();
+        }
+        return MAPPERS.get(name).get();
+    }
+}


### PR DESCRIPTION
This PR introduces an interface, HttpResponseStatusMapper that exposes a single method that accepts a Throwable and returns an HttpResponseStatus.

This will allow users to customize the behavior of responses returned to the client for certain error conditions.

It also introduces an HttpResponseStatusProvider. This object allows plugins to register their implementations of HttpResponseStatusMapper with DJLServing and use them in the inference request handler
