### PR TITLE
[ci] fix auto awq integration test failure

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -563,7 +563,8 @@ lmi_dist_model_list = {
     "llama-2-tiny": {
         "option.model_id": "s3://djl-llm/llama-2-tiny/",
         "option.quantize": "awq",
-        "option.tensor_parallel_degree": 4
+        "option.tensor_parallel_degree": 4,
+        "option.device_map": "auto"
     },
     "llava_v1.6-mistral": {
         "option.model_id": "s3://djl-llm/llava-v1.6-mistral-7b-hf/",


### PR DESCRIPTION
## Description ##

AutoAwq error seems to be happening with 4.43.2 transformers version. https://github.com/casper-hansen/AutoAWQ/issues/558

As suggested in the issue, setting device_map to auto, resolves the error. 
