### PR TITLE
[CI] Add trust remote code option in TRTLLM CI

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -791,6 +791,7 @@ trtllm_handler_list = {
         "option.smoothquant_per_channel": "True",
         "option.rolling_batch": "trtllm",
         "option.output_formatter": "jsonlines",
+        "option.trust_remote_code": True
     },
     "internlm-7b": {
         "option.model_id": "internlm/internlm-7b",


### PR DESCRIPTION
Fixes the following CI error:

```
ValueError: The repository for ccdv/cnn_dailymail contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/ccdv/cnn_dailymail.
```