### PR TITLE
[Neo] [Neuron] Various CX improvements for Neo Neuron entrypoint

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -139,8 +139,11 @@ class TNXModelLoader(ModelLoader):
         self._neuronx_class = self.set_neuronx_class()
 
     def set_neuronx_class(self):
-        module_name, class_name = self.MODEL_TYPE_TO_CLS_LOADER[
-            self.model_config.model_type].rsplit(".", maxsplit=1)
+        try:
+            module_name, class_name = self.MODEL_TYPE_TO_CLS_LOADER[
+                self.model_config.model_type].rsplit(".", maxsplit=1)
+        except KeyError as exc:
+            raise KeyError(f"Unsupported model: {str(exc)}")
         module = importlib.import_module(f"transformers_neuronx.{module_name}")
         neuronx_class = getattr(module, class_name, None)
         if neuronx_class is None:

--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -143,7 +143,9 @@ class TNXModelLoader(ModelLoader):
             module_name, class_name = self.MODEL_TYPE_TO_CLS_LOADER[
                 self.model_config.model_type].rsplit(".", maxsplit=1)
         except KeyError as exc:
-            raise KeyError(f"Unsupported model: {str(exc)}")
+            raise KeyError(
+                f"Unsupported model: {str(exc)}. Supported architectures: {list(self.MODEL_TYPE_TO_CLS_LOADER.keys())}"
+            )
         module = importlib.import_module(f"transformers_neuronx.{module_name}")
         neuronx_class = getattr(module, class_name, None)
         if neuronx_class is None:

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -27,7 +27,8 @@ from huggingface_hub import snapshot_download
 from datasets import load_dataset
 
 from utils import (get_partition_cmd, extract_python_jar,
-                   get_python_executable, get_download_dir, load_hf_config_and_tokenizer)
+                   get_python_executable, get_download_dir,
+                   load_hf_config_and_tokenizer)
 
 PYTHON_CACHE_DIR = '/tmp/djlserving/cache'
 
@@ -207,7 +208,8 @@ class PartitionService(object):
             self.cleanup()
             return partition_stdout
         else:
-            logging.error(f"Partitioning was not successful: {partition_stderr}")
+            logging.error(
+                f"Partitioning was not successful: {partition_stderr}")
             raise Exception(partition_stderr)
 
     def load_the_generated_checkpoints(self):

--- a/serving/docker/partition/partition.py
+++ b/serving/docker/partition/partition.py
@@ -191,10 +191,9 @@ class PartitionService(object):
             for line in proc.stdout:
                 partition_stdout += line
                 print(line, end='')
-            # Exception is the last line of stderr
+            # Exception details are in the last line of stderr
             for line in proc.stderr:
-                pass
-            partition_stderr = line
+                partition_stderr = line
         logging.info(proc)
         if proc.returncode == 0:
             logging.info("Partitioning done.")
@@ -210,7 +209,9 @@ class PartitionService(object):
         else:
             logging.error(
                 f"Partitioning was not successful: {partition_stderr}")
-            raise Exception(partition_stderr)
+            raise Exception(
+                f"Partitioning exited with return code: {proc.returncode}. Details: {partition_stderr}"
+            )
 
     def load_the_generated_checkpoints(self):
         if self.properties['engine'] == 'DeepSpeed':

--- a/serving/docker/partition/run_partition.py
+++ b/serving/docker/partition/run_partition.py
@@ -37,8 +37,8 @@ def invoke_partition(properties):
                                            properties['entryPoint'], None)
         model_service.invoke_handler(handler, inputs)
     except Exception as e:
-        logging.exception(f"Partitioning failed {str(e)}")
-        raise Exception("Partitioning failed.")
+        logging.exception(f"Partitioning failed: {str(e)}")
+        raise e
 
 
 def main():

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -219,9 +219,7 @@ class NeoNeuronPartitionService():
         try:
             return partition_service.run_partition()
         except Exception as exc:
