### PR TITLE
[ci] remove HF_MODEL_ID env for lmi_dist_1 test

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -243,8 +243,8 @@ class TestLmiDist1:
             envs = [
                 "OPTION_MAX_ROLLING_BATCH_SIZE=2",
                 "OPTION_OUTPUT_FORMATTER=jsonlines",
-                "TENSOR_PARALLEL_DEGREE=1", "HF_MODEL_ID=gpt2",
-                "OPTION_TASK=text-generation", "OPTION_ROLLING_BATCH=lmi-dist"
+                "TENSOR_PARALLEL_DEGREE=1", "OPTION_TASK=text-generation",
+                "OPTION_ROLLING_BATCH=lmi-dist"
             ]
             r.launch("\n".join(envs))
             client.run("lmi_dist gpt2".split())


### PR DESCRIPTION
## Description ##
- prepare.py has serving.properties, which has `option.model_id=gpt2` 
- and env has HF_MODEL_ID also has gpt2. So it is loading the model again, which leads to OOM. 

https://github.com/deepjavalibrary/djl-serving/actions/runs/9698967044/job/26767133000#step:7:476
