### PR TITLE
[engine] include lmi recommended entrypoint when model.py exists

### DIFF
--- a/engines/python/setup/djl_python/arg_parser.py
+++ b/engines/python/setup/djl_python/arg_parser.py
@@ -71,6 +71,11 @@ class ArgParser(object):
                             dest="tensor_parallel_degree",
                             type=int,
                             help='The tensor parallel degree')
+        parser.add_argument('--recommended-entry-point',
+                            required=False,
+                            type=str,
+                            dest="recommended_entry_point",
+                            help="Lmi recommended entry point")
         return parser
 
     @staticmethod

--- a/engines/python/setup/djl_python/service_loader.py
+++ b/engines/python/setup/djl_python/service_loader.py
@@ -69,3 +69,8 @@ def load_model_service(model_dir, entry_point, device_id):
                                 batch_size, envelope)
 
     return TorchServeService(service, model_dir)
+
+
+def has_function_in_module(module, function_name):
+    return hasattr(module, function_name) and callable(
+        getattr(module, function_name))

--- a/engines/python/setup/djl_python_engine.py
+++ b/engines/python/setup/djl_python_engine.py
@@ -175,7 +175,8 @@ def main():
         sock_type = args.sock_type
         sock_name = args.sock_name if rank is None else f"{args.sock_name}.{rank}"
 