-            raise CompilationFatalError(
-                f"Encountered an error during Transformers-NeuronX compilation: {exc}"
-            )
+            raise CompilationFatalError(str(exc))
 
     def write_properties(self) -> str:
         """

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -155,10 +155,14 @@ class NeoNeuronPartitionService():
         self.compiler_interface: str = None
 
         neo_environ = get_neo_env_vars()
-        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
-        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
-        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_CACHE_DIR"]
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ[
+            "SM_NEO_COMPILATION_ERROR_FILE"]
+        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ[
+            "SM_NEO_CACHE_DIR"]
         # Specific to Neuron compilation
         self.CACHE_JUMPSTART_FORMAT: Final[str] = os.environ.get(
             "SM_CACHE_JUMPSTART_FORMAT", "false")
@@ -281,7 +285,8 @@ class NeoNeuronPartitionService():
     def neo_partition(self):
         self.update_neuron_cache_location()
         self.initialize_partition_args_namespace()
-        logging.info("Reading compiler options from provided serving.properties file")
+        logging.info(
+            "Reading compiler options from provided serving.properties file")
         self.construct_properties_manager_from_serving_properties()
         logging.info(f"Model options: {self.properties_manager.properties}")
         partition_output = self.run_partition()

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -124,7 +124,7 @@ class NeoNeuronCacheManager():
         /neuronxcc-2.13.68.0+6dfecc895/<Module folders>
         """
         try:
-            jumpstart_model_id = jumpstart_metadata["model_info"]["model_id"]
+            jumpstart_model_id = jumpstart_metadata["model_info"]["ModelId"]
             jumpstart_model_scope = jumpstart_metadata["script_info"]["Scope"]
         except KeyError as key:
             logging.warning(
@@ -264,7 +264,10 @@ class NeoNeuronPartitionService():
 
     def copy_input_files_to_output(self):
         """
-        Copies inputted files to output so that custom entrypoints or requirements files are preserved.
+        Copies input model files to output directory. Compilation outputs are
+        saved in a subdirectory of the output directory, and the generated
+        serving.properties sets the model location to the subdirectory.
+        This is done so that that custom entrypoints or requirements.txt files are preserved.
 
         TODO: Avoid making redundant copies of model weights.
         """
@@ -291,6 +294,8 @@ class NeoNeuronPartitionService():
         logging.info(f"Model options: {self.properties_manager.properties}")
         partition_output = self.run_partition()
 
+        self.copy_input_files_to_output()
+
         if self.CACHE_JUMPSTART_FORMAT.lower() == 'true':
             logging.info("JumpStart cache environment variable is set")
             if self.jumpstart_metadata:
@@ -303,8 +308,6 @@ class NeoNeuronPartitionService():
                     self.OUTPUT_MODEL_DIRECTORY)
                 cache_manager.create_jumpstart_neuron_cache_in_cache_dir(
                     self.jumpstart_metadata)
-
-        self.copy_input_files_to_output()
 
 
 def main():

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -16,15 +16,12 @@ import logging
 import os
 from types import SimpleNamespace
 from typing import Final, Optional
-import argparse
 import re
 import shutil
 
-from optimum.commands.export.neuronx import parse_args_neuronx
-
 from sm_neo_utils import (InputConfiguration, CompilationFatalError,
                           write_error_to_file, get_neo_env_vars,
-                          get_neo_compiler_flags, load_jumpstart_metadata)
+                          load_jumpstart_metadata)
 from utils import extract_python_jar, load_properties
 from properties_manager import PropertiesManager
 from partition import PartitionService
@@ -157,12 +154,11 @@ class NeoNeuronPartitionService():
         self.compiler_flags: dict = None
         self.compiler_interface: str = None
 
-        env = get_neo_env_vars()
-        self.NEO_COMPILER_OPTIONS: Final[str] = env[0]
-        self.INPUT_MODEL_DIRECTORY: Final[str] = env[1]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = env[2]
-        self.COMPILATION_ERROR_FILE: Final[str] = env[3]
-        self.COMPILER_CACHE_LOCATION: Final[str] = env[4]
+        neo_environ = get_neo_env_vars()
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
+        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_CACHE_DIR"]
         # Specific to Neuron compilation
         self.CACHE_JUMPSTART_FORMAT: Final[str] = os.environ.get(
             "SM_CACHE_JUMPSTART_FORMAT", "false")
