### PR TITLE
[python] refactor input parser to support Request

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -12,65 +12,49 @@
 # the specific language governing permissions and limitations under the License.
 import logging
 from dataclasses import dataclass, field
-from typing import List, Union, Callable, Any
+from typing import List, Dict
 
 from djl_python import Input
 from djl_python.chat_completions.chat_utils import is_chat_completions_request, parse_chat_completions_request
 from djl_python.encode_decode import decode
+from djl_python.properties_manager.properties import is_rolling_batch_enabled
+from djl_python.request import Request
+from djl_python.request_io import TextInput
 from djl_python.three_p.three_p_utils import is_3p_request, parse_3p_request
 
 
 @dataclass
 class ParsedInput:
-    input_data: List[str]
-    input_size: List[int]
-    parameters: List[dict]
-    errors: dict
-    batch: list
-    is_client_side_batch: list = field(default_factory=lambda: [])
-    adapters: list = None
+    errors: dict = field(default_factory=lambda: {})
+    requests: List[Request] = field(default_factory=lambda: [])
+    batch: List = field(default_factory=lambda: [])
 
 
-@dataclass
-class InputFormatConfigs:
-    is_rolling_batch: bool = False
-    is_adapters_supported: bool = False
-    output_formatter: Union[str, Callable] = None
-    tokenizer: Any = None
-
-
-def parse_input_with_formatter(inputs: Input,
-                               input_format_configs: InputFormatConfigs,
-                               adapter_registry: dict = {}) -> ParsedInput:
+def parse_input_with_formatter(inputs: Input, **kwargs) -> ParsedInput:
     """
     Preprocessing function that extracts information from Input objects.
-    :param input_format_configs: format configurations for the input.
     :param inputs :(Input) a batch of inputs, each corresponding to a new request
 
     :return parsed_input: object of data class that contains all parsed input details
     """
 
-    input_data = []
-    input_size = []
-    parameters = []
-    adapters = []
     errors = {}
-    found_adapters = False
+    requests = []
     batch = inputs.get_batches()
-    # only for dynamic batch
-    is_client_side_batch = [False for _ in range(len(batch))]
-    for i, item in enumerate(batch):
+    request_id_counter = get_req_id_counter(kwargs)
+    for i, input_item in enumerate(batch):
         try:
-            content_type = item.get_property("Content-Type")
-            invoke_type = item.get_property("X-Amzn-SageMaker-Forwarded-Api")
-            input_map = decode(item, content_type)
-            _inputs, _param, is_client_side_batch[i] = _parse_inputs_params(
-                input_map, item, input_format_configs, invoke_type)
-            if input_format_configs.is_adapters_supported:
-                adapters_per_item, found_adapter_per_item = _parse_adapters(
-                    _inputs, input_map, item, adapter_registry)
+            request_id = request_id_counter.next_id(
+            ) if request_id_counter else i
+            # TODO: Decide whether it is a text input based on content-type
+            request_input = TextInput(
+                request_id=request_id,
+                tokenizer=kwargs.get("tokenizer"),
+                tgi_compat=kwargs.get("configs").tgi_compat)
+            format_input(request_input, input_item, **kwargs)
+            request = Request(request_input=request_input)
+            requests.append(request)
         except Exception as e:  # pylint: disable=broad-except
-            input_size.append(0)
             err_msg = "Input Parsing failed. Ensure that the request payload is valid. "
             # str(e) for KeyError only yields the name of the key, which isn't useful as a response to the client
             if isinstance(e, KeyError):
@@ -81,94 +65,118 @@ def parse_input_with_formatter(inputs: Input,
             logging.warning(err_msg, exc_info=True)
             continue
 
-        input_data.extend(_inputs)
-        input_size.append(len(_inputs))
-
-        if input_format_configs.is_adapters_supported:
-            adapters.extend(adapters_per_item)
-            found_adapters = found_adapter_per_item or found_adapters
-
-        for _ in range(input_size[i]):
-            parameters.append(_param)
-
-    if found_adapters and adapters is not None:
-        adapter_data = [
-            adapter_registry.get(adapter, None) for adapter in adapters
-        ]
-    else:
-        adapter_data = None
-
-    return ParsedInput(input_data=input_data,
-                       input_size=input_size,
-                       parameters=parameters,
-                       errors=errors,
-                       batch=batch,
-                       is_client_side_batch=is_client_side_batch,
-                       adapters=adapter_data)
+    return ParsedInput(errors=errors, requests=requests, batch=batch)
 
 
-def _parse_inputs_params(input_map, item, input_format_configs, invoke_type):
+def get_req_id_counter(kwargs):
+    req_id_counter = None
+    if is_rolling_batch_enabled(kwargs.get("configs").rolling_batch):
+        req_id_counter = kwargs.get("rolling_batch").req_id_counter
+    return req_id_counter
+
+
+def format_input(request_input: TextInput, input_item: Input,
+                 **kwargs) -> None:
+    content_type = input_item.get_property("Content-Type")
+    input_map = decode(input_item, content_type)
+    parse_text_inputs_params(request_input, input_item, input_map, **kwargs)
+    add_server_maintained_params(request_input, input_item, **kwargs)
+    parse_adapters(request_input, input_item, input_map, **kwargs)
+
+
+def parse_text_inputs_params(request_input: TextInput, input_item: Input,
+                             input_map: Dict, **kwargs):
+    invoke_type = input_item.get_property("X-Amzn-SageMaker-Forwarded-Api")
+    tokenizer = kwargs.get("tokenizer")
     if is_chat_completions_request(input_map):
         _inputs, _param = parse_chat_completions_request(
-            input_map, input_format_configs.is_rolling_batch,
-            input_format_configs.tokenizer)
+            input_map, kwargs.get("is_rolling_batch"), tokenizer)
     elif is_3p_request(invoke_type):
