### PR TITLE
[python] Fix new logprobs computation in vllm_utils

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -116,8 +116,8 @@ def update_multiple_sequences(cache, request_output, vllm_request_output):
                 cur_len] if prev_len < cur_len else completion_output.logprobs
             new_logprobs = []
             for token_id, logprobs in zip(new_token_ids, new_logprobs_list):
+                new_logprobs.append(logprobs[token_id].logprob)
                 for token_id_key, logprob in logprobs.items():
-                    new_logprobs.append(logprobs[token_id].logprob)
                     top_tokens.append(
                         Token(id=token_id_key,
                               text=logprob.decoded_token,
@@ -137,7 +137,7 @@ def update_multiple_sequences(cache, request_output, vllm_request_output):
             for i, (token_id, token_text, logprob) in enumerate(
                     zip(new_token_ids, output_token_texts, new_logprobs)):
                 token = Token(token_id, token_text, logprob)
-                is_last_token = i == (len(new_logprobs) -
+                is_last_token = i == (len(new_token_ids) -
                                       1) and finish_reason is not None
                 request_output.sequences[sequence_index].set_next_token(
                     token, is_last_token)


### PR DESCRIPTION
## Description ##

**This bug is only in master, not in 0.28.0. This fixes the LMI no-code low code CI failures.**

 Even if we set logprobs=1, sometimes, vLLM sends more than one log probabilities. Here for new log probs, we add all the log probabilities that are return by vLLM to new_logprobs dict. 

But when we determine whether it is last token or not, `i == (len(new_logprobs) -1)` and this fails, because now it has more than one new probs, this case will never be true. So last_token never occurred, so it returned broken json without any details. Hence the CI failed. 

Will add unit test cases for this use-cases as well in the next PR.