### PR TITLE
[chat][lmi] use generation prompt in tokenizer to avoid bot prompt re…

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/chat_utils.py
@@ -41,7 +41,7 @@ def parse_chat_completions_request(input_map: Dict,
         tokenizer_inputs.append(
             message.get_tokenizer_inputs(image_token=image_token))
         images.extend(message.get_images())
-    inputs = tokenizer.apply_chat_template(tokenizer_inputs, tokenize=False)
+    inputs = apply_chat_template(tokenizer, tokenizer_inputs)
     param[
         "do_sample"] = chat_params.temperature is not None and chat_params.temperature > 0.0
     param["details"] = True  # Enable details for chat completions
@@ -52,3 +52,15 @@ def parse_chat_completions_request(input_map: Dict,
         param["images"] = images
 
     return inputs, param
+
+
+def apply_chat_template(tokenizer, inputs):
+    try:
+        inputs = tokenizer.apply_chat_template(inputs,
+                                               tokenize=False,
+                                               add_generation_prompt=True)
+        return inputs
+    except Exception as e:
+        # add_generation_prompt doesn't work for all tokenizers...
+        # This is a workaround for now until we can verify it works for all tokenizers
+        return tokenizer.apply_chat_template(inputs, tokenize=False)


### PR DESCRIPTION
…turned in response

## Description ##
Enabling this flag appends the bot instruction to the prompt.

If no bot instruction exists for the tokenizer chat template, it has no effect. See https://huggingface.co/docs/transformers/main/en/chat_templating#what-are-generation-prompts.

As a result, the bot instruction text is not returned to the user in chat use-cases. It would still be returned to the users if using LMI/TGI api and specifying "return_full_text": true.