-        _inputs, _param = parse_3p_request(
-            input_map, input_format_configs.is_rolling_batch,
-            input_format_configs.tokenizer, invoke_type)
+        _inputs, _param = parse_3p_request(input_map,
+                                           kwargs.get("is_rolling_batch"),
+                                           tokenizer, invoke_type)
     else:
         _inputs = input_map.pop("inputs", input_map)
         _param = input_map.pop("parameters", {})
 
-    # Add some additional parameters that are necessary.
-    # Per request streaming is only supported by rolling batch
-    if input_format_configs.is_rolling_batch:
-        _param["stream"] = input_map.pop("stream", _param.get("stream", False))
+    request_input.input_text = _inputs
+    request_input.parameters = _param
+    # assign input_ids
+    if kwargs.get("tokenizer"):
+        request_input.input_ids = tokenizer.encode(request_input.input_text)
 
+    # re-organize the parameters
+    if is_rolling_batch_enabled(kwargs.get("configs").rolling_batch):
+        if "stream" in input_map:
+            request_input.parameters["stream"] = input_map.pop("stream")
     if "cached_prompt" in input_map:
-        _param["cached_prompt"] = input_map.pop("cached_prompt")
-    if "seed" not in _param:
+        request_input.parameters["cached_prompt"] = input_map.pop(
+            "cached_prompt")
+
+
+def add_server_maintained_params(request_input: TextInput, input_item: Input,
+                                 **kwargs):
+    # Add some additional parameters for djl serving to do some work that are necessary.
+    request_input.server_parameters = request_input.parameters.copy()
+    # Per request streaming is only supported by rolling batch
+    if "seed" not in request_input.server_parameters:
         # set server provided seed if seed is not part of request
-        if item.contains_key("seed"):
-            _param["seed"] = item.get_as_string(key="seed")
-    if not "output_formatter" in _param:
-        _param["output_formatter"] = input_format_configs.output_formatter
+        if input_item.contains_key("seed"):
+            request_input.server_parameters["seed"] = input_item.get_as_string(
+                key="seed")
+    if not "output_formatter" in request_input.server_parameters:
+        request_input.server_parameters["output_formatter"] = kwargs.get(
+            "configs").output_formatter
 
-    if isinstance(_inputs, list):
-        return _inputs, _param, True
-    else:
-        return [_inputs], _param, False
+    request_input.output_formatter = request_input.server_parameters.get(
+        "output_formatter")
 
+    if request_input.output_formatter == "json" or request_input.output_formatter == "sse":
+        request_input.tgi_compat = kwargs.get("configs").tgi_compat
 
-def _parse_adapters(_inputs, input_map, item,
-                    adapter_registry) -> (List, bool):
-    adapters_per_item = _fetch_adapters_from_input(input_map, item)
-    found_adapter_per_item = False
-    if adapters_per_item:
-        _validate_adapters(adapters_per_item, adapter_registry)
-        found_adapter_per_item = True
-    else:
-        # inference with just base model.
-        adapters_per_item = [""] * len(_inputs)
-
-    if len(_inputs) != len(adapters_per_item):
-        raise ValueError(
-            f"Number of adapters is not equal to the number of inputs")
-    return adapters_per_item, found_adapter_per_item
+    # duplicating parameters for client side batching
+    if isinstance(request_input.input_text, list):
+        parameters = []
+        for _ in range(len(request_input.input_text)):
+            parameters.append(request_input.server_parameters.copy())
+        request_input.server_parameters = parameters
 
 
-def _fetch_adapters_from_input(input_map: dict, inputs: Input):
+def parse_adapters(request_input: TextInput, input_item: Input,
+                   input_map: Dict, **kwargs):
+    adapter_registry = kwargs.get("adapter_registry")
+    # if adapter registry exists and not empty, then we assume, peft is supported for the incoming
+    if adapter_registry:
+        adapters_per_item = _fetch_adapters_from_input(input_map, input_item)
+        if adapters_per_item:
+            _validate_adapters(adapters_per_item,
+                               kwargs.get("adapter_registry"))
+        else:
+            # inference with just base model.
+            adapters_per_item = [""] * len(request_input.input_text)
+
+        if len(request_input.input_text) != len(adapters_per_item):
+            raise ValueError(
+                f"Number of adapters is not equal to the number of inputs")
+        # lookup the adapter registry to get the adapter details of the registered adapter.
+        request_input.adapters = [
+            kwargs.get("adapter_registry").get(adapter, None)
+            for adapter in adapter_registry
+        ]
+
+
+def _fetch_adapters_from_input(input_map: dict, input_item: Input):
     adapters_per_item = []
     if "adapters" in input_map:
         adapters_per_item = input_map.pop("adapters", [])
 
     # check content, possible in workflow approach
