### PR TITLE
Update max_model_len for llama-3 lora test

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -556,6 +556,8 @@ lmi_dist_model_list = {
         "adapter_names": ["french", "spanish"],
         "option.gpu_memory_utilization":
         "0.8",
+        "option.max_model_len":
+        65528,
     },
     "llama-2-tiny": {
         "option.model_id": "s3://djl-llm/llama-2-tiny/",
@@ -730,6 +732,8 @@ vllm_model_list = {
         "adapter_names": ["french", "spanish"],
         "option.gpu_memory_utilization":
         "0.8",
+        "option.max_model_len":
+        65528,
     },
     "starcoder2-7b": {
         "option.model_id": "s3://djl-llm/bigcode-starcoder2",


### PR DESCRIPTION
## Description ##

Seems like llama3 checkpoint used in the test was updated with `max_model_len` greater than what's supported for lora. Explicitly setting value to maximum supported value for lora.
