### PR TITLE
[Partiton] Don't output `option.parallel_loading` when partitioning

### DIFF
--- a/serving/docker/partition/utils.py
+++ b/serving/docker/partition/utils.py
@@ -43,9 +43,10 @@ def get_partition_cmd(is_mpi_mode, properties):
 
 def get_engine_configs(properties):
     engine = properties.get('engine')
-    configs = {'option.parallel_loading': True}
+    configs = {}
     if engine == 'DeepSpeed':
         configs['option.checkpoint'] = 'ds_inference_config.json'
+        configs['option.parallel_loading'] = True
 
     return configs
 


### PR DESCRIPTION
## Description ##

Changes partition script behavior to only output `option.parallel_loading=true` when handler=DeepSpeed. No longer outputs this field for Neuron & LMI handlers.