-    if inputs.contains_key("adapter"):
-        adapters_per_item = inputs.get_as_string("adapter")
+    if input_item.contains_key("adapter"):
+        adapters_per_item = input_item.get_as_string("adapter")
 
     # check properties, possible from header
-    if "adapter" in inputs.get_properties():
-        adapters_per_item = inputs.get_properties()["adapter"]
+    if "adapter" in input_item.get_properties():
+        adapters_per_item = input_item.get_properties()["adapter"]
 
     if not isinstance(adapters_per_item, list):
         adapters_per_item = [adapters_per_item]

--- a/engines/python/setup/djl_python/request.py
+++ b/engines/python/setup/djl_python/request.py
@@ -11,11 +11,10 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import inspect
-from typing import Union, Callable, Any, List
+from typing import Union, Callable, Any, List, Dict
 
-from djl_python.output_formatter import get_output_formatter, _json_output_formatter, sse_response_formatter, \
-    adapt_legacy_output_formatter
-from djl_python.request_io import Token, TextGenerationOutput, TextInput, RequestOutput
+from djl_python.output_formatter import get_output_formatter, adapt_legacy_output_formatter
+from djl_python.request_io import Token, TextGenerationOutput, TextInput, RequestOutput, RequestInput
 from djl_python.utils import wait_till_generation_finished
 
 
@@ -29,54 +28,26 @@ class Request(object):
 
     """
 
-    def __init__(self,
-                 id: int,
-                 input_text: str,
-                 parameters: dict,
-                 input_ids: list = [],
-                 adapter=None,
-                 output_formatter: Union[str, Callable] = None,
-                 tgi_compat: bool = False,
-                 tokenizer: Any = None):
+    def __init__(self, request_input: TextInput = None):
         """
         Initialize a request
 
         :param id: request id