-        model_service = load_model_service(args.model_dir, args.entry_point,
+        entry_point = args.entry_point if args.entry_point else args.recommended_entry_point
+        model_service = load_model_service(args.model_dir, entry_point,
                                            args.device_id)
 
         engine = PythonEngine(args, model_service)

--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -124,6 +124,7 @@ class Connection {
         Device device = model.getNDManager().getDevice();
         int deviceId = device.getDeviceId();
         int tensorParallelDegree = pyEnv.getTensorParallelDegree();
+        String entryPoint = pyEnv.getEntryPoint();
         String recommendedEntryPoint = pyEnv.getRecommendedEntryPoint();
         if (pyEnv.isMpiMode()) {
             String cudaDevices = getVisibleDevices(workerId, tensorParallelDegree);
@@ -165,7 +166,7 @@ class Connection {
             args[30] = "--model-dir";
             args[31] = model.getModelPath().toAbsolutePath().toString();
             args[32] = "--entry-point";
-            args[33] = pyEnv.getEntryPoint();
+            args[33] = entryPoint == null ? "" : entryPoint;
             args[34] = "--sock-type";
             args[35] = "unix";
             args[36] = "--sock-name";
@@ -205,7 +206,7 @@ class Connection {
         args[6] = "--model-dir";
         args[7] = model.getModelPath().toAbsolutePath().toString();
         args[8] = "--entry-point";
-        args[9] = pyEnv.getEntryPoint();
+        args[9] = entryPoint == null ? "" : entryPoint;
         args[10] = "--device-id";
         args[11] = String.valueOf(deviceId);
         args[12] = "--recommended-entry-point";

--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -124,10 +124,11 @@ class Connection {
         Device device = model.getNDManager().getDevice();
         int deviceId = device.getDeviceId();
         int tensorParallelDegree = pyEnv.getTensorParallelDegree();
+        String recommendedEntryPoint = pyEnv.getRecommendedEntryPoint();
         if (pyEnv.isMpiMode()) {
             String cudaDevices = getVisibleDevices(workerId, tensorParallelDegree);
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);
-            String[] args = new String[40];
+            String[] args = new String[42];
             args[0] = "mpirun";
             args[1] = "-np";
             // TODO: When we support multi nodes, change it to the product of tensor parallel value
@@ -171,6 +172,8 @@ class Connection {
             args[37] = getSocketPath(port);
             args[38] = "--tensor-parallel-degree";
             args[39] = String.valueOf(tensorParallelDegree);
+            args[40] = "--recommended-entry-point";
+            args[41] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
             return args;
         }
 
@@ -192,7 +195,7 @@ class Connection {
             logger.info("Set OMP_NUM_THREADS={}", neuronThreads);
         }
         boolean uds = Epoll.isAvailable() || KQueue.isAvailable();
-        String[] args = new String[12];
+        String[] args = new String[14];
         args[0] = pyEnv.getPythonExecutable();
         args[1] = PyEnv.getEngineCacheDir() + "/djl_python_engine.py";
         args[2] = "--sock-type";
@@ -205,6 +208,8 @@ class Connection {
         args[9] = pyEnv.getEntryPoint();
         args[10] = "--device-id";
         args[11] = String.valueOf(deviceId);
+        args[12] = "--recommended-entry-point";
+        args[13] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
         return args;
     }
 

--- a/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
@@ -357,7 +357,7 @@ public class PyEnv {
      * @return the model's entrypoint file path
      */
     public String getEntryPoint() {
-        return entryPoint == null ? "model.py" : entryPoint;
+        return entryPoint;
     }
 
     /**

--- a/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
@@ -49,6 +49,7 @@ public class PyEnv {
     private boolean mpiMode;
     private String pythonExecutable;
     private String entryPoint;
+    private String recommendedEntryPoint;
     private String handler;
     private int predictTimeout;
     private int modelLoadingTimeout;
@@ -366,6 +367,24 @@ public class PyEnv {
      */
     public void setEntryPoint(String entryPoint) {
         this.entryPoint = entryPoint;
+    }
+
+    /**
+     * Returns the lmi recommended entrypoint file path.
+     *
+     * @return lmi recommended entrypoint file path
+     */
+    public String getRecommendedEntryPoint() {
+        return this.recommendedEntryPoint;
+    }
+
+    /**
+     * Sets the lmi recommended entrypoint file path.
+     *
+     * @param recommendedEntryPoint the lmi recommended entrypoint file path
+     */
+    public void setRecommendedEntryPoint(String recommendedEntryPoint) {
+        this.recommendedEntryPoint = recommendedEntryPoint;
     }
 
     /**

--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -153,23 +153,23 @@ public class PyModel extends BaseModel {
         if (entryPoint == null) {
             entryPoint = Utils.getenv("DJL_ENTRY_POINT");
             if (entryPoint == null) {
+                Path modelFile = findModelFile(prefix);
                 String features = Utils.getEnvOrSystemProperty("SERVING_FEATURES");
+                // find default entryPoint
+                if (modelFile != null) {
+                    entryPoint = modelFile.toFile().getName();
+                }
+                // find recommendedEntryPoint
                 if ("nc".equals(manager.getDevice().getDeviceType())
                         && pyEnv.getTensorParallelDegree() > 0) {
-                    entryPoint = "djl_python.transformers_neuronx";
+                    recommendedEntryPoint = "djl_python.transformers_neuronx";
                 } else if ("trtllm".equals(features)) {
-                    entryPoint = "djl_python.tensorrt_llm";
+                    recommendedEntryPoint = "djl_python.tensorrt_llm";
                 } else if (pyEnv.getInitParameters().containsKey("model_id")
                         || Files.exists(modelPath.resolve("config.json"))) {
-                    entryPoint = "djl_python.huggingface";
+                    recommendedEntryPoint = "djl_python.huggingface";
                 }
-                Path modelFile = findModelFile(prefix);
-                if (modelFile != null) {
-                    if (entryPoint != null) {
-                        recommendedEntryPoint = entryPoint;
-                    }
-                    entryPoint = modelFile.toFile().getName();
-                } else {
+                if (entryPoint == null && recommendedEntryPoint == null) {
                     throw new FileNotFoundException(".py file not found in: " + modelPath);
                 }
             }


### PR DESCRIPTION
## Description ##

Existing flow: If model.py exists in the model directory, without explicitly set by the user either in serving.properties or environment variables, then we take that as the entryPoint. 

This PR:
- Still takes model.py as the entryPoint.
- But we also send the inferred built in handler as the recommended_entry_point to the python engine. 
- In the python side, we check whether the given entry point has the `handle` or handler function name. If it does not exist, then we use the recommended_entry_point as the entry point

Tests:
- Manually tested in my ec2 machine. 
