### PR TITLE
[tnx] fix optimum token selection and sampling

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_modeling.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_modeling.py
@@ -25,7 +25,7 @@ from tempfile import TemporaryDirectory
 from transformers import PretrainedConfig
 from transformers_neuronx import bucket
 from transformers_neuronx.constants import LAYOUT_BSH, LAYOUT_HSB
-from optimum.neuron.generation import TokenSelector
+from djl_python.transformers_neuronx_scheduler.optimum_token_selector import OptimumTokenSelector
 from optimum.neuron.utils.version_utils import check_compiler_compatibility, get_neuronxcc_version
 from optimum.modeling_base import OptimizedModel
 from transformers.generation import StoppingCriteriaList
@@ -238,11 +238,12 @@ class OptimumModelForCausalLM(OptimizedModel, GenerationMixin):
         self._validate_model_kwargs(model_kwargs)
 
         # Instantiate a TokenSelector for the specified configuration
-        selector = TokenSelector.create(input_ids,
-                                        generation_config,
-                                        self,
-                                        self.max_length,
-                                        stopping_criteria=stopping_criteria)
+        selector = OptimumTokenSelector.create(
+            input_ids,
+            generation_config,
+            self,
+            self.max_length,
+            stopping_criteria=stopping_criteria)
 
         # Verify that the inputs are compatible with the model static input dimensions
         batch_size, sequence_length = input_ids.shape
@@ -280,7 +281,7 @@ class OptimumModelForCausalLM(OptimizedModel, GenerationMixin):
     def generate_tokens(
         self,
         input_ids: torch.LongTensor,
-        selector: TokenSelector,
+        selector: OptimumTokenSelector,
         batch_size: int,
         attention_mask: Optional[torch.Tensor] = None,
         **model_kwargs,
@@ -291,7 +292,7 @@ class OptimumModelForCausalLM(OptimizedModel, GenerationMixin):
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 The sequence used as a prompt for the generation.
-            selector (`TokenSelector`):
+            selector (`OptimumTokenSelector`):
                 The object implementing the generation logic based on transformers processors and stopping criterias.
             batch_size (`int`):
                 The actual input batch size. Used to avoid generating tokens for padded inputs.

--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
@@ -24,7 +24,6 @@ from transformers import PreTrainedTokenizerBase
 from dataclasses import dataclass
 
 from djl_python.transformers_neuronx_scheduler.slot import Slot
-from djl_python.rolling_batch.rolling_batch import filter_unused_generation_params
 from djl_python.request import Request
 from djl_python.transformers_neuronx_scheduler.token_selector import TokenSelector
 from djl_python.transformers_neuronx_scheduler.speculation import (


### PR DESCRIPTION
## Description ##

Fix transformers issue with optimum token selection post 4.43 update. Fix sampling for rolling batch post transformers bump.

OptimumTokenSelector is a copy of optimum-neuron's token selector but upgraded to work with transfomers 4.43, and can be removed and reverted after the dependencies are updated to support llama3.1
