### PR TITLE
[python] add input formatter decorator

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -46,6 +46,7 @@ class Properties(BaseModel):
     # Required configurations from user
     model_id_or_path: str
     # Optional configurations with default values
+    model_dir: Optional[str] = None
     # Make the default to auto, after java front end changes and test cases are changed.
     rolling_batch: RollingBatchEnum = RollingBatchEnum.disable
     tensor_parallel_degree: int = 1
@@ -57,6 +58,7 @@ class Properties(BaseModel):
     dtype: Optional[str] = None
     revision: Optional[str] = None
     output_formatter: Optional[Union[str, Callable]] = None
+    input_formatter: Optional[Callable] = None
     waiting_steps: Optional[int] = None
     mpi_mode: bool = False
     tgi_compat: Optional[bool] = False

--- a/engines/python/setup/djl_python/request.py
+++ b/engines/python/setup/djl_python/request.py
@@ -28,7 +28,7 @@ class Request(object):
 
     """
 
-    def __init__(self, request_input: TextInput = None):
+    def __init__(self, request_input: RequestInput = None):
         """
         Initialize a request
 

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -132,7 +132,7 @@ class RequestInput:
         parameters: parameters in the request payload
         server_parameters: parameters that are modified by the built-in handlers to support backend engines.
     """
-    request_id: int
+    request_id: int = None
     output_formatter: Union[Callable, str] = None
     parameters: Dict = field(default_factory=lambda: {})
     server_parameters: Dict = field(default_factory=lambda: {})

--- a/engines/python/setup/djl_python_engine.py
+++ b/engines/python/setup/djl_python_engine.py
@@ -24,7 +24,7 @@ import sys
 from djl_python.arg_parser import ArgParser
 from djl_python.inputs import Input
 from djl_python.outputs import Output
-from djl_python.service_loader import load_model_service, has_function_in_module
+from djl_python.service_loader import load_model_service, has_function_in_module, get_annotated_function
 from djl_python.sm_log_filter import SMLogFilter
 
 SOCKET_ACCEPT_TIMEOUT = 30.0
@@ -55,6 +55,8 @@ class PythonEngine(object):
         self.cluster_size = args.cluster_size
         self.entry_point = args.entry_point
         self.recommended_entry_point = args.recommended_entry_point
+        self.input_formatter = get_annotated_function(args.model_dir,
+                                                      "is_input_formatter")
 
         if self.sock_type == "unix":
             if self.sock_name is None:
@@ -128,6 +130,8 @@ class PythonEngine(object):
                     self.service, prop["output_formatter"]):
                 prop["output_formatter"] = getattr(self.service,
                                                    prop["output_formatter"])
+            if self.input_formatter:
+                prop["input_formatter"] = self.input_formatter
             function_name = inputs.get_function_name()
             if not is_entry_point_verified:
                 if self.recommended_entry_point:


### PR DESCRIPTION
## Description ##
This PR introduces a new decorator `input_formatter`. Users are expected to annotate this in their input_formatter function in `model.py`. 

This PR also expects the user to define their input_formatter with signature 
```
def my_custom_input_formatter(input_item: Input, **kwargs) -> RequestInput:
```

Example of UX for users writing their own input formatter:

```
from djl_python import Input
from djl_python.input_parser import input_formatter
from djl_python.request_io import TextInput
from djl_python.encode_decode import decode

## **kwargs -> has most of the class attributes of TRTLLMService/HuggingFaceService
## example, for TRTLLMService, it has configs (serving.properties), tokenizer, rolling_batch

@input_formatter
def custom_input_formatter(input_item: Input, **kwargs):
    request_input = TextInput()
    content_type = input_item.get_property("Content-Type")
    input_map = decode(input_item, content_type)

    inputs = input_map.pop("inputs", input_map)
    params = input_map.pop("parameters", {})
    
    request_input.input_text = inputs
    request_input.parameters = params
    
    return request_input
```
