### PR TITLE
[multimodal] add additional vlm architectures to lmi config recommender

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -68,7 +68,10 @@ public final class LmiConfigRecommender {
                     Map.entry("llava", "lmi-dist"),
                     Map.entry("llava_next", "lmi-dist"),
                     Map.entry("paligemma", "lmi-dist"),
-                    Map.entry("phi3_v", "lmi-dist"));
+                    Map.entry("phi3_v", "lmi-dist"),
+                    // vllm 0.5.3
+                    Map.entry("chameleon", "lmi-dist"),
+                    Map.entry("fuyu", "lmi-dist"));
 
     private static final Set<String> OPTIMIZED_TASK_ARCHITECTURES =
             Set.of("ForCausalLM", "LMHeadModel", "ForConditionalGeneration");


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
