### PR TITLE
[cherry-pick] add ignore_eos support in chat completions schema (#2281)

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/chat_properties.py
+++ b/engines/python/setup/djl_python/chat_completions/chat_properties.py
@@ -114,6 +114,7 @@ class ChatProperties(BaseModel):
     temperature: Optional[float] = 1.0
     top_p: Optional[float] = 1.0
     user: Optional[str] = Field(default=None, exclude=True)
+    ignore_eos: bool = False
 
     @field_validator('frequency_penalty', mode='before')
     def validate_frequency_penalty(

--- a/serving/docs/lmi/user_guides/chat_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/chat_input_output_schema.md
@@ -34,6 +34,7 @@ Request Body Fields:
 | `temperature`       | float                        | no       | Float number between 0.0 and 2.0.         |
 | `top_p`             | float                        | no       | Float number.                             |
 | `user`              | string                       | no       | example: "test"                           |
+| `ignore_eos`        | boolean                      | no       | `true`, `false` (default)                 |
 
 Example request using curl
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
