### PR TITLE
[multimodal][ci] do not use tp for paligemma due to issues in vllm

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -579,7 +579,8 @@ lmi_dist_model_list = {
         "option.model_id": "s3://djl-llm/llava-v1.6-mistral-7b-hf/",
     },
     "paligemma-3b-mix-448": {
-        "option.model_id": "s3://djl-llm/paligemma-3b-mix-448/"
+        "option.model_id": "s3://djl-llm/paligemma-3b-mix-448/",
+        "option.tensor_parallel_degree": 1,
     },
     "phi-3-vision-128k-instruct": {
         "option.model_id": "s3://djl-llm/phi-3-vision-128k-instruct/",


### PR DESCRIPTION
## Description ##

Paligemma has an issue with tensor parallelism in vllm due to some issue in the preprocessing.

I have raise a bug with vllm https://github.com/vllm-project/vllm/issues/6910.


The failure that was occurring with phi3v was due to not including the custom modeling files in s3 - i have fixed that.