@@ -174,6 +170,8 @@ class NeoNeuronPartitionService():
         logging.info(
             f"Updating Neuron Persistent Cache directory to: {self.COMPILER_CACHE_LOCATION}"
         )
+        if not os.path.isdir(self.COMPILER_CACHE_LOCATION):
+            raise InputConfiguration("Provided Neo cache directory is invalid")
         os.environ['NEURON_COMPILE_CACHE_URL'] = self.COMPILER_CACHE_LOCATION
 
     def initialize_partition_args_namespace(self):
@@ -193,161 +191,6 @@ class NeoNeuronPartitionService():
         self.args.tensor_parallel_degree = None
         self.args.pipeline_parallel_degree = None
         self.args.quantize = None
-
-    def parse_neo_compiler_flags(self):
-        """
-        Parses the compiler_flags field of Neo CompilerOptions.
-        """
-        if self.compiler_flags:
-            logging.debug(f"Compiler Flags: {self.compiler_flags}")
-            if not isinstance(self.compiler_flags, dict):
-                raise InputConfiguration(
-                    "Invalid compiler flags. Ensure that the input is a valid JSON dictionary."
-                )
-
-            if "compile_only" in self.compiler_flags and self.compiler_flags[
-                    "compile_only"].lower() == "true":
-                logging.info(
-                    "Warning: compile_only flag passed. SafeTensors weights or split model "
-                    "weights must be provided to deploy the model.")
-                self.properties["option.partition_schema"] = "compile_only"
-                del self.compiler_flags["compile_only"]
-
-            if "compiler_interface" in self.compiler_flags:
-                self.compiler_interface = self.compiler_flags[
-                    "compiler_interface"]
-                del self.compiler_flags["compiler_interface"]
-                logging.info(
-                    f"{self.compiler_interface} is set as the compiler interface by "
-                    "Neo CompilerOptions.")
-
-    @staticmethod
-    def convert_tnx_options_to_djl_options(options: dict) -> dict:
-        """
-        Converts Transformers-NeuronX options accepted by Neo to the equivalent option
-        in djl-serving. Only options that have a different name or set of values are converted;
-        the remaining are kept as-is. Supports an additional option "continuous_batching"
-        (equivalently "batch_size_for_shared_caches") to allow users to enable continuous batching.
-
-        :param options: A dictionary containing Transformers-NeuronX options as key-value pairs.
-        :return: returns the modified dictionary
-        """
-        amp_dtype_map = {
-            'f32': 'fp32',
-            'f16': 'fp16',
-            'bf16': 'bf16',
-            's8': 'int8'
-        }
-
-        logging.debug(f"tnx options dict: {options}")
-        if "amp" in options:
-            options["option.dtype"] = amp_dtype_map[options["amp"]]
-            del options["amp"]
-        if "tp_degree" in options:
-            options["option.tensor_parallel_degree"] = options["tp_degree"]
-            del options["tp_degree"]
-        if "continuous_batching" in options or "batch_size_for_shared_caches" in options:
-            max_rolling_batch_size = options[
-                "continuous_batching"] if options.get(
-                    "continuous_batching"
-                ) else options["batch_size_for_shared_caches"]
-            options["option.rolling_batch"] = "auto"
-            options["option.max_rolling_batch_size"] = max_rolling_batch_size
-
-            options.pop("continuous_batching", None)
-            options.pop("batch_size_for_shared_caches", None)
-            # can't set batch_size and max_rolling_batch_size at the same time
-            options.pop("batch_size", None)
-
-        return options
-
-    def construct_properties_manager_from_tnx_options(self):
-        """
-        Factory method used to construct a PropertiesManager from Transformers-NeuronX
-        Neo CompilerOptions
-        """
-        self.args.engine = "Python"
-        # Passing a dummy location because it's expected by PropertiesManager
-        self.args.properties_dir = "/dev/null"
-
-        self.properties["model_dir"] = self.INPUT_MODEL_DIRECTORY
-        self.properties["option.model_loader"] = "tnx"
-        self.properties |= NeoNeuronPartitionService.convert_tnx_options_to_djl_options(
-            self.compiler_flags)
-        logging.debug("Constructing PropertiesManager from TNX "
-                      f"options\nargs:{self.args}\nprops:{self.properties}")
-        self.properties_manager = PropertiesManager(
-            self.args, addl_properties=self.properties)
-
-    @staticmethod
-    def convert_optimum_flags_to_djl_options(
-            flags: argparse.Namespace) -> dict:
-        """
-        This takes a namespace created by parsing Optimum CLI flags and maps the values to
-        djl-serving options.
-
-        :param flags: a mamespace object returned by the Optimum ArgumentParser
-        :return: dictionary containing the converted options
-        """
-        OPTIMUM_TO_DJL_MAP = {
-            "task": "option.task",
-            "trust-remote-code": "option.trust_remote_code",
-            "auto_cast_type": "option.dtype",
-            "num_cores": "option.tensor_parallel_degree",
-            # rolling batch must be true for optimum
-            "batch_size": "option.max_rolling_batch_size",
-            "sequence_length": "option.n_positions"
-        }
-
-        props = {}
-
-        logging.debug(f"optimum flags: {flags}")
-
-        # Iterating through the attributes of the namespace
-        for flag, value in vars(flags).items():
-            if flag == "task" and value == "auto":
-                continue
-
-            if flag in OPTIMUM_TO_DJL_MAP:
-                props[OPTIMUM_TO_DJL_MAP[flag]] = value
-                if flag == "batch_size":
-                    props["option.rolling_batch"] = "auto"
-            elif flag == "01":
-                props["option.neuron_optimize_level"] = 1
-            elif flag == "02":
-                props["option.neuron_optimize_level"] = 2
-            elif flag == "03":
-                props["option.neuron_optimize_level"] = 3
-
-        return props
-
-    def construct_properties_manager_from_optimum_flags(self):
-        """
-        Factory method used to construct a PropertiesManager from Optimum Flags Neo CompilerOptions
-        """
-        self.properties["model_dir"] = self.INPUT_MODEL_DIRECTORY
-        self.properties["option.model_loader"] = "optimum"
-        self.args.engine = "Python"
-        # Passing a dummy location because it's expected by PropertiesManager
-        self.args.properties_dir = "/dev/null"
-
-        # Construct the optimum CLI argparser
-        parser = argparse.ArgumentParser()
-        # This function adds the desired arguments to the parser. Not parsing yet.
-        parse_args_neuronx(parser)
-        # The parser requries the --model param and a trailing output parameter.
-        # Passing the dummy arguments so we can still use the parser.
-        optimum_flags = self.compiler_flags["flags"].split()
-        optimum_flags = ["--model", "/dev/null"] + optimum_flags
-        optimum_flags += ["/dev/null"]
-        flags = parser.parse_args(optimum_flags)
-        self.properties |= NeoNeuronPartitionService.convert_optimum_flags_to_djl_options(
-            flags)
-
-        logging.debug("Constructing PropertiesManager from optimum "
-                      f"options\nargs:{self.args}\nprops:{self.properties}")
-        self.properties_manager = PropertiesManager(
-            self.args, addl_properties=self.properties)
 
     def construct_properties_manager_from_serving_properties(self):
         """
@@ -440,26 +283,8 @@ class NeoNeuronPartitionService():
     def neo_partition(self):
         self.update_neuron_cache_location()
         self.initialize_partition_args_namespace()
-        self.compiler_flags = get_neo_compiler_flags(self.NEO_COMPILER_OPTIONS)
-        self.parse_neo_compiler_flags()
-        if self.compiler_interface == "transformers-neuronx":
-            logging.info(
-                "Reading Neo CompilerOptions in transformers-neuronx format. "
-                "serving.properties will be ignored")
-            self.construct_properties_manager_from_tnx_options()
-            logging.info("Reading Neo CompilerOptions in optimum format. "
-                         "serving.properties will be ignored")
-        elif self.compiler_interface == "optimum":
-            self.construct_properties_manager_from_optimum_flags()
-        elif self.compiler_interface:
-            raise InputConfiguration(
-                f"Invalid compiler interface provided. Got: {self.compiler_interface}"
-            )
-        else:
-            logging.info(
-                "Reading compiler options from provided serving.properties file"
-            )
-            self.construct_properties_manager_from_serving_properties()
+        logging.info("Reading compiler options from provided serving.properties file")
+        self.construct_properties_manager_from_serving_properties()
         logging.info(f"Model options: {self.properties_manager.properties}")
         partition_output = self.run_partition()
 

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -288,6 +288,7 @@ class NeoNeuronPartitionService():
                 self.INPUT_MODEL_DIRECTORY, "model.safetensors.index.json")
             # build the set of weight files to ignore
             weight_files = set()
+            weight_files.add(os.path.basename(safetensors_index_file))
             with open(safetensors_index_file) as f:
                 index = json.load(f)
                 for k, v in index["weight_map"].items():

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -20,7 +20,7 @@ import re
 import shutil
 import json
 
-from sm_neo_utils import (InputConfiguration, CompilationFatalError,
+from sm_neo_utils import (InputConfiguration, OptimizationFatalError,
                           write_error_to_file, get_neo_env_vars,
                           load_jumpstart_metadata)
 from utils import extract_python_jar, load_properties
@@ -224,7 +224,7 @@ class NeoNeuronPartitionService():
         try:
             return partition_service.run_partition()
         except Exception as exc:
-            raise CompilationFatalError(str(exc))
+            raise OptimizationFatalError(str(exc))
 
     def write_properties(self) -> str:
         """

