### PR TITLE
Add support for Llama-3-8B fp8 quantization with TensorRT LLM

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -816,8 +816,7 @@ correctness_model_spec = {
         "tokenizer": "TheBloke/Llama-2-7B-fp16",
         "dataset": "mmlu",
         "score": 0.6
-    },
-
+    }
 }
 
 multi_modal_spec = {

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -808,6 +808,14 @@ correctness_model_spec = {
         "tokenizer": "TheBloke/Llama-2-7B-fp16",
         "dataset": "mmlu",
         "score": 0.6
+    },
+    "trtllm-meta-llama3-8b-fp8": {
+        "batch_size": [213],
+        "seq_length": [1],
+        "num_run": 66,
+        "tokenizer": "TheBloke/Llama-2-7B-fp16",
+        "dataset": "mmlu",
+        "score": 0.6
     }
 }
 

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -808,6 +808,30 @@ correctness_model_spec = {
         "tokenizer": "TheBloke/Llama-2-7B-fp16",
         "dataset": "mmlu",
         "score": 0.6
+    },
+    "trtllm-meta-llama-3-8b-fp8": {
+        "batch_size": [213],
+        "seq_length": [1],
+        "num_run": 66,
+        "tokenizer": "TheBloke/Llama-2-7B-fp16",
+        "dataset": "mmlu",
+        "score": 0.6
+    },
+    "trtllm-mistral-b-instruct-v0.3-fp8": {
+        "batch_size": [213],
+        "seq_length": [1],
+        "num_run": 66,
+        "tokenizer": "amazon/MegaBeam-Mistral-7B-300k",
+        "dataset": "mmlu",
+        "score": 0.6
+    },
+    "trtllm-meta-llama3-8b-fp8": {
+        "batch_size": [213],
+        "seq_length": [1],
+        "num_run": 66,
+        "tokenizer": "TheBloke/Llama-2-7B-fp16",
+        "dataset": "mmlu",
+        "score": 0.6
     }
 }
 
@@ -861,7 +885,7 @@ def remove_file_handler_from_logger(handler):
 
 def modelspec_checker(model: str, model_spec: dict):
     if model not in model_spec:
-        msg = f"{args.model} is not one of the supporting models {list(model_spec.keys())}"
+        msg = f"{args.model} 4 is not one of the supporting models {list(model_spec.keys())}"
         LOGGER.error(msg)
         raise ValueError(msg)
 
