### PR TITLE
[fix] align default neuron behavior between model server and handler

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -87,7 +87,10 @@ public final class LmiConfigRecommender {
             lmiProperties.setProperty("option.rolling_batch", "disable");
             return;
         }
-        String rollingBatch = lmiProperties.getProperty("option.rolling_batch", "auto");
+
+        String defaultRollingBatch = isTnxEnabled(features) ? "disable" : "auto";
+        String rollingBatch =
+                lmiProperties.getProperty("option.rolling_batch", defaultRollingBatch);
         String modelType = modelConfig.getModelType();
         if (!"auto".equals(rollingBatch)) {
             return;


### PR DESCRIPTION
## Description ##

Updating the behavior of LmiConfigRecommender to match the behavior of the default properties when using a serving.properties for NeuronX containers. The recommender currently defaults all models to rolling batch, but this is not the desired behavior for LMI NeuronX due to the limited number of supported models for rolling batch.

This undoes a change that was a altered the default as aa side effect of the recommenders implementation but is not consistent in defaulting between launching with environmental variables and serving.properties for LMI NeuronX.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
