### PR TITLE
determine bedrock usage based on explicit property rather than inferr…

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -21,7 +21,7 @@ from djl_python.encode_decode import decode
 from djl_python.properties_manager.properties import is_rolling_batch_enabled
 from djl_python.request import Request
 from djl_python.request_io import TextInput, RequestInput
-from djl_python.three_p.three_p_utils import is_3p_request, parse_3p_request
+from djl_python.three_p.three_p_utils import parse_3p_request
 
 
 def input_formatter(function):
@@ -128,13 +128,17 @@ def parse_text_inputs_params(request_input: TextInput, input_item: Input,
     invoke_type = input_item.get_property("X-Amzn-SageMaker-Forwarded-Api")
     tokenizer = kwargs.get("tokenizer")
     image_token = kwargs.get("image_placeholder_token")
+    configs = kwargs.get("configs")
+    is_bedrock = False
+    if configs is not None:
+        is_bedrock = configs.bedrock_compat
     if is_chat_completions_request(input_map):
         inputs, param = parse_chat_completions_request(
             input_map,
             kwargs.get("is_rolling_batch"),
             tokenizer,
             image_token=image_token)
-    elif is_3p_request(invoke_type):
+    elif is_bedrock:
         inputs, param = parse_3p_request(input_map,
                                          kwargs.get("is_rolling_batch"),
                                          tokenizer, invoke_type)

--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -62,6 +62,7 @@ class Properties(BaseModel):
     waiting_steps: Optional[int] = None
     mpi_mode: bool = False
     tgi_compat: Optional[bool] = False
+    bedrock_compat: Optional[bool] = False
 
     # Spec_dec
     draft_model_id: Optional[str] = None

--- a/engines/python/setup/djl_python/three_p/three_p_utils.py
+++ b/engines/python/setup/djl_python/three_p/three_p_utils.py
@@ -10,13 +10,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-from typing import Optional
-
-
-def is_3p_request(invoke_type: Optional[str]) -> bool:
-    # TODO, not sure if this is reliable
-    # We might want to just use an env var since in the 3p env will will only run in 1 way
-    return invoke_type == "InvokeEndpoint" or invoke_type == "InvokeEndpointWithResponseStream"
 
 
 def parse_3p_request(input_map: dict, is_rolling_batch: bool, tokenizer,


### PR DESCRIPTION
…ed from header

## Description ##

This change makes it so that we do not infer the bedrock schema based on the http header. To enable bedrock behavior, user must specify `OPTION_BEDROCK_COMPAT=true` config.

Validated locally with lmi/trt containers