### PR TITLE
[3p][python]add metering and error details to 3p outputs

### DIFF
--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -23,7 +23,8 @@ class Token(object):
                  id: int,
                  text: str,
                  log_prob: float = None,
-                 special_token: bool = None):
+                 special_token: bool = None,
+                 error_msg: str = None):
         """
         Initialize a Token
 
@@ -31,17 +32,21 @@ class Token(object):
         :param text: the decoded text
         :param log_prob: log probability for the token
         :param special_token: if this token is special token
+        :param error_msg: the exception message if an error occurs during rolling batch inference
         """
         self.id = id
         self.text = text
         self.log_prob = log_prob
         self.special_token = special_token
         self.request_id = None
+        self.error_msg = error_msg
 
     def as_dict(self):
         output = {"id": self.id, "text": self.text, "log_prob": self.log_prob}
         if self.special_token:
             output["special_token"] = self.special_token
+        if self.error_msg:
+            output["error_msg"] = self.error_msg
         return output
 
     def as_tgi_dict(self):

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -44,10 +44,14 @@ def stop_on_any_exception(func):
     def try_catch_handling(self, *args, **kwargs):
         try:
             return func(self, *args, **kwargs)
-        except Exception:
+        except Exception as e:
             logging.exception("Rolling batch inference error")
             for request in self.active_requests:
-                token = Token(-1, "", -1, True)
+                token = Token(-1,
+                              "",
+                              log_prob=-1,
+                              special_token=True,
+                              error_msg=str(e))
                 request.set_next_token(token,
                                        last_token=True,
                                        finish_reason="error")

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -251,14 +251,27 @@ class TestRollingBatch(unittest.TestCase):
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
         req.set_next_token(Token(244, "llo", -0.123123))
-        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
+        req.set_next_token(Token(4558, " world", -0.567854))
+        req.set_next_token(Token(245, "", -1, True, "some error"), True,
+                           "error")
         final_str.append(req.get_next_token())
         output = json.loads(''.join(final_str))
         assert output == {
-            "generation": "This is a wonderful dayHello world",
-            "prompt_token_count": 0,
-            "generation_token_count": 3,
-            "stop_reason": "length"
+            "body": {
+                "generation": "This is a wonderful dayHello world",
+                "prompt_token_count": 0,
+                "generation_token_count": 4,
+                "stop_reason": "error"
+            },
+            "content_type": "application/json",
+            "metering": {
+                "inputTokenCount": 0,
+                "outputTokenCount": 4,
+            },
+            "error": {
+                "error_code": 400,
+                "error_msg": "some error",
+            }
         }
 
     def test_3p_stream_fmt(self):
@@ -272,30 +285,68 @@ class TestRollingBatch(unittest.TestCase):
         req.set_next_token(Token(244, "He", -0.334532))
         next_token = json.loads(req.get_next_token())
         assert next_token == {
-            "generation": "He",
-            "prompt_token_count": 0,
-            "generation_token_count": 1,
-            "stop_reason": None,
+            "body": {
+                "generation": "He",
+                "prompt_token_count": 0,
+                "generation_token_count": 1,
+                "stop_reason": None,
+            },
+            "metering": {
+                "inputTokenCount": 0,
+                "outputTokenCount": 1,
+            },
+            "content_type": "application/jsonlines",
         }
         req.reset_next_token()
         req.set_next_token(Token(244, "llo", -0.123123))
         next_token = json.loads(req.get_next_token())
         assert next_token == {
-            "generation": "llo",
-            "prompt_token_count": None,
-            "generation_token_count": 2,
-            "stop_reason": None,
+            "body": {
+                "generation": "llo",
+                "prompt_token_count": None,
+                "generation_token_count": 2,
+                "stop_reason": None,
+            },
+            "metering": {
+                "outputTokenCount": 2,
+            },
+            "content_type": "application/jsonlines",
         }
         req.reset_next_token()
-        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
+        req.set_next_token(Token(4558, " world", -0.567854))
         next_token = json.loads(req.get_next_token())
-        self.assertEquals(
-            next_token, {
+        assert next_token == {
+            "body": {
                 "generation": " world",
                 "prompt_token_count": None,
                 "generation_token_count": 3,
-                "stop_reason": "length",
-            })
+                "stop_reason": None,
+            },
+            "metering": {
+                "outputTokenCount": 3,
+            },
+            "content_type": "application/jsonlines",
+        }
+        req.reset_next_token()
+        req.set_next_token(Token(-1, "", -1, True, "some error"), True,
+                           "error")
+        next_token = json.loads(req.get_next_token())
+        assert next_token == {
+            "body": {
+                "generation": "",
+                "prompt_token_count": None,
+                "generation_token_count": 4,
+                "stop_reason": "error",
+            },
+            "metering": {
+                "outputTokenCount": 4,
+            },
+            "content_type": "application/jsonlines",
+            "error": {
+                "error_code": 400,
+                "error_msg": "some error",
+            }
+        }
 
     def test_return_full_text(self):
         req = Request(0,

--- a/engines/python/setup/djl_python/three_p/three_p_utils.py
+++ b/engines/python/setup/djl_python/three_p/three_p_utils.py
@@ -26,6 +26,8 @@ def parse_3p_request(input_map: dict, is_rolling_batch: bool, tokenizer,
     _param["temperature"] = input_map.pop("temperature", 0.5)
     _param["top_p"] = input_map.pop("top_p", 0.9)
     _param["max_new_tokens"] = input_map.pop("max_gen_len", 512)
+    if _param["temperature"] > 0:
+        _param["do_sample"] = True
     if invoke_type == "InvokeEndpointWithResponseStream":
         _param["stream"] = True
         _param["output_formatter"] = "3p_stream"


### PR DESCRIPTION
## Description ##

3p Changes:
1. Fix the output formatters to respond with the correct expected payload schema
2. Add metering and error details to the output schema for 3p use-case
3. force do_sample to be true when temperature > 0

General Change:
1. Add exception details to the Token that is set when rolling batch inference occurs. This makes it possible for output formatters to further provide specific error details in the response rather than just saying "error". This is currently only used by the 3p output formatters.