--- a/serving/docker/partition/sm_neo_neuron_partition.py
+++ b/serving/docker/partition/sm_neo_neuron_partition.py
@@ -279,7 +279,8 @@ class NeoNeuronPartitionService():
         with os.scandir(self.OUTPUT_MODEL_DIRECTORY) as it:
             for entry in it:
                 if os.path.abspath(entry.path) != optimized_model_dir:
-                    shutil.move(entry.path, optimized_model_dir)
+                    if entry.name != "serving.properties":
+                        shutil.move(entry.path, optimized_model_dir)
 
         # use safetensors index to determine which weights to skip copying
         ignore_fun = None

--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -20,9 +20,8 @@ import torch
 import json
 
 from sm_neo_utils import (CompilationFatalError, InputConfiguration,
-                          write_error_to_file, get_neo_env_vars)
-from utils import (extract_python_jar, load_properties,
-                   update_dataset_cache_location)
+                          write_error_to_file, get_neo_env_vars, update_dataset_cache_location)
+from utils import (extract_python_jar, load_properties)
 from properties_manager import PropertiesManager
 from partition import PartitionService
 
@@ -37,11 +36,11 @@ class NeoQuantizationService():
         self.properties_manager: PropertiesManager = None
         self.compiler_flags: dict = None
 
