### PR TITLE
[CI] Creates nightly pipeline

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,17 +1,19 @@
-name: OLD Build and push docker nightly
-# For use in building CVE patches for branches <= 0.28.0
+name: Docker Build
 
 on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'release/nightly/temp, default is nightly'
+        description: 'release/nightly, default is nightly'
         required: true
         default: 'nightly'
+        options:
+          - nightly
+          - release
   workflow_call:
     inputs:
       mode:
-        description: 'release/nightly/temp, default is nightly'
+        description: 'release/nightly, default is nightly'
         type: string
         required: true
         default: 'nightly'
@@ -35,12 +37,13 @@ jobs:
           $AGENT_TOOLSDIRECTORY
       - uses: actions/checkout@v4
       - name: Login to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: install awscli
         run: |
+          sudo dpkg --configure -a
           sudo apt-get update
           sudo apt-get install awscli -y
       - name: Configure AWS Credentials
@@ -68,14 +71,6 @@ jobs:
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
           export NIGHTLY="-nightly"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT ${{ matrix.arch }}
-          docker compose push ${{ matrix.arch }}
-      - name: Build and push temp image
-        if: ${{ inputs.mode == 'temp' }}
-        working-directory: serving/docker
-        run: |
-          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
-          export NIGHTLY="-nightly"
-          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT ${{ matrix.arch }}
           repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
           tempTag="$repo:${{ matrix.arch }}-${GITHUB_SHA}"
@@ -89,14 +84,11 @@ jobs:
           export BASE_RELEASE_VERSION="${DJL_VERSION}"
           export RELEASE_VERSION="${DJL_VERSION}-"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} ${{ matrix.arch }}
-          docker compose push ${{ matrix.arch }}
-      - name: Retag image for release
-        if: ${{ matrix.arch == 'cpu' && inputs.mode == 'release' }}
-        working-directory: serving/docker
-        run: |
-          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
-          docker tag deepjavalibrary/djl-serving:${DJL_VERSION} deepjavalibrary/djl-serving:latest
-          docker push deepjavalibrary/djl-serving:latest
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:${{ matrix.arch }}-${GITHUB_SHA}"
+          docker tag deepjavalibrary/djl-serving:${{ matrix.arch }}-nightly $tempTag
+          docker push $tempTag
 
   create-runner:
     runs-on: [ self-hosted, scheduler ]
@@ -134,7 +126,7 @@ jobs:
         run: |
           yes | docker system prune -a --volumes
       - name: Login to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -167,18 +159,11 @@ jobs:
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
           export NIGHTLY="-nightly"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT aarch64
-          docker compose push aarch64
-      - name: Build and push temp image
-        if: ${{ inputs.mode == 'temp' }}
-        working-directory: serving/docker
-        run: |
-          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
-          export NIGHTLY="-nightly"
-          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT aarch64
           repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
           tempTag="$repo:aarch64-${GITHUB_SHA}"
           docker tag deepjavalibrary/djl-serving:aarch64-nightly $tempTag
+          
           docker push $tempTag
       - name: Build and push release docker image
         if: ${{ inputs.mode == 'release' }}
@@ -188,7 +173,11 @@ jobs:
           export BASE_RELEASE_VERSION="${DJL_VERSION}"
           export RELEASE_VERSION="${DJL_VERSION}-"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} aarch64
-          docker compose push aarch64
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:aarch64-${GITHUB_SHA}"
+          docker tag deepjavalibrary/djl-serving:aarch64 $tempTag
+          docker push $tempTag
 
   nightly-lmi:
     runs-on: [ self-hosted, cpu ]
@@ -201,7 +190,7 @@ jobs:
         run: |
           yes | docker system prune -a --volumes
       - name: Login to Docker
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -229,14 +218,6 @@ jobs:
           ./gradlew --refresh-dependencies :serving:dockerDeb -Psnapshot
       - name: Build and push nightly docker image
         if: ${{ inputs.mode == '' || inputs.mode == 'nightly' }}
-        working-directory: serving/docker
-        run: |
-          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
-          export NIGHTLY="-nightly"
-          docker compose build --no-cache --build-arg djl_version=${DJL_VERSION}-SNAPSHOT lmi
-          docker compose push lmi
-      - name: Build and push temp image
-        if: ${{ inputs.mode == 'temp' }}
         working-directory: serving/docker
         run: |
           DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
@@ -255,7 +236,11 @@ jobs:
           export BASE_RELEASE_VERSION="${DJL_VERSION}"
           export RELEASE_VERSION="${DJL_VERSION}-"
           docker compose build --no-cache --build-arg djl_version=${DJL_VERSION} lmi
