### PR TITLE
[CI] Supports temp repo in execute job

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -7,6 +7,13 @@ on:
         description: 'release/nightly/temp, default is nightly'
         required: true
         default: 'nightly'
+  workflow_call:
+    inputs:
+      mode:
+        description: 'release/nightly/temp, default is nightly'
+        type: string
+        required: true
+        default: 'nightly'
   schedule:
     - cron: '0 13 * * *'
 
@@ -52,11 +59,11 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
       - name: Build serving package for nightly
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         run: |
           ./gradlew --refresh-dependencies :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -64,7 +71,7 @@ jobs:
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT ${{ matrix.arch }}
           docker compose push ${{ matrix.arch }}
       - name: Build and push temp image
-        if: ${{ github.event.inputs.mode == 'temp' }}
+        if: ${{ inputs.mode == 'temp' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -76,7 +83,7 @@ jobs:
           docker tag deepjavalibrary/djl-serving:${{ matrix.arch }}-nightly $tempTag
           docker push $tempTag
       - name: Build and push release docker image
-        if: ${{ github.event.inputs.mode == 'release' }}
+        if: ${{ inputs.mode == 'release' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -85,7 +92,7 @@ jobs:
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} ${{ matrix.arch }}
           docker compose push ${{ matrix.arch }}
       - name: Retag image for release
-        if: ${{ matrix.arch == 'cpu' && github.event.inputs.mode == 'release' }}
+        if: ${{ matrix.arch == 'cpu' && inputs.mode == 'release' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -151,11 +158,11 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
       - name: Build serving package for nightly
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         run: |
           ./gradlew --refresh-dependencies :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -163,7 +170,7 @@ jobs:
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT aarch64
           docker compose push aarch64
       - name: Build and push temp image
-        if: ${{ github.event.inputs.mode == 'temp' }}
+        if: ${{ inputs.mode == 'temp' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -175,7 +182,7 @@ jobs:
           docker tag deepjavalibrary/djl-serving:aarch64-nightly $tempTag
           docker push $tempTag
       - name: Build and push release docker image
-        if: ${{ github.event.inputs.mode == 'release' }}
+        if: ${{ inputs.mode == 'release' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -218,11 +225,11 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
       - name: Build serving package for nightly
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         run: |
           ./gradlew --refresh-dependencies :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
-        if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'nightly' }}
+        if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -230,7 +237,7 @@ jobs:
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT lmi
           docker compose push lmi
       - name: Build and push temp image
-        if: ${{ github.event.inputs.mode == 'temp' }}
+        if: ${{ inputs.mode == 'temp' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -242,7 +249,7 @@ jobs:
           docker tag deepjavalibrary/djl-serving:lmi-nightly $tempTag
           docker push $tempTag
       - name: Build and push release docker image
-        if: ${{ github.event.inputs.mode == 'release' }}
+        if: ${{ inputs.mode == 'release' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)

--- a/.github/workflows/integration_execute.yml
+++ b/.github/workflows/integration_execute.yml
@@ -16,14 +16,24 @@ on:
           - action_graviton
           - action_inf2
       djl-version:
-        description: 'The released version of DJL'
+        description: 'The released version of DJL. Can be "nightly", "temp", or a DJL release version like "0.28.0"'
         required: false
-        default: ''
+        default: 'temp'
 
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
+  build-temp:
+    if: ${{ inputs.djl-version == 'temp' }}
+    uses: ./.github/workflows/docker-nightly-publish.yml
+    secrets: inherit
+    with:
+      mode: temp
   create-runners:
     runs-on: [self-hosted, scheduler]
+    needs: [build-temp]
     steps:
       - name: Create new instance
         id: create_instance
@@ -37,12 +47,10 @@ jobs:
     outputs:
       instance_id: ${{ steps.create_instance.outputs.instance_id }}
       label: ${{ steps.create_instance.outputs.label }}
-
-
   test:
     runs-on: [ self-hosted, "${{ needs.create-runners.outputs.label }}"]
     timeout-minutes: 60
-    needs: create-runners
+    needs: [create-runners, build-temp]
     steps:
       - uses: actions/checkout@v4
       - name: Clean env
@@ -64,6 +72,19 @@ jobs:
           sudo apt-get install python3 python-is-python3 python3-pip -y
       - name: Install pip dependencies
         run: pip3 install pytest requests "numpy<2" pillow huggingface_hub
+      - name: install awscli
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
+      - name: Login for temp
+        if: ${{ inputs.djl-version == 'temp' }}
+        run: |
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp
       - name: Install awscurl
         working-directory: tests/integration
         run: |
@@ -99,7 +120,7 @@ jobs:
   stop-runners:
     if: always()
     runs-on: [ self-hosted, scheduler ]
-    needs: [ create-runners, test]
+    needs: [ build-temp, create-runners, test]
     steps:
       - name: Stop all instances
         run: |

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -17,16 +17,22 @@ class Runner:
         self.container = container
         self.test_name = test_name
 
-        # Compute flavor
-        if djl_version is not None and len(djl_version) > 0:
-            if container == "cpu":
-                flavor = djl_version
-            else:
-                flavor = f"{djl_version}-{container}"
-        else:
+        # Compute flavor and repo
+        repo = "deepjavalibrary/djl-serving"
+        if djl_version is None or len(
+                djl_version) == 0 or djl_version == "nightly":
             flavor = f"{container}-nightly"
+        else:
+            if djl_version == "temp":
+                repo = "185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+                flavor = f"{container}-{os.environ['GITHUB_SHA']}"
+            else:
+                if container == "cpu":
+                    flavor = djl_version
+                else:
+                    flavor = f"{djl_version}-{container}"
 
-        self.image = f"deepjavalibrary/djl-serving:{flavor}"
+        self.image = f"{repo}:{flavor}"
 
         # os.system(f'docker pull {self.image}')
         os.system('rm -rf models')


### PR DESCRIPTION
This revives the use of the temp repo from #1266 and implements it in the execute job. The job can now be used to automatically test a particular branch through the temp repo. The repo is automatically built as part of the job. So, to test a branch using the pytest suite with actions, these are the only steps required:

1. Push the branch to test to the deepjavalibrary/djl-serving upstream repo
2. Run the integration execute job with the default djl-version "temp"