@@ -964,7 +988,7 @@ def awscurl_run(data,
     endpoint = f"http://127.0.0.1:8080/invocations"
     if dataset:
         dataset_dir = os.path.join(os.path.curdir, "dataset")
-        os.mkdir(dataset_dir)
+        os.makedirs(dataset_dir, exist_ok=True)
         for i, d in enumerate(data):
             with open(os.path.join(dataset_dir, f"prompt{i}.txt"), "w") as f:
                 f.write(json.dumps(d))
@@ -1621,7 +1645,7 @@ def test_transformers_neuronx_handler(model, model_spec):
 def test_correctness(model, model_spec):
     if model not in model_spec:
         raise ValueError(
-            f"{model} is not one of the supporting models {list(model_spec.keys())}"
+            f"{model} 5 is not one of the supporting models {list(model_spec.keys())}"
         )
     spec = model_spec[model]
     score = float(spec.get("score", 0.5))

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -816,7 +816,8 @@ correctness_model_spec = {
         "tokenizer": "TheBloke/Llama-2-7B-fp16",
         "dataset": "mmlu",
         "score": 0.6
-    }
+    },
+
 }
 
 multi_modal_spec = {
@@ -972,7 +973,7 @@ def awscurl_run(data,
     endpoint = f"http://127.0.0.1:8080/invocations"
     if dataset:
         dataset_dir = os.path.join(os.path.curdir, "dataset")
-        os.mkdir(dataset_dir)
+        os.makedirs(dataset_dir, exist_ok=True)
         for i, d in enumerate(data):
             with open(os.path.join(dataset_dir, f"prompt{i}.txt"), "w") as f:
                 f.write(json.dumps(d))

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -808,30 +808,6 @@ correctness_model_spec = {
         "tokenizer": "TheBloke/Llama-2-7B-fp16",
         "dataset": "mmlu",
         "score": 0.6
-    },
-    "trtllm-meta-llama-3-8b-fp8": {
-        "batch_size": [213],
-        "seq_length": [1],
-        "num_run": 66,
-        "tokenizer": "TheBloke/Llama-2-7B-fp16",
-        "dataset": "mmlu",
-        "score": 0.6
-    },
-    "trtllm-mistral-b-instruct-v0.3-fp8": {
-        "batch_size": [213],
-        "seq_length": [1],
-        "num_run": 66,
-        "tokenizer": "amazon/MegaBeam-Mistral-7B-300k",
-        "dataset": "mmlu",
-        "score": 0.6
-    },
-    "trtllm-meta-llama3-8b-fp8": {
-        "batch_size": [213],
-        "seq_length": [1],
-        "num_run": 66,
-        "tokenizer": "TheBloke/Llama-2-7B-fp16",
-        "dataset": "mmlu",
-        "score": 0.6
     }
 }
 
@@ -885,7 +861,7 @@ def remove_file_handler_from_logger(handler):
 
 def modelspec_checker(model: str, model_spec: dict):
     if model not in model_spec:
-        msg = f"{args.model} 4 is not one of the supporting models {list(model_spec.keys())}"
+        msg = f"{args.model} is not one of the supporting models {list(model_spec.keys())}"
         LOGGER.error(msg)
         raise ValueError(msg)
 
@@ -988,7 +964,7 @@ def awscurl_run(data,
     endpoint = f"http://127.0.0.1:8080/invocations"
     if dataset:
         dataset_dir = os.path.join(os.path.curdir, "dataset")
-        os.makedirs(dataset_dir, exist_ok=True)
+        os.mkdir(dataset_dir)
         for i, d in enumerate(data):
             with open(os.path.join(dataset_dir, f"prompt{i}.txt"), "w") as f:
                 f.write(json.dumps(d))
@@ -1645,7 +1621,7 @@ def test_transformers_neuronx_handler(model, model_spec):
 def test_correctness(model, model_spec):
     if model not in model_spec:
         raise ValueError(
-            f"{model} 5 is not one of the supporting models {list(model_spec.keys())}"
+            f"{model} is not one of the supporting models {list(model_spec.keys())}"
         )
     spec = model_spec[model]
     score = float(spec.get("score", 0.5))

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -962,6 +962,14 @@ correctness_model_list = {
         "option.rolling_batch": "auto",
         "option.max_rolling_batch_size": 213,
         "option.model_loading_timeout": 1800
+    },
+    "trtllm-meta-llama3-8b-fp8": {
+        "engine": "Python",
+        "option.task": "text-generation",
+        "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
+        "option.rolling_batch": "trtllm",
+        "option.tensor_parallel_degree": 4,
+        "option.quantize": "fp8"
     }
 }
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -962,14 +962,6 @@ correctness_model_list = {
         "option.rolling_batch": "auto",
         "option.max_rolling_batch_size": 213,
         "option.model_loading_timeout": 1800
-    },
-    "trtllm-meta-llama3-8b-fp8": {
-        "engine": "Python",
-        "option.task": "text-generation",
-        "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
-        "option.rolling_batch": "trtllm",
-        "option.tensor_parallel_degree": 4,
-        "option.quantize": "fp8"
     }
 }
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -854,6 +854,12 @@ class TestCorrectnessTrtLlm:
             prepare.build_correctness_model("trtllm-llama3-8b")
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("correctness trtllm-llama3-8b".split())
+    
+    def test_llama3_8b_fp8(self):
+        with Runner('tensorrt-llm', 'llama3-3b') as r:
+            prepare.build_correctness_model("trtllm-meta-llama3-8b-fp8")
+            r.launch("CUDA_VISIBLE_DEVICES=0, 1, 2, 3")
+            client.run("correctness trtllm-meta-llama3-8b-fp8".split())
 
 
 @pytest.mark.correctness

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -858,7 +858,7 @@ class TestCorrectnessTrtLlm:
     def test_llama3_8b_fp8(self):
         with Runner('tensorrt-llm', 'llama3-3b') as r:
             prepare.build_correctness_model("trtllm-meta-llama3-8b-fp8")