-        :param input_text: request's input text
-        :param parameters: list of parameters
-        :param input_ids: request's input ids
-        :param adapter: list of adapters
-        :param output_formatter: output formatter function (for example,
-            _json_output_formatter, _jsonlines_output_formatter, or user provided function
         """
-        self.id = id
-        self.input_text = input_text
-        self.parameters = parameters
-        original_parameters = parameters.copy()
+        self.id = request_input.request_id
+        self.request_input = request_input
+        self.parameters = self.request_input.server_parameters
+        self.input_text = request_input.input_text
         self.last_token = False
-        self.adapter = adapter
+        self.adapter = request_input.adapters
 
         # output formatter
-        # remove stream from parameters
-        stream = parameters.pop("stream", False)
+        stream = self.request_input.parameters.get("stream", False)
         self.output_formatter, self.content_type = get_output_formatter(
-            output_formatter, stream, tgi_compat)
+            request_input.output_formatter, stream, request_input.tgi_compat)
         self.legacy_formatter = self._is_output_formatter_legacy()
 
-        # remove details from parameters
-        parameters.pop("details", None)
-
-        # TODO: Strategically find the task and initialize based on task
-        self.request_input = TextInput(request_id=id,
-                                       output_formatter=self.output_formatter,
-                                       parameters=original_parameters,
-                                       input_text=input_text,
-                                       input_ids=input_ids,
-                                       adapters=adapter,
-                                       tokenizer=tokenizer)
-        if self.output_formatter == _json_output_formatter or self.output_formatter == sse_response_formatter:
-            self.request_input.tgi_compat = tgi_compat
-        self.request_output = TextGenerationOutput(request_id=id,
+        self.request_output = TextGenerationOutput(request_id=self.id,
                                                    input=self.request_input)
         self.next_token_str = ""
 

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -129,11 +129,12 @@ class RequestInput:
     Attributes:
         request_id: The request ID.
         output_formatter: Output formatter of the request
-        parameters: parameters in the request payload
+        parameters: parameters in the request payload, will be used in the output formatter
     """
     request_id: int
     output_formatter: Union[Callable, str] = None
     parameters: Dict = field(default_factory=lambda: {})
+    server_parameters: Dict = field(default_factory=lambda: {})
     tgi_compat: bool = False
 
 
@@ -150,6 +151,7 @@ class TextInput(RequestInput):
     input_ids: List[int] = field(default_factory=lambda: [])
     adapters: Optional[Any] = None
     tokenizer: Optional[Any] = None
+    found_adapters: bool = False
 
     def prompt_tokens_length(self) -> int:
         return len(self.input_ids)

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -129,7 +129,8 @@ class RequestInput:
     Attributes:
         request_id: The request ID.
         output_formatter: Output formatter of the request
-        parameters: parameters in the request payload, will be used in the output formatter
+        parameters: parameters in the request payload
+        server_parameters: parameters that are modified by the built-in handlers to support backend engines.
     """
     request_id: int
     output_formatter: Union[Callable, str] = None
@@ -147,11 +148,10 @@ class TextInput(RequestInput):
         adapters: adapter used for the request.
         tokenizer: tokenizer used for the request.
     """
-    input_text: str = None
+    input_text: Union[str, List[str]] = None
     input_ids: List[int] = field(default_factory=lambda: [])
     adapters: Optional[Any] = None
     tokenizer: Optional[Any] = None
-    found_adapters: bool = False
 
     def prompt_tokens_length(self) -> int:
         return len(self.input_ids)

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -15,6 +15,8 @@ from seq_scheduler.lm_block import HuggingfaceBlock, BloomBlock, FalconBlock
 from seq_scheduler.search_config import SearchConfig
 from seq_scheduler.seq_batch_scheduler import SeqBatchScheduler
 from collections import namedtuple, defaultdict
+
+from djl_python.request import Request
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, filter_unused_generation_params
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 
@@ -67,21 +69,14 @@ class SchedulerRollingBatch(RollingBatch):
         self._init_scheduler()
 
     @stop_on_any_exception
-    def inference(self,
-                  input_text: List[str],
-                  parameters: List[dict],
-                  adapters=None) -> list:
+    def inference(self, requests: List) -> List:
         """
         Performs prefill and decode operations for the batch.
 
-        :param input_text: List of input texts for each request in a batch
-        :param parameters: List of kwargs for each request in a batch
-        :param adapters: List of adapters inputs for each request in a batch
+        :param requests: List[Request] List of requests
         :return: generated batch decoded tokens
         """
-        batch_size = len(input_text)
-        new_requests = self.get_new_requests(input_text, parameters,
-                                             batch_size)
+        new_requests = self.get_new_requests(requests)
 
         preprocessed_new_requests = self.preprocess_requests(new_requests)
         self._prefill_and_decode(preprocessed_new_requests)

--- a/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/trtllm_rolling_batch.py
@@ -13,6 +13,7 @@
 import tensorrt_llm_toolkit
 
 from djl_python.properties_manager.trt_properties import TensorRtLlmProperties
+from djl_python.request import Request
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception
 from djl_python.request_io import Token
 from typing import List
@@ -86,24 +87,20 @@ class TRTLLMRollingBatch(RollingBatch):
         return parameters
 
     @stop_on_any_exception
-    def inference(self,
-                  input_data: List[str],
-                  parameters: List[dict],
-                  adapters=None) -> list:
+    def inference(self, requests: List[Request]) -> List:
         """
         Loads new requests into the batch when there is availability, and gets output tokens from the backend
         asynchronously.
 
+        :param requests: List[Request] List of requests
         :param input_data: List of input prompts.
         :param parameters: List of settings pertaining to each request.
         :param adapters: List of adapters inputs for each request in a batch
 
         :return results: List of dictionaries, one for each request, that contain output tokens and other data.
         """
-        batch_size = len(input_data)
         # add pending requests to active requests list
-        new_requests = self.get_new_requests(input_data, parameters,
-                                             batch_size)
+        new_requests = self.get_new_requests(requests)
         # step 0: register new active requests
         for request in new_requests:
             param = self.translate_triton_params(request.parameters)

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -15,6 +15,8 @@ from collections import OrderedDict, defaultdict
 
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.utils import random_uuid
+
+from djl_python.request import Request
 from djl_python.rolling_batch.rolling_batch import RollingBatch, stop_on_any_exception, filter_unused_generation_params
 from djl_python.rolling_batch.rolling_batch_vllm_utils import (
     update_request_cache_with_output, get_lora_request_params,
@@ -105,24 +107,15 @@ class VLLMRollingBatch(RollingBatch):
         return parameters
 
     @stop_on_any_exception
-    def inference(self,
-                  input_data: List[str],
-                  parameters: List[dict],
-                  adapters=None) -> list:
+    def inference(self, requests: List[Request]) -> List:
         """
         Adds new requests and gets output tokens from the backend.
 
-        :param input_data: List of input prompts.
-        :param parameters: List of settings pertaining to each request.
-        :param adapters: List of adapters inputs for each request in a batch
+        :param requests: List[Request] List of requests
 
         :return results: List of dictionaries, one for each request, that contain output tokens and other data.
         """
-        batch_size = len(input_data)
-        new_requests = self.get_new_requests(input_data,
-                                             parameters,
-                                             batch_size,
-                                             adapters=adapters)
+        new_requests = self.get_new_requests(requests)
         # step 0: register new requests to engine
         for request in new_requests:
             request_id = random_uuid()

--- a/engines/python/setup/djl_python/tensorrt_llm.py
+++ b/engines/python/setup/djl_python/tensorrt_llm.py
@@ -29,6 +29,7 @@ class TRTLLMService(object):
     """
 
     def __init__(self):
+        self.input_format_args = None
         self.initialized = False
         self.trt_configs = None
         self.rolling_batch = None
@@ -40,6 +41,7 @@ class TRTLLMService(object):
         self.rolling_batch = TRTLLMRollingBatch(
             self.trt_configs.model_id_or_path, properties, self.trt_configs)
         self.tokenizer = self.rolling_batch.get_tokenizer()
+        self.input_format_args = self.get_input_format_args()
         self.initialized = True
         return
 
@@ -54,16 +56,14 @@ class TRTLLMService(object):
         """
         Does preprocessing and sends new requests to the rolling batch script for inference
 
-        :param inputs (Input): a batch of inputs, each corresponding to a new request
+        :param inputs: (Input) a batch of inputs, each corresponding to a new request
 
         :return outputs (Output): a batch of outputs that contain status code, output text, and other information
         """
         outputs = Output()
-        kwargs = self.__dict__
-        kwargs[
-            "configs"] = self.trt_configs  # TODO: Rename it to configs, so it would uniform in all handlers
 
-        parsed_input = parse_input_with_formatter(inputs, **kwargs)
+        parsed_input = parse_input_with_formatter(inputs,
+                                                  **self.input_format_args)
         if len(parsed_input.requests) == 0:
             for i in range(len(parsed_input.batch)):
                 err = parsed_input.errors.get(i)

--- a/engines/python/setup/djl_python/tensorrt_llm_python.py
+++ b/engines/python/setup/djl_python/tensorrt_llm_python.py
@@ -121,10 +121,8 @@ class TRTLLMPythonService:
                 outputs.add(err, key="data", batch_index=i)
             return outputs
 
-        input_data, input_size = get_input_details(parsed_input.requests,
-                                                   parsed_input.errors,
-                                                   parsed_input.batch)
-        params = parsed_input.requests[0].request_input.server_parameters
+        input_data, input_size, params, _ = get_input_details(
+            parsed_input.requests, parsed_input.errors, parsed_input.batch)
 
         if "output_formatter" in params:
             # output formatter is not supported for TensorRT-LLM python backend.

--- a/engines/python/setup/djl_python/tests/rolling_batch_test_scripts/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/rolling_batch_test_scripts/test_rb_vllm_utils.py
@@ -12,7 +12,7 @@ from transformers import AutoTokenizer
 import djl_python
 from djl_python.output_formatter import _json_output_formatter
 from djl_python.request import Request
-from djl_python.request_io import TextGenerationOutput, TextInput, Sequence, Token
+from djl_python.request_io import TextGenerationOutput, TextInput, Sequence, Token, RequestInput
 '''These Mock classes are in compliance with vllm RequestOutput version 0.4.2'''
 
 
@@ -367,12 +367,12 @@ class TestVllmUtils(unittest.TestCase):
             "top_n_tokens": 3
         }
 
+        request_input = TextInput(request_id=0,
+                                  input_text="I am a",
+                                  parameters=parameters.copy(),
+                                  tokenizer=tokenizer)
         # 1. Creates the request
-        req = Request(0,
-                      "I am a",
-                      parameters=parameters.copy(),
-                      output_formatter=_json_output_formatter,
-                      tokenizer=tokenizer)
+        req = Request(request_input)
         self.assertEqual(
             TextGenerationOutput(request_id=0,
                                  input=TextInput(

--- a/engines/python/setup/djl_python/tests/test_input_parser.py
+++ b/engines/python/setup/djl_python/tests/test_input_parser.py
@@ -1,0 +1,29 @@
+import unittest
+
+from djl_python.input_parser import parse_input_with_formatter
+from djl_python.test_model import create_concurrent_batch_request
+
+
+class InputParserTest(unittest.TestCase):
+
+    def test_input_parameters(self):
+        inputs = [{
+            "inputs": "The winner of oscar this year is",
+            "parameters": {
+                "max_new_tokens": 50
+            },
+            "stream": False
+        }, {
+            "inputs": "A little redhood is",
+            "parameters": {
+                "min_new_tokens": 51,
+                "max_new_tokens": 256,
+            },
+            "stream": True
+        }]
+
+        serving_properties = {"rolling_batch": "disable"}
+
+        inputs = create_concurrent_batch_request(
+            inputs, serving_properties=serving_properties)
+        parsed_input = parse_input_with_formatter(inputs)

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -210,7 +210,7 @@ class TestRollingBatch(unittest.TestCase):
                       input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
-                          "stream": True
+                          "stream": True,
                       },
                       tgi_compat=True))
         req.set_next_token(Token(244, "He", -0.334532))

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -4,22 +4,28 @@ import unittest
 from djl_python.request import Request
 from djl_python.output_formatter import _json_output_formatter, _jsonlines_output_formatter, \
     _jsonlines_chat_output_formatter, _json_chat_output_formatter
-from djl_python.request_io import Token, RequestOutput, TextGenerationOutput
+from djl_python.request_io import Token, TextGenerationOutput, TextInput
 
 
 class TestRollingBatch(unittest.TestCase):
 
     def test_json_fmt(self):
-        req1 = Request(0,
-                       "This is a wonderful day",
-                       parameters={"max_new_tokens": 256},
-                       output_formatter=_json_output_formatter)
-        req2 = Request(1,
-                       "This is a wonderful day",
-                       parameters={
-                           "max_new_tokens": 256,
-                           "stream": False
-                       })
+        req_input1 = TextInput(
+            request_id=0,
+            input_text="This is a wonderful day",
+            parameters={"max_new_tokens": 256},
+            output_formatter=_json_output_formatter,
+        )
+        req1 = Request(req_input1)
+        req_input2 = TextInput(
+            request_id=1,
+            input_text="This is a wonderful day",
+            parameters={
+                "max_new_tokens": 256,
+                "stream": False
+            },
+        )
+        req2 = Request(req_input2)
         for req in [req1, req2]:
             req.set_next_token(Token(244, "He", -0.334532))
             print(req.get_next_token(), end='')
@@ -36,16 +42,20 @@ class TestRollingBatch(unittest.TestCase):
             req.reset_next_token()
 
     def test_json_fmt_with_appending(self):
-        req1 = Request(0,
-                       "This is a wonderful day",
-                       parameters={"max_new_tokens": 256},
-                       output_formatter=_json_output_formatter)
-        req2 = Request(1,
-                       "This is a wonderful day",
-                       parameters={
-                           "max_new_tokens": 256,
-                           "stream": False
-                       })
+        req_input1 = TextInput(request_id=0,
+                               input_text="This is a wonderful day",
+                               parameters={"max_new_tokens": 256},
+                               output_formatter=_json_output_formatter)
+        req1 = Request(req_input1)
+        req_input2 = TextInput(
+            request_id=1,
+            input_text="This is a wonderful day",
+            parameters={
+                "max_new_tokens": 256,
+                "stream": False
+            },
+        )
+        req2 = Request(req_input2)
         for req in [req1, req2]:
             req.set_next_token(Token(244, "He", -0.334532))
             req.set_next_token(Token(576, "llo", -0.123123))
@@ -58,15 +68,16 @@ class TestRollingBatch(unittest.TestCase):
             assert req.get_next_token() == ' world"}'
 
     def test_fmt_hf_compat(self):
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "return_full_text": True,
                           "details": True
                       },
                       output_formatter=_json_output_formatter,
-                      tgi_compat=True)
+                      tgi_compat=True))
 
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
@@ -105,16 +116,18 @@ class TestRollingBatch(unittest.TestCase):
         }]
 
     def test_jsonlines_fmt(self):
-        req1 = Request(0,
-                       "This is a wonderful day",
-                       parameters={"max_new_tokens": 256},
-                       output_formatter=_jsonlines_output_formatter)
-        req2 = Request(1,
-                       "This is a wonderful day",
-                       parameters={
-                           "max_new_tokens": 256,
-                           "stream": True
-                       })
+        req1 = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
+                      parameters={"max_new_tokens": 256},
+                      output_formatter=_jsonlines_output_formatter))
+        req2 = Request(
+            TextInput(request_id=1,
+                      input_text="This is a wonderful day",
+                      parameters={
+                          "max_new_tokens": 256,
+                          "stream": True
+                      }))
         for req in [req1, req2]:
             req.set_next_token(Token(244, "He", -0.334532))
             print(req.get_next_token(), end='')
@@ -149,10 +162,11 @@ class TestRollingBatch(unittest.TestCase):
             }
 
     def test_sse_fmt(self):
-        req = Request(0,
-                      "This is a wonderful day",
-                      parameters={"max_new_tokens": 256},
-                      output_formatter="sse")
+        request_input = TextInput(request_id=0,
+                                  input_text="This is a wonderful day",
+                                  parameters={"max_new_tokens": 256},
+                                  output_formatter="sse")
+        req = Request(request_input)
         req.set_next_token(Token(244, "He", -0.334532))
         next_token = req.get_next_token()
         print(next_token, end='')
@@ -191,13 +205,14 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_sse_tgi_compat_fmt(self):
-        req = Request(1,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=1,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "stream": True
                       },
-                      tgi_compat=True)
+                      tgi_compat=True))
         req.set_next_token(Token(244, "He", -0.334532))
         next_token = req.get_next_token()
         print(next_token, end='')
@@ -241,13 +256,14 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_3p_fmt(self):
-        req = Request(1,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=1,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 1024,
                           "details": True
                       },
-                      output_formatter="3p")
+                      output_formatter="3p"))
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
         req.set_next_token(Token(244, "llo", -0.123123))
@@ -275,13 +291,14 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_3p_stream_fmt(self):
-        req = Request(1,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=1,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 1024,
                           "details": True
                       },
-                      output_formatter="3p_stream")
+                      output_formatter="3p_stream"))
         req.set_next_token(Token(244, "He", -0.334532))
         next_token = json.loads(req.get_next_token())
         assert next_token == {
@@ -349,13 +366,14 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_return_full_text(self):
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "return_full_text": True,
                       },
-                      output_formatter=_json_output_formatter)
+                      output_formatter=_json_output_formatter))
 
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
@@ -372,13 +390,14 @@ class TestRollingBatch(unittest.TestCase):
             "generated_text": "This is a wonderful dayHello world",
         }
 
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "return_full_text": True
                       },
-                      output_formatter=_jsonlines_output_formatter)
+                      output_formatter=_jsonlines_output_formatter))
         req.set_next_token(Token(244, "He", -0.334532))
         req.set_next_token(Token(576, "llo", -0.123123))
         req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
@@ -393,13 +412,14 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_details(self):
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      output_formatter=_json_output_formatter)
+                      output_formatter=_json_output_formatter))
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
         final_str.append(req.get_next_token())
@@ -436,13 +456,14 @@ class TestRollingBatch(unittest.TestCase):
             }
         }
         # Jsonlines tests
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      output_formatter=_jsonlines_output_formatter)
+                      output_formatter=_jsonlines_output_formatter))
         req.set_next_token(Token(244, "He", -0.334532))
         req.set_next_token(Token(576, "llo", -0.123123))
         req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
@@ -462,14 +483,15 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_details_jsonlines(self):
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True,
                           "decoder_input_details": True
                       },
-                      output_formatter=_jsonlines_output_formatter)
+                      output_formatter=_jsonlines_output_formatter))
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
@@ -540,14 +562,17 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_chat_json(self):
-        req = Request(0,
-                      "This is a wonderful day",
-                      parameters={
-                          "max_new_tokens": 256,
-                          "details": True,
-                          "logprobs": True
-                      },
-                      output_formatter=_json_chat_output_formatter)
+        req = Request(
+            TextInput(
+                request_id=0,
+                input_text="This is a wonderful day",
+                parameters={
+                    "max_new_tokens": 256,
+                    "details": True,
+                    "logprobs": True
+                },
+                output_formatter=_json_chat_output_formatter,
+            ))
         final_str = []
         req.set_next_token(Token(244, "He", -0.334532))
         final_str.append(req.get_next_token())
@@ -610,15 +635,16 @@ class TestRollingBatch(unittest.TestCase):
         }
 
     def test_chat_jsonlines(self):
-        req = Request(0,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True,
                           "decoder_input_details": True,
                           "logprobs": True
                       },
-                      output_formatter=_jsonlines_chat_output_formatter)
+                      output_formatter=_jsonlines_chat_output_formatter))
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token())["choices"] == [{
@@ -713,13 +739,14 @@ class TestRollingBatch(unittest.TestCase):
                 result["finish_reason"] = details["finish_reason"]
             return json.dumps(result) + "\n"
 
-        req = Request(132,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=132,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True
                       },
-                      output_formatter=custom_fmt)
+                      output_formatter=custom_fmt))
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
@@ -752,14 +779,15 @@ class TestRollingBatch(unittest.TestCase):
             result = details
             return json.dumps(result) + "\n"
 
-        req = Request(132,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=132,
+                      input_text="This is a wonderful day",
                       parameters={
                           "max_new_tokens": 256,
                           "details": True
                       },
                       input_ids=[101, 1188, 1110, 170, 7310, 1285, 102],
-                      output_formatter=custom_fmt)
+                      output_formatter=custom_fmt))
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
         assert json.loads(req.get_next_token()) == {
@@ -869,12 +897,13 @@ class TestRollingBatch(unittest.TestCase):
 
         parameters = {"max_new_tokens": 256, "details": True, "stream": False}
 
-        req = Request(132,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=132,
+                      input_text="This is a wonderful day",
                       parameters=parameters,
-                      output_formatter=custom_fmt_wait)
-        print(parameters)
-        assert parameters == {"max_new_tokens": 256}
+                      output_formatter=custom_fmt_wait))
+        print(req.request_input.parameters)
+        assert req.request_input.parameters == parameters
 
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
@@ -922,12 +951,17 @@ class TestRollingBatch(unittest.TestCase):
 
         parameters = {"max_new_tokens": 256, "details": True, "best_of": 2}
 
-        req = Request(132,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=132,
+                      input_text="This is a wonderful day",
                       parameters=parameters,
-                      output_formatter=_json_output_formatter)
+                      output_formatter=_json_output_formatter))
         print(parameters)
-        assert parameters == {"max_new_tokens": 256, "best_of": 2}
+        assert parameters == {
+            "max_new_tokens": 256,
+            "details": True,
+            "best_of": 2
+        }
 
         req.set_next_token(Token(244, "He", -0.334532))
         print(req.get_next_token(), end='')
@@ -970,12 +1004,13 @@ class TestRollingBatch(unittest.TestCase):
 
         parameters = {"max_new_tokens": 4, "details": True, "best_of": 2}
 
-        req = Request(132,
-                      "This is a wonderful day",
+        req = Request(
+            TextInput(request_id=132,
+                      input_text="This is a wonderful day",
                       parameters=parameters,
-                      output_formatter=_json_output_formatter)
+                      output_formatter=_json_output_formatter))
         print(parameters)
-        assert parameters == {"max_new_tokens": 4, "best_of": 2}
+        assert req.request_input.parameters == parameters
 
         req.request_output.set_next_token(Token(244, "He", -0.334532),
                                           sequence_index=0)

--- a/engines/python/setup/djl_python/tests/test_test_model.py
+++ b/engines/python/setup/djl_python/tests/test_test_model.py
@@ -123,6 +123,7 @@ class TestTestModel(unittest.TestCase):
         loaded_result = []
         for row in sse_result:
             loaded_result.append(json.loads(row[6:]))
+        print(loaded_result)
         self.assertTrue("details" in loaded_result[-1], loaded_result[-1])
 
         for key in envs.keys():

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -219,7 +219,8 @@ class TransformersNeuronXService(object):
         self.initialized = True
 
     def inference(self, inputs: Input) -> Output:
-        parsed_input = parse_input_with_formatter(inputs, **self.__dict__)
+        parsed_input = parse_input_with_formatter(inputs,
+                                                  **self.input_format_args)
         errors = parsed_input.errors
         requests = parsed_input.requests
         outputs = Output()
@@ -229,11 +230,8 @@ class TransformersNeuronXService(object):
                                            self.rolling_batch)
 
         batch = parsed_input.batch
-        input_data, input_size = get_input_details(requests, errors, batch)
-        parameters = parsed_input.requests[0].request_input.server_parameters
-        # Remove rolling batch default parameters
-        parameters.pop("output_formatter", None)
-        parameters.pop("stream", None)
+        input_data, input_size, parameters, _ = get_input_details(
+            requests, errors, batch)
         model_kwargs = {}
 
         prompt_size = len(input_data)

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -114,8 +114,8 @@ def get_input_details(requests, errors, batch):
     input_size = []
     adapters = []
     idx = 0
-    request_input = requests[0].request_input
-    parameters = request_input.server_parameters
+    parameters = requests[0].request_input.server_parameters
+
     for i in range(len(batch)):
         if i in errors:
             input_size.append(0)
@@ -134,4 +134,4 @@ def get_input_details(requests, errors, batch):
 
         idx += 1
     adapters = adapters if adapters else None
-    return input_data, input_size, adapters
+    return input_data, input_size, parameters, adapters


### PR DESCRIPTION
## Description ##

Refactoring input parser to support Request. Before this PR, we loop through the list of requests to list of input_text, input_size, parameters etc.. and then in rolling batch, we loop through through these parsed list and then convert to list of requests `Request` again. This PR aims to avoid this duplicate work. 

## Assumptions ## 
1. Before this PR, we duplicated the parameters for client side batching, which is not needed anymore as we no longer maintain this as list, we maintan this a list of Requests. 
2. In this PR, we assume, if adapter_registry is non empty, then adapters needs to be looked in the requests. If adapter_registry is empty, then we dont look for adapters. 
3. In this PR, we introduced server_parameters => which will have the server modified parameters and the built-in handlers should look for this in order to modify or send to backend engines like vllm. 

## After this PR, for future improvements ##
1.  For the new standard of input_formatter, we would want request_input and part of the input_formatter. This refactor makes this easier.
2. For mulitmodal parsing, this should also makes thing easier. 
3. output_formatter could be easily used by dynamic batching use cases as well. This will unify the API UX for rolling batch and dynamic batching. 

## Testing ##
- https://github.com/deepjavalibrary/djl-serving/actions/runs/9862485646/job/27233337263 
- There is a failure LMIDIst2 and vllm LoRA, will investigate in my local machine, but others are passing now. 

P.S. I could not divide this into multiple PRs, sorry about that. All these changes has to go in one PR.
