### PR TITLE
[lmi][hf]remove usage of HF Conversational pipeline as it is deprecated

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -15,19 +15,19 @@ import os
 import re
 
 import torch
-from transformers import (
-    pipeline, Pipeline, Conversation, AutoModelForCausalLM,
-    AutoModelForSeq2SeqLM, AutoTokenizer, AutoConfig,
-    AutoModelForSequenceClassification, AutoModelForTokenClassification,
-    AutoModelForQuestionAnswering, StoppingCriteria, StoppingCriteriaList)
+from transformers import (pipeline, Pipeline, AutoModelForCausalLM,
+                          AutoModelForSeq2SeqLM, AutoTokenizer, AutoConfig,
+                          AutoModelForSequenceClassification,
+                          AutoModelForTokenClassification,
+                          AutoModelForQuestionAnswering, StoppingCriteria,
+                          StoppingCriteriaList)
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from peft import PeftConfig, PeftModel, PeftModelForCausalLM
-from typing import Tuple, List, Callable, Dict
+from typing import Tuple, List
 
 from djl_python.encode_decode import encode
 from djl_python.inputs import Input
 from djl_python.outputs import Output
-from djl_python.rolling_batch.rolling_batch import RollingBatch
 from djl_python.streaming_utils import StreamingUtils
 
 from djl_python.properties_manager.properties import StreamingEnum, is_rolling_batch_enabled, is_streaming_enabled
@@ -383,12 +383,6 @@ class HuggingFaceService(object):
                                    tokenizer=self.tokenizer,
                                    device=self.hf_configs.device)
 
-        # wrap specific pipeline to support better ux
-        if task == "conversational":
-            self.hf_pipeline_unwrapped = hf_pipeline
-            hf_pipeline = self.wrap_conversation_pipeline(
-                self.hf_pipeline_unwrapped)
-
         if task == "text-generation":
             if issubclass(type(hf_pipeline.tokenizer),
                           PreTrainedTokenizerBase):
@@ -438,26 +432,6 @@ class HuggingFaceService(object):
 
         if self.hf_configs.device:
             self.model.to(self.hf_configs.device)
-
-    @staticmethod
-    def wrap_conversation_pipeline(hf_pipeline):
-
-        def wrapped_pipeline(inputs, *args, **kwargs):
-            converted_input = Conversation(
-                inputs["text"],
-                past_user_inputs=inputs.get("past_user_inputs", []),
-                generated_responses=inputs.get("generated_responses", []),
-            )
-            prediction = hf_pipeline(converted_input, *args, **kwargs)
-            return {
-                "generated_text": prediction.generated_responses[-1],
-                "conversation": {
-                    "past_user_inputs": prediction.past_user_inputs,
-                    "generated_responses": prediction.generated_responses,
-                },
-            }
-
-        return wrapped_pipeline
 
     def wrap_text_generation_pipeline(self, hf_pipeline):
 


### PR DESCRIPTION
## Description ##

Conversation, and "conversation" task for hf pipelines have been removed in release 4.42.0 https://github.com/huggingface/transformers/releases/tag/v4.42.0. 

Removing usage from our handler.

This use-case is now handled by the text-generation pipeline from hf. I think some updates are needed there to make it work, but for now just removing the usage.