### PR TITLE
[ci] add files for triggering old workflows

### DIFF
--- a/.github/workflows/llm_inf2_integration.yml
+++ b/.github/workflows/llm_inf2_integration.yml
@@ -1,0 +1,21 @@
+name: Inferentia2 integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      djl-version:
+        description: 'The released version of DJL'
+        required: false
+        default: ''
+
+
+jobs:
+  fast-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if run on master branch
+        id: fast_fail
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "Fast fail"
+          exit 1

--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -1,0 +1,21 @@
+name: Large model integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      djl-version:
+        description: 'The released version of DJL'
+        required: false
+        default: ''
+
+
+jobs:
+  fast-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if run on master branch
+        id: fast_fail
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "Fast fail"
+          exit 1


### PR DESCRIPTION
## Description ##

This PR adds fast fail workflows that stand in for manually triggered workflows on release branches. These files should be retained until maintenance windows have passed for 0.28.0-dlc release branch.
