### PR TITLE
[serving][python] Support non 200 HTTP response codes for non-streami…

### DIFF
--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -115,6 +115,11 @@ class Sequence:
             return self.tokens[index], first_token, last_token
         return None, False, False
 
+    def get_last_token(self) -> Optional[Token]:
+        if self._last_token_index:
+            return self.tokens[self._last_token_index]
+        return None
+
     def get_next_top_tokens(self):
         """Returns the next list of top tokens from the top_tokens list, or None if all have been iterated."""
         if self.has_next_top_tokens():

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -11,6 +11,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import logging
+import json
 from abc import ABC, abstractmethod
 from typing import List
 
@@ -56,6 +57,9 @@ def stop_on_any_exception(func):
                 request.set_next_token(token,
                                        last_token=True,
                                        finish_reason="error")
+                request.set_error_message(str(e))
+                # TODO: make configurable
+                request.set_error_code(424)
             response = self.postprocess_results()
             self.reset()
             return response
@@ -134,6 +138,10 @@ class RollingBatch(ABC):
                 "last": req.is_last_token(),
                 "content_type": req.get_content_type()
             }
+            if req.get_error_message():
+                res["error"] = req.get_error_message()
+            if req.get_error_code():
+                res["code"] = req.get_error_code()
             req.reset_next_token()
             results.append(res)
 

--- a/engines/python/setup/djl_python/three_p/three_p_utils.py
+++ b/engines/python/setup/djl_python/three_p/three_p_utils.py
@@ -26,6 +26,7 @@ def parse_3p_request(input_map: dict, is_rolling_batch: bool, tokenizer,
     _param["temperature"] = input_map.pop("temperature", 0.5)
     _param["top_p"] = input_map.pop("top_p", 0.9)
     _param["max_new_tokens"] = input_map.pop("max_gen_len", 512)
+    _param["return_full_text"] = True
     if _param["temperature"] > 0:
         _param["do_sample"] = True
     if invoke_type == "InvokeEndpointWithResponseStream":

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -98,7 +98,7 @@ def rolling_batch_inference(parsed_input, inputs: Input, outputs: Output,
             outputs.add(Output.binary_encode(err), key="data", batch_index=i)
             outputs.add_property(f"batch_{i}_Content-Type", "application/json")
         else:
-            content_type = result[idx].pop("content_type")
+            content_type = result[idx].get("content_type")
             outputs.add(Output.binary_encode(result[idx]),
                         key="data",
                         batch_index=i)


### PR DESCRIPTION
…ng rolling-batch

1. Change non-streaming output formatters to only generate output on final token (valid and error cases)
2. Update InferenceRequestHandler to only publish HTTP Response when data is actually received
3. Update RollingBatch to properly set status code in non-streaming use-cases

Note:
- The ask for supporting non 200 HTTP responses has been asked for be a few users.

TODO:
- I need to update unit tests, but i have done extensive local testing and am comfortable with the core changes raised here. I'll change from WIP to Open once i complete the unit tests.
---

This change is motivated by two things:
- Make output formatters for non streaming use-cases easier to deal with, and more readable
- Provide non-200 HTTP status code in the non-streaming error cases.

The output formatters for non-streaming use-cases are currently pretty hard to reason about. Beyond just making it easier to read and work with, this also fixes an issue:
- If there is an error during generation after we have generated a few tokens, the current behavior results in a response that is not valid json. This change ensure that the output formatters we provide always result in valid json content in mid-generation error scenarios

The second part of this change is to provide non-200 status codes during non-streaming use-cases when an error occurs during inference. This is only possible with the first change to the output formatters. There are two small changes in InferenceRequestHandler and RollingBatch to enable this.
