### PR TITLE
[aot] fix aot partition args, add pipeline parallel

### DIFF
--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -301,6 +301,10 @@ def main():
         type=str,
         required=False,
         help='local path or s3 uri to save/upload the partitioned checkpoints')
+    parser.add_argument('--pipeline-parallel-degree',
+                        type=str,
+                        required=False,
+                        help='pipeline parallel degree')
     parser.add_argument('--tensor-parallel-degree',
                         type=str,
                         required=False,


### PR DESCRIPTION
## Description ##

CI is failing for Neuron for AOT due to pipeline parallel being added to properties_manager.py in partitioning but not in the partion.py parse args. This adds the argument and fixes the CI.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