-          docker compose push lmi
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          tempTag="$repo:lmi-$GITHUB_SHA"
+          docker tag deepjavalibrary/djl-serving:lmi $tempTag
+          docker push lmi
 
   stop-runner:
     if: always()

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,100 @@
+name: Sync docker and ECR repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        required: true
+        default: 'nightly'
+        options:
+          - nightly
+          - release
+  workflow_call:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        type: string
+        required: true
+        default: 'nightly'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  create-aarch64-runner:
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new Graviton instance
+        id: create_aarch64
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_graviton $token djl-serving
+    outputs:
+      aarch64_instance_id: ${{ steps.create_aarch64.outputs.action_graviton_instance_id }}
+
+  nightly-aarch64:
+    runs-on: [ self-hosted, aarch64 ]
+    timeout-minutes: 60
+    needs: create-aarch64-runner
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean docker env
+        working-directory: serving/docker
+        run: |
+          yes | docker system prune -a --volumes
+      - name: Login to Docker
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: install awscli
+        run: |
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
+      - name: Pull and sync to docker hub
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          repo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          ./scripts/pull_and_retag.sh $DJL_VERSION deepjavalibrary/djl-serving ${{ inputs.mode }}
+      - name: Pull and sync to ECR
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          repo="125045733377.dkr.ecr.us-east-1.amazonaws.com/djl-serving"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          ./scripts/pull_and_retag.sh $DJL_VERSION $repo ${{ inputs.mode }}
+      - name: Retag image for release latest
+        if: ${{ inputs.mode == 'release' }}
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          docker tag deepjavalibrary/djl-serving:${DJL_VERSION} deepjavalibrary/djl-serving:latest
+          docker push deepjavalibrary/djl-serving:latest
+      - name: Clean docker env
+        working-directory: serving/docker
+        run: |
+          yes | docker system prune -a --volumes
+
+  stop-aarch64-runner:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [nightly-aarch64, create-aarch64-runner]
+    steps:
+      - name: Stop all instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-aarch64-runner.outputs.aarch64_instance_id }}
+          ./stop_instance.sh $instance_id

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,11 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       djl-version:
-        description: 'The released version of DJL'
+        description: 'The released version of DJL. Can be "nightly", "temp", or a DJL release version like "0.28.0"'
         required: false
-        default: ''
-  schedule:
-    - cron: '0 15 * * *'
+        default: 'temp'
+  workflow_call:
+    inputs:
+      djl-version:
+        description: 'The released version of DJL. Can be "nightly", "temp", or a DJL release version like "0.28.0"'
+        type: string
+        required: false
+        default: 'temp'
+
 
 
 jobs:
@@ -148,6 +154,15 @@ jobs:
         # Torch version doesn't really matter that much
         run: |
           pip3 install torch==2.3.0
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
+      - name: Login for temp
+        if: ${{ inputs.djl-version == 'temp' }}
+        run: |
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp
       - name: Install awscurl
         working-directory: tests/integration
         run: |

--- a/.github/workflows/integration_execute.yml
+++ b/.github/workflows/integration_execute.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   build-temp:
     if: ${{ inputs.djl-version == 'temp' }}
-    uses: ./.github/workflows/docker-nightly-publish.yml
+    uses: ./.github/workflows/docker_build.yml
     secrets: inherit
     with:
       mode: temp

--- a/.github/workflows/nightly-docker-ecr-sync.yml
+++ b/.github/workflows/nightly-docker-ecr-sync.yml
@@ -1,4 +1,5 @@
-name: Sync docker and ECR repo
+name: OLD Sync docker and ECR repo
+# For use in building CVE patches for branches <= 0.28.0
 
 on:
   workflow_dispatch:
@@ -7,8 +8,6 @@ on:
         description: 'version string like 0.27.0, default is nightly'
         required: true
         default: 'nightly'
-  schedule:
-    - cron: '0 14 * * *'
 
 jobs:
   create-aarch64-runner:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,46 @@
+name: Nightly Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        required: true
+        default: 'nightly'
+        options:
+          - nightly
+          - release
+  workflow_call:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        type: string
+        required: true
+        default: 'nightly'
+  schedule:
+    - cron: '0 13 * * *'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/docker_build.yml
+    secrets: inherit
+    with:
+      mode: ${{ inputs.mode }}
+  integration:
+    needs: [build]
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+    with:
+      djl-version: 'temp'
+  publish:
+    needs:
+      - build
+#      - integration # Uncomment to enable verified publishing only
+    uses: ./.github/workflows/docker_publish.yml
+    secrets: inherit
+    with:
+      mode: ${{ inputs.mode }}

--- a/serving/docker/scripts/pull_and_retag.sh
+++ b/serving/docker/scripts/pull_and_retag.sh
@@ -2,19 +2,22 @@
 
 version=$1
 repo=$2
+mode=$3
 images="cpu aarch64 cpu-full pytorch-inf2 pytorch-gpu lmi tensorrt-llm"
 
+temprepo="185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+
 for image in $images; do
-  if [[ ! "$version" == "nightly" ]]; then
+  if [[ ! "$mode" == "nightly" ]]; then
     if [[ "$image" == "cpu" ]]; then
-      image=$version
+      tag=$version
     else
-      image="$version-$image"
+      tag="$version-$image"
     fi
   else
-    image="$image-$version"
+    tag="$image-nightly"
   fi
-  docker pull deepjavalibrary/djl-serving:$image
-  docker tag deepjavalibrary/djl-serving:$image $repo/djl-serving:$image
-  docker push $repo/djl-serving:$image
+  docker pull $temprepo:$image-$GITHUB_SHA
+  docker tag $temprepo:$image-$GITHUB_SHA $repo:$tag
+  docker push $repo:$tag
 done


### PR DESCRIPTION
This creates a full nightly pipeline for the build, test, and release.

First, it enables a full build through temp repo approach. The build will always go to the temp repo in docker_build.yml, and then the separate docker_publish.yml can be used for the actual release step.

Following this, it also enables the integration suite to test the temp repo similarly to the integration runner.

Finally, a new action "Nightly Pipeline" is enabled to pull it all together. Right now, it will publish regardless of the result of the test. This matches the current behavior. When it changes in the future, the testing can be enabled through un-commenting the line.

@tosterberg 