### PR TITLE
[ci] Update neuron tests to mirror observed mistral/mixtral support

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -139,20 +139,15 @@ transformers_neuronx_model_spec = {
         "batch_size": [2],
         "stream_output": True,
     },
-    "mistral-7b": {
-        "worker": 1,
-        "seq_length": [128, 256],
+    "mixtral-8x7b": {
         "batch_size": [4],
+        "seq_length": [256],
+        "tokenizer": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO"
     },
     "mistral-7b-rb": {
         "batch_size": [1, 4],
         "seq_length": [256],
         "tokenizer": "amazon/MegaBeam-Mistral-7B-300k"
-    },
-    "mixtral-8x7b-rb": {
-        "batch_size": [4],
-        "seq_length": [256],
-        "tokenizer": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO"
     },
     "llama-7b-rb": {
         "batch_size": [1, 4],

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -167,13 +167,12 @@ transformers_neuronx_handler_list = {
         "option.dtype": "fp16",
         "option.model_loading_timeout": 1200
     },
-    "mistral-7b": {
-        "option.model_id": "s3://djl-llm/mistral-7b/",
+    "mixtral-8x7b": {
+        "option.model_id": "s3://djl-llm/mixtral-8x7b/",
+        "option.tensor_parallel_degree": 8,
+        "option.n_positions": 1024,
         "batch_size": 4,
-        "option.tensor_parallel_degree": 4,
-        "option.dtype": "fp16",
-        "option.n_positions": 512,
-        "option.model_loading_timeout": 2400,
+        "option.model_loading_timeout": 3600,
     },
     "opt-1.3b-streaming": {
         "option.model_id": "s3://djl-llm/opt-1.3b/",
@@ -247,22 +246,12 @@ transformers_neuronx_handler_list = {
         "option.output_formatter": "jsonlines"
     },
     "mistral-7b-rb": {
-        "option.model_id": "s3://djl-llm/mistral-7b/",
+        "option.model_id": "s3://djl-llm/mistral-7b-instruct-v02/",
+        "option.rolling_batch": "auto",
+        "option.max_rolling_batch_size": 4,
         "option.tensor_parallel_degree": 4,
-        "option.n_positions": 512,
-        "option.max_rolling_batch_size": 4,
-        "option.rolling_batch": 'auto',
-        "option.model_loading_timeout": 2400,
-        "option.output_formatter": "jsonlines"
-    },
-    "mixtral-8x7b-rb": {
-        "option.model_id": "s3://djl-llm/mixtral-8x7b/",
-        "option.tensor_parallel_degree": 8,
         "option.n_positions": 1024,
-        "option.max_rolling_batch_size": 4,
-        "option.rolling_batch": 'auto',
-        "option.model_loading_timeout": 3600,
-        "option.output_formatter": "jsonlines"
+        "option.model_loading_timeout": 2400,
     },
     "llama-speculative-rb": {
         "option.model_id": "s3://djl-llm/llama-2-13b-hf/",

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -755,11 +755,12 @@ class TestNeuronx2:
             r.launch(container='pytorch-inf2-6')
             client.run("transformers_neuronx opt-1.3b-streaming".split())
 
-    def test_mistral(self):
-        with Runner('pytorch-inf2', 'mistral-7b') as r:
-            prepare.build_transformers_neuronx_handler_model("mistral-7b")
-            r.launch(container='pytorch-inf2-2')
-            client.run("transformers_neuronx mistral-7b".split())
+    def test_mixtral(self):
+        with Runner('pytorch-inf2', 'mixtral-8x7b') as r:
+            prepare.build_transformers_neuronx_handler_model("mixtral-8x7b")
+            r.launch(container='pytorch-inf2-4')
+            client.run(
+                "transformers_neuronx_rolling_batch mixtral-8x7b".split())
 
     def test_stable_diffusion_1_5(self):
         with Runner('pytorch-inf2', 'stable-diffusion-1.5-neuron') as r:
@@ -812,12 +813,11 @@ class TestNeuronxRollingBatch:
             client.run("transformers_neuronx_rolling_batch llama-3-8b-rb-vllm".
                        split())
 
-    def test_mixtral(self):
-        with Runner('pytorch-inf2', 'mixtral-8x7b-rb') as r:
-            prepare.build_transformers_neuronx_handler_model("mixtral-8x7b-rb")
-            r.launch(container='pytorch-inf2-4')
-            client.run(
-                "transformers_neuronx_rolling_batch mixtral-8x7b-rb".split())
+    def test_mistral(self):
+        with Runner('pytorch-inf2', 'mistral-7b-rb') as r:
+            prepare.build_transformers_neuronx_handler_model("mistral-7b-rb")
+            r.launch(container='pytorch-inf2-2')
+            client.run("transformers_neuronx mistral-7b-rb".split())
 
     def test_llama_speculative(self):
         with Runner('pytorch-inf2', 'llama-speculative-rb') as r:


### PR DESCRIPTION
## Description ##

With 2.19.1 - Mistral v2 models work with continuous batching, Mistral v1 with windowed context sill does not work and as such the Mixtral rolling batch test was moved to a dynamic batch test until it is resolved.