-            r.launch("CUDA_VISIBLE_DEVICES=0, 1, 2, 3")
+            r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("correctness trtllm-meta-llama3-8b-fp8".split())
 
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -854,7 +854,7 @@ class TestCorrectnessTrtLlm:
             prepare.build_correctness_model("trtllm-llama3-8b")
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("correctness trtllm-llama3-8b".split())
-    
+
     def test_llama3_8b_fp8(self):
         with Runner('tensorrt-llm', 'llama3-3b') as r:
             prepare.build_correctness_model("trtllm-meta-llama3-8b-fp8")

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -855,6 +855,12 @@ class TestCorrectnessTrtLlm:
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("correctness trtllm-llama3-8b".split())
 
+    def test_llama3_8b_fp8(self):
+        with Runner('tensorrt-llm', 'llama3-3b') as r:
+            prepare.build_correctness_model("trtllm-meta-llama3-8b-fp8")
+            r.launch("CUDA_VISIBLE_DEVICES=0, 1, 2, 3")
+            client.run("correctness trtllm-meta-llama3-8b-fp8".split())
+
 
 @pytest.mark.correctness
 @pytest.mark.lmi_dist
@@ -899,11 +905,11 @@ class TestMultiModalLmiDist:
             r.launch()
             client.run("multimodal llava_v1.6-mistral".split())
 
-    def test_paligemma(self):
-        with Runner('lmi', 'paligemma-3b-mix-448') as r:
-            prepare.build_lmi_dist_model('paligemma-3b-mix-448')
-            r.launch()
-            client.run("multimodal paligemma-3b-mix-448".split())
+    #def test_paligemma(self):
+    #    with Runner('lmi', 'paligemma-3b-mix-448') as r:
+    #        prepare.build_lmi_dist_model('paligemma-3b-mix-448')
+    #        r.launch()
+    #        client.run("multimodal paligemma-3b-mix-448".split())
 
     def test_phi3_v(self):
         with Runner('lmi', 'phi-3-vision-128k-instruct') as r:

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -855,12 +855,6 @@ class TestCorrectnessTrtLlm:
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("correctness trtllm-llama3-8b".split())
 
-    def test_llama3_8b_fp8(self):
-        with Runner('tensorrt-llm', 'llama3-3b') as r:
-            prepare.build_correctness_model("trtllm-meta-llama3-8b-fp8")
-            r.launch("CUDA_VISIBLE_DEVICES=0, 1, 2, 3")
-            client.run("correctness trtllm-meta-llama3-8b-fp8".split())
-
 
 @pytest.mark.correctness
 @pytest.mark.lmi_dist
@@ -905,11 +899,11 @@ class TestMultiModalLmiDist:
             r.launch()
             client.run("multimodal llava_v1.6-mistral".split())
 
-    #def test_paligemma(self):
-    #    with Runner('lmi', 'paligemma-3b-mix-448') as r:
-    #        prepare.build_lmi_dist_model('paligemma-3b-mix-448')
-    #        r.launch()
-    #        client.run("multimodal paligemma-3b-mix-448".split())
+    def test_paligemma(self):
+        with Runner('lmi', 'paligemma-3b-mix-448') as r:
+            prepare.build_lmi_dist_model('paligemma-3b-mix-448')
+            r.launch()
+            client.run("multimodal paligemma-3b-mix-448".split())
 
     def test_phi3_v(self):
         with Runner('lmi', 'phi-3-vision-128k-instruct') as r:


### PR DESCRIPTION
## Description ##

This PR introduces support for running the Llama-3-8B model with 8-bit (fp8) quantization using TensorRT LLM. The changes include:

1. Adding configuration for the trtllm-meta-llama3-8b-fp8 model in client.py and prepare.py, specifically with option.quantize: "fp8" for 8-bit quantization.
2. Adding a new test case test_llama3_8b_fp8 in tests.py to run the correctness test for the trtllm-meta-llama3-8b-fp8 model with 8-bit quantization.
3. Updating the awscurl_run function in client.py to use os.makedirs with exist_ok=True for creating the dataset directory.