### PR TITLE
[cherrypick][0.28.0 dlc] Neo fixes (#2189) (#2115) (#2095)

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -28,6 +28,11 @@ from transformers_neuronx.module import save_pretrained_split
 from djl_python.neuron_utils.utils import NeuronXModelAdapter, get_neuronxcc_version
 from huggingface_hub import hf_hub_download
 
+# Temporary Fix: These loggers are disabled during vLLM import.
+# Remove when fixed in vLLM
+logging.getLogger("NEURON_CC_WRAPPER").disabled = False
+logging.getLogger("NEURON_CACHE").disabled = False
+
 
 class ModelLoader(ABC):
 

--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -39,7 +39,6 @@ class NeoQuantizationService():
         self.OUTPUT_MODEL_DIRECTORY: Final[str] = env[2]
         self.COMPILATION_ERROR_FILE: Final[str] = env[3]
         self.HF_CACHE_LOCATION: Final[str] = env[5]
-        self.TARGET_INSTANCE_TYPE: Final[str] = env[6]
 
     def update_dataset_cache_location(self):
         logging.info(

--- a/serving/docker/partition/utils.py
+++ b/serving/docker/partition/utils.py
@@ -43,9 +43,10 @@ def get_partition_cmd(is_mpi_mode, properties):
 
 def get_engine_configs(properties):
     engine = properties.get('engine')
-    configs = {'option.parallel_loading': True}
+    configs = {}
     if engine == 'DeepSpeed':
         configs['option.checkpoint'] = 'ds_inference_config.json'
+        configs['option.parallel_loading'] = True
 
     return configs
 


### PR DESCRIPTION
## Description ##

Cherry-pick for the following Neo fixes for v10 containers
587fa2241665cc3702e9a0d2b897a8a0ac01caa2 - [[Link to PR](https://github.com/deepjavalibrary/djl-serving/pull/2189)] - Today's fix of parallel_loading
88f84ba7c127c1e639b3527cae6128d0e9e97730 - [[Link to PR](https://github.com/deepjavalibrary/djl-serving/pull/2115)] - Various Neo script fixes for QuickSilver
ac4acb8b860e45d4138186a9522edc8449c166ad - [[Link to PR](https://github.com/deepjavalibrary/djl-serving/pull/2095/commits)] - vLLM logging fix

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
