### PR TITLE
[ci] fix hf lora test for accelerate

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -47,6 +47,7 @@ hf_handler_list = {
     "gpt4all-lora": {
         "option.model_id": "s3://djl-llm/gpt4all-lora/",
         "option.tensor_parallel_degree": 4,
+        "option.device_map": "auto",
         "option.task": "text-generation",
         "option.dtype": "fp16"
     }


### PR DESCRIPTION
## Description ##

Previous to pipeline_parallel being added to hf properties, the base behavior for TP > 0 would initiate device mapping as auto. With the addition of pipeline_parallel it now also requires pipeline_parallel to be set PP > 0. Both of these values default value is -1, so this changed the default behavior.

I have fixed this by specifically adding the device mapping, but we should consider reverting the issue above.
https://github.com/deepjavalibrary/djl-serving/blob/master/engines/python/setup/djl_python/properties_manager/hf_properties.py#L116-L137
