### PR TITLE
[ci] add handler performance test

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -10,6 +10,21 @@ permissions:
   contents: read
 
 jobs:
+  create-runners:
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new G6 instance
+        id: create_gpu
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_g6 $token djl-serving
+    outputs:
+      gpu_instance_id: ${{ steps.create_gpu.outputs.action_g6_instance_id }}
+
   g5-2xl:
     uses: ./.github/workflows/instant_benchmark.yml
     secrets: inherit
@@ -31,3 +46,75 @@ jobs:
       running_template: ./benchmark/nightly/g5-48xl.txt
       instance: g5.48xlarge
       record: cloudwatch
+
+  handler-performance-test:
+    runs-on: [ self-hosted, g6 ]
+    timeout-minutes: 60
+    needs: create-runners
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - test: TestGPUHandlerPerformance
+            instance: g6
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean env
+        run: |
+          yes | docker system prune -a --volumes
+          sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
+          echo "wait dpkg lock..."
+          while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 5; done
+      - name: Set up Python3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.x'
+      - name: Install pip dependencies
+        run: pip3 install pytest requests "numpy<2" pillow huggingface_hub
+      - name: Install torch
+        # Use torch to get cuda capability of current device to selectively run tests
+        # Torch version doesn't really matter that much
+        run: |
+          pip3 install torch==2.3.0
+      - name: Install awscurl
+        working-directory: tests/integration
+        run: |
+          wget https://publish.djl.ai/awscurl/awscurl
+          chmod +x awscurl
+          mkdir outputs
+      - name: Test
+        working-directory: tests/integration
+        env:
+          TEST_DJL_VERSION: nightly
+        run: |
+          python -m pytest -k ${{ matrix.test.test }} tests.py
+      - name: Cleanup
+        working-directory: tests/integration
+        run: |
+          rm -rf outputs
+          rm awscurl
+      - name: On Failure
+        if: ${{ failure() }}
+        working-directory: tests/integration
+        run: |
+          for file in outputs/*; do if [ -f "$file" ]; then echo "Contents of $file:"; cat "$file"; echo; fi; done
+          sudo rm -rf outputs && sudo rm -rf models
+          rm awscurl
+          ./remove_container.sh
+      - name: Upload test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-${{ matrix.test.test }}-logs
+          path: tests/integration/all_logs/
+
+  stop-g6-runners:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [ create-runners, handler-performance-test ]
+    steps:
+      - name: Stop g6 instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-runners.outputs.gpu_instance_id }}
+          ./stop_instance.sh $instance_id

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -981,6 +981,29 @@ text_embedding_model_list = {
     }
 }
 
+handler_performance_model_list = {
+    "tiny-llama-lmi": {
+        "engine": "MPI",
+        "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        "option.rolling_batch": "lmi-dist",
+        "option.max_rolling_batch_size": 512,
+    },
+    "tiny-llama-vllm": {
+        "engine": "Python",
+        "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        "option.task": "text-generation",
+        "option.rolling_batch": "vllm",
+        "option.gpu_memory_utilization": "0.9",
+        "option.max_rolling_batch_size": 512,
+    },
+    "tiny-llama-trtllm": {
+        "engine": "Python",
+        "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        "option.rolling_batch": "trtllm",
+        "option.max_rolling_batch_size": 512,
+    },
+}
+
 
 def write_model_artifacts(properties,
                           requirements=None,
@@ -1159,6 +1182,15 @@ def build_correctness_model(model):
     write_model_artifacts(options)
 
 
+def build_handler_performance_model(model):
+    if model not in handler_performance_model_list.keys():
+        raise ValueError(
+            f"{model} is not one of the supporting handler {list(handler_performance_model_list.keys())}"
+        )
+    options = handler_performance_model_list[model]
+    write_model_artifacts(options)
+
+
 def build_text_embedding_model(model):
     if model not in text_embedding_model_list:
         raise ValueError(
@@ -1176,6 +1208,7 @@ supported_handler = {
     'transformers_neuronx': build_transformers_neuronx_handler_model,
     'transformers_neuronx_aot': build_transformers_neuronx_aot_handler_model,
     'performance': build_performance_model,
+    'handler_performance': build_handler_performance_model,
     'rolling_batch_scheduler': build_rolling_batch_model,
     'lmi_dist': build_lmi_dist_model,
     'lmi_dist_aiccl': build_lmi_dist_aiccl_model,

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -15,3 +15,4 @@ markers =
 
     lora: Tests lora feature
     correctness: Correctness tests
+    handler_performance: Handler performance tests

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -926,3 +926,26 @@ class TestTextEmbedding:
             prepare.build_text_embedding_model("bge-reranker")
             r.launch()
             client.run("reranking bge-reranker".split())
+
+
+@pytest.mark.gpu
+@pytest.mark.handler_performance
+class TestGPUHandlerPerformance:
+
+    def test_lmi_dist(self):
+        with Runner('lmi', 'handler-performance-lmi-dist') as r:
+            prepare.build_handler_performance_model("tiny-llama-lmi")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance lmi".split())
+
+    def test_vllm(self):
+        with Runner('lmi', 'handler-performance-vllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-vllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance vllm".split())
+
+    def test_trtllm(self):
+        with Runner('tensorrt-llm', 'handler-performance-trtllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-trtllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance trtllm".split())


### PR DESCRIPTION
## Description ##

This PR adds nightly benchmarking for our main GPU handlers (lmi-dist, vllm, trtllm), using tiny-llama it does performance testing for batch size 1 and 128 for both the standard and chat template inference paths. The performance metrics are persisted to cloudwatch for monitoring.