-        env = get_neo_env_vars()
-        self.INPUT_MODEL_DIRECTORY: Final[str] = env[1]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = env[2]
-        self.COMPILATION_ERROR_FILE: Final[str] = env[3]
-        self.HF_CACHE_LOCATION: Final[str] = env[5]
+        neo_environ = get_neo_env_vars()
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
+        self.HF_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_HF_CACHE_DIR"]
 
         self.customer_properties: dict = load_properties(
             self.INPUT_MODEL_DIRECTORY)

--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -20,7 +20,8 @@ import torch
 import json
 
 from sm_neo_utils import (CompilationFatalError, InputConfiguration,
-                          write_error_to_file, get_neo_env_vars, update_dataset_cache_location)
+                          write_error_to_file, get_neo_env_vars,
+                          update_dataset_cache_location)
 from utils import (extract_python_jar, load_properties)
 from properties_manager import PropertiesManager
 from partition import PartitionService
@@ -37,9 +38,12 @@ class NeoQuantizationService():
         self.compiler_flags: dict = None
 
         neo_environ = get_neo_env_vars()
-        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
-        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ[
+            "SM_NEO_COMPILATION_ERROR_FILE"]
         self.HF_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_HF_CACHE_DIR"]
 
         self.customer_properties: dict = load_properties(

--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -19,7 +19,7 @@ from typing import Final
 import torch
 import json
 
-from sm_neo_utils import (CompilationFatalError, InputConfiguration,
+from sm_neo_utils import (OptimizationFatalError, InputConfiguration,
                           write_error_to_file, get_neo_env_vars,
                           update_dataset_cache_location)
 from utils import (extract_python_jar, load_properties)
@@ -104,7 +104,7 @@ class NeoQuantizationService():
         try:
             return partition_service.run_quantization(self.autofp8_config)
         except Exception as exc:
-            raise CompilationFatalError(
+            raise OptimizationFatalError(
                 f"Encountered an error during quantization: {exc}")
 
     def write_properties(self):

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -19,7 +19,7 @@ from typing import Final
 from utils import (update_kwargs_with_env_vars, load_properties,
                    remove_option_from_properties)
 from sm_neo_utils import (CompilationFatalError, write_error_to_file,
-                   update_dataset_cache_location, get_neo_env_vars)
+                          update_dataset_cache_location, get_neo_env_vars)
 from tensorrt_llm_toolkit import create_model_repo
 
 
@@ -29,10 +29,14 @@ class NeoTRTLLMPartitionService():
         self.properties: dict = {}
 
         neo_environ = get_neo_env_vars()
-        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
-        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
-        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_CACHE_DIR"]
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ[
+            "SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ[
+            "SM_NEO_COMPILATION_ERROR_FILE"]
+        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ[
+            "SM_NEO_CACHE_DIR"]
         self.HF_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_HF_CACHE_DIR"]
 
     def run_partition(self):

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -17,10 +17,9 @@ import sys
 from typing import Final
 
 from utils import (update_kwargs_with_env_vars, load_properties,
-                   update_dataset_cache_location,
                    remove_option_from_properties)
 from sm_neo_utils import (CompilationFatalError, write_error_to_file,
-                          get_neo_env_vars)
+                   update_dataset_cache_location, get_neo_env_vars)
 from tensorrt_llm_toolkit import create_model_repo
 
 
@@ -29,12 +28,12 @@ class NeoTRTLLMPartitionService():
     def __init__(self):
         self.properties: dict = {}
 
-        env = get_neo_env_vars()
-        self.INPUT_MODEL_DIRECTORY: Final[str] = env[1]
-        self.OUTPUT_MODEL_DIRECTORY: Final[str] = env[2]
-        self.COMPILATION_ERROR_FILE: Final[str] = env[3]
-        self.COMPILER_CACHE_LOCATION: Final[str] = env[4]
-        self.HF_CACHE_LOCATION: Final[str] = env[5]
+        neo_environ = get_neo_env_vars()
+        self.INPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_INPUT_MODEL_DIR"]
+        self.OUTPUT_MODEL_DIRECTORY: Final[str] = neo_environ["SM_NEO_COMPILED_MODEL_DIR"]
+        self.COMPILATION_ERROR_FILE: Final[str] = neo_environ["SM_NEO_COMPILATION_ERROR_FILE"]
+        self.COMPILER_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_CACHE_DIR"]
+        self.HF_CACHE_LOCATION: Final[str] = neo_environ["SM_NEO_HF_CACHE_DIR"]
 
     def run_partition(self):
         kwargs = remove_option_from_properties(self.properties)

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -18,7 +18,7 @@ from typing import Final
 
 from utils import (update_kwargs_with_env_vars, load_properties,
                    remove_option_from_properties)
-from sm_neo_utils import (CompilationFatalError, write_error_to_file,
+from sm_neo_utils import (OptimizationFatalError, write_error_to_file,
                           update_dataset_cache_location, get_neo_env_vars)
 from tensorrt_llm_toolkit import create_model_repo
 
@@ -48,7 +48,7 @@ class NeoTRTLLMPartitionService():
         try:
             create_model_repo(self.INPUT_MODEL_DIRECTORY, **kwargs)
         except Exception as exc:
-            raise CompilationFatalError(
+            raise OptimizationFatalError(
                 f"Encountered an error during TRT-LLM compilation: {exc}")
 
     def get_properties(self):

--- a/serving/docker/partition/sm_neo_utils.py
+++ b/serving/docker/partition/sm_neo_utils.py
@@ -33,18 +33,21 @@ def get_neo_env_vars():
     """
     neo_environ = {}
     try:
-        neo_environ["SM_NEO_INPUT_MODEL_DIR"] = os.environ["SM_NEO_INPUT_MODEL_DIR"]
-        neo_environ["SM_NEO_COMPILED_MODEL_DIR"] = os.environ["SM_NEO_COMPILED_MODEL_DIR"]
-        neo_environ["SM_NEO_COMPILATION_ERROR_FILE"] = os.environ["SM_NEO_COMPILATION_ERROR_FILE"]
+        neo_environ["SM_NEO_INPUT_MODEL_DIR"] = os.environ[
+            "SM_NEO_INPUT_MODEL_DIR"]
+        neo_environ["SM_NEO_COMPILED_MODEL_DIR"] = os.environ[
+            "SM_NEO_COMPILED_MODEL_DIR"]
+        neo_environ["SM_NEO_COMPILATION_ERROR_FILE"] = os.environ[
+            "SM_NEO_COMPILATION_ERROR_FILE"]
         neo_environ["SM_NEO_CACHE_DIR"] = os.environ.get("SM_NEO_CACHE_DIR")
-        neo_environ["SM_NEO_HF_CACHE_DIR"] = os.environ.get("SM_NEO_HF_CACHE_DIR")
+        neo_environ["SM_NEO_HF_CACHE_DIR"] = os.environ.get(
+            "SM_NEO_HF_CACHE_DIR")
         return neo_environ
     except KeyError as exc:
         raise InputConfiguration(
             f"SageMaker Neo environment variable '{exc.args[0]}' expected but not found"
             f"\nRequired env vars are: 'SM_NEO_INPUT_MODEL_DIR', 'SM_NEO_COMPILED_MODEL_DIR',"
-            f" 'SM_NEO_COMPILATION_ERROR_FILE'"
-        )
+            f" 'SM_NEO_COMPILATION_ERROR_FILE'")
 
 
 def load_jumpstart_metadata(path: str) -> dict:

--- a/serving/docker/partition/sm_neo_utils.py
+++ b/serving/docker/partition/sm_neo_utils.py
@@ -11,8 +11,8 @@ class InputConfiguration(Exception):
     """Raise when SageMaker Neo interface expectation is not met"""
 
 
-class CompilationFatalError(Exception):
-    """Raise for errors encountered during the TensorRT-LLM build process"""
+class OptimizationFatalError(Exception):
+    """Raise for errors encountered during Neo model optimization jobs"""
 
 
 def write_error_to_file(error_message, error_file):

--- a/serving/docker/partition/utils.py
+++ b/serving/docker/partition/utils.py
@@ -6,10 +6,10 @@ import tempfile
 import logging
 import sys
 
+from transformers import AutoTokenizer
+
 MASTER_ADDR = "127.0.0.1"
 MASTER_PORT = 29761
-
-from transformers import AutoConfig, AutoTokenizer
 
 
 def get_python_executable():
@@ -67,7 +67,7 @@ def get_djl_version_from_lib():
             version = filename.replace("djl-serving-", "")
 
     if not version:
-        raise ValueError(f"Cannot retrieve version from lib file name.")
+        raise ValueError("Cannot retrieve version from lib file name.")
     return version
 
 
@@ -146,11 +146,3 @@ def load_hf_config_and_tokenizer(properties: dict):
     tokenizer = init_hf_tokenizer(hf_configs.model_id_or_path, hf_configs)
 
     return hf_configs, tokenizer
-
-
-def update_dataset_cache_location(hf_cache_location):
-    logging.info(
-        f"Updating HuggingFace Datasets cache directory to: {hf_cache_location}"
-    )
-    os.environ['HF_DATASETS_CACHE'] = hf_cache_location
-    #os.environ['HF_DATASETS_OFFLINE'] = "1"


### PR DESCRIPTION
## Description ##

### Changelog
- Removes unused logic for parsing Neo CompilerOptions.
- Improves error messaging for Neo. The actual error message will be passed to errors.json, rather than just "Partitioning Failed".
- Clarifies the error message for unsupported Neuron models.
- JumpStart cache
    - Previously, JS cache is outputted to `output/optimized_model/`
    - Now, it will be saved in root dir, and merged with inputted cache if it exists:
        - i.e. `output/PRE_COMPILED_NEURON_GRAPH_INFER` 
- Skips duplicating model weights when copying input files to output. Only skips weights in the root directory to preserve draft models. 
- Change error messages for all Neo scripts to OptimizationFatalError from CompilationFatalError