### PR TITLE
[lmi] remove redundant auto logic from python handler

### DIFF
--- a/engines/python/setup/djl_python/tests/test_test_model.py
+++ b/engines/python/setup/djl_python/tests/test_test_model.py
@@ -19,14 +19,12 @@ from djl_python.test_model import TestHandler
 from djl_python import huggingface
 
 
-def override_rolling_batch(rolling_batch_type: str, is_mpi: bool,
-                           model_config):
+def override_rolling_batch(rolling_batch_type: str):
     from djl_python.tests.rolling_batch.fake_rolling_batch import FakeRollingBatch
     return FakeRollingBatch
 
 
-def override_rolling_batch_with_exception(rolling_batch_type: str,
-                                          is_mpi: bool, model_config):
+def override_rolling_batch_with_exception(rolling_batch_type: str):
     from djl_python.tests.rolling_batch.fake_rolling_batch import FakeRollingBatchWithException
     return FakeRollingBatchWithException
 


### PR DESCRIPTION
## Description ##

There is quite a bit of old/outdated logic scattered throughout djl_python and our default handlers. I'll be raising PRs to slowly clear out this outdated logic.

This change removes the "auto" logic for rolling batch from out python code. This logic has been fully moved to the LmiConfigRecommender on the java side. The logic here is not up to date anymore either.
