### PR TITLE
[lmi_dist][vllm] Fix chunked prefill bug that caused error with prompt_logprobs

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
@@ -36,8 +36,8 @@ class LmiDistRbProperties(Properties):
     dtype: Optional[str] = "auto"
     load_format: Optional[str] = "auto"
     quantize: Optional[LmiDistQuantizeMethods] = None
-    tensor_parallel_degree: Optional[int] = None
-    pipeline_parallel_degree: Optional[int] = None
+    tensor_parallel_degree: int = 1
+    pipeline_parallel_degree: int = 1
     max_rolling_batch_prefill_tokens: Optional[int] = None
     # Adjustable prefix model length for certain 32k or longer model
     max_model_len: Optional[int] = None

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -41,6 +41,9 @@ class Token(object):
         self.request_id = None
         self.error_msg = error_msg
 
+    def __repr__(self):
+        return f"Token({self.as_dict()})"
+
     def as_dict(self):
         output = {"id": self.id, "text": self.text, "log_prob": self.log_prob}
         if self.special_token:
@@ -60,6 +63,9 @@ class Iterator:
 
     def __init__(self):
         self._index = 0
+
+    def __repr__(self):
+        return f"Iterator(_index={self._index})"
 
     def get_index(self):
         return self._index

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -52,7 +52,8 @@ def update_request_cache_with_output(request_cache: OrderedDict,
         return request_cache
 
     # Prefill is complete if any of the outputs have token_ids set
-    prefill_is_complete = any((output.token_ids for output in vllm_request_output.outputs))
+    prefill_is_complete = any(
+        (output.token_ids for output in vllm_request_output.outputs))
     if not prefill_is_complete:
         return request_cache
 

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -51,6 +51,11 @@ def update_request_cache_with_output(request_cache: OrderedDict,
     if is_beam_search(parameters) and not vllm_request_output.finished:
         return request_cache
 
+    # Prefill is complete if any of the outputs have token_ids set
+    prefill_is_complete = any((output.token_ids for output in vllm_request_output.outputs))
+    if not prefill_is_complete:
+        return request_cache
+
     # sets prompt token details if not set
     if not request_output.prompt_tokens_details:
         # TODO: Temp check adding the check fo T5.

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -13,7 +13,9 @@ import djl_python
 from djl_python.output_formatter import _json_output_formatter
 from djl_python.request import Request
 from djl_python.request_io import TextGenerationOutput, TextInput, Sequence, Token, RequestInput
-'''These Mock classes are in compliance with vllm RequestOutput version 0.4.2'''
+import djl_python.rolling_batch
+
+'''These Mock classes are in compliance with vllm RequestOutput version 0.5.3.post1'''
 
 
 @dataclass

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -13,8 +13,6 @@ import djl_python
 from djl_python.output_formatter import _json_output_formatter
 from djl_python.request import Request
 from djl_python.request_io import TextGenerationOutput, TextInput, Sequence, Token, RequestInput
-import djl_python.rolling_batch
-
 '''These Mock classes are in compliance with vllm RequestOutput version 0.5.3.post1'''
 
 

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -603,13 +603,13 @@ class TestVllmUtils(unittest.TestCase):
                             token, actual_sequence.top_tokens[top_tokens_index]
                             [token_index]))
 
-    @mock.patch(
-        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
-        new=MockRequestOutput)
     @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
     def test_chunked_prefill_prompt_logprobs(self):
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         parameters = {
@@ -657,13 +657,13 @@ class TestVllmUtils(unittest.TestCase):
         self.assertEqual(repr(expected_sequences),
                          repr(req.request_output.sequences))
 
-    @mock.patch(
-        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
-        new=MockRequestOutput)
     @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
     def test_chunked_prefill(self):
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         parameters = {

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -339,6 +339,51 @@ example_request_output = [
         finished=True)
 ]
 
+example_chunked_prefill_prompt_logprobs_request_output = [
+    MockRequestOutput(request_id="test_chunked_request_id",
+                      prompt="I am a",
+                      prompt_token_ids=[1, 315, 837, 264],
+                      prompt_logprobs=[
+                          None, {
+                              315:
+                              MockLogprob(logprob=-4.37,
+                                          rank=8,
+                                          decoded_token='I'),
+                              422:
+                              MockLogprob(logprob=-1.25,
+                                          rank=1,
+                                          decoded_token='#')
+                          }
+                      ],
+                      outputs=[
+                          MockCompletionOutput(index=0,
+                                               text='',
+                                               token_ids=[],
+                                               cumulative_logprob=0.0,
+                                               logprobs=[],
+                                               finish_reason=None,
+                                               stop_reason=None)
+                      ],
+                      finished=False),
+]
+
+example_chunked_prefill_request_output = [
+    MockRequestOutput(request_id="test_chunked_request_id",
+                      prompt="I am a",
+                      prompt_token_ids=[1, 315, 837, 264],
+                      prompt_logprobs=None,
+                      outputs=[
+                          MockCompletionOutput(index=0,
+                                               text='',
+                                               token_ids=[],
+                                               cumulative_logprob=0.0,
+                                               logprobs=[],
+                                               finish_reason=None,
+                                               stop_reason=None)
+                      ],
+                      finished=False),
+]
+
 
 def _compare_tokens(expected_token, actual_token):
     return expected_token.id == actual_token.id and expected_token.text == actual_token.text and \
@@ -348,14 +393,13 @@ def _compare_tokens(expected_token, actual_token):
 
 class TestVllmUtils(unittest.TestCase):
 
-    def setUp(self):
-        sys.modules['vllm'] = MagicMock()
-        sys.modules['vllm.outputs'] = MagicMock()
-        sys.modules['vllm.lora.request'] = MagicMock()
-
     @mock.patch(
         'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
         new=MockRequestOutput)
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
     def test_multiple_sequences(self):
         tokenizer = AutoTokenizer.from_pretrained("gpt2")
         parameters = {
@@ -366,6 +410,8 @@ class TestVllmUtils(unittest.TestCase):
             "n": 2,
             "top_n_tokens": 3
         }
+        server_parameters = parameters.copy()
+        server_parameters.pop("details")
 
         request_input = TextInput(request_id=0,
                                   input_text="I am a",
@@ -374,15 +420,19 @@ class TestVllmUtils(unittest.TestCase):
         # 1. Creates the request
         req = Request(request_input)
         self.assertEqual(
-            TextGenerationOutput(request_id=0,
-                                 input=TextInput(
-                                     request_id=0,
-                                     input_text="I am a",
-                                     parameters=parameters,
-                                     output_formatter=_json_output_formatter,
-                                     tokenizer=tokenizer),
-                                 sequences={},
-                                 finished=False), req.request_output)
+            repr(
+                TextGenerationOutput(
+                    request_id=0,
+                    input=TextInput(
+                        request_id=0,
+                        input_text="I am a",
+                        parameters=parameters,
+                        server_parameters=server_parameters,
+                        output_formatter=_json_output_formatter,
+                        tokenizer=tokenizer,
+                    ),
+                    sequences={},
+                    finished=False)), repr(req.request_output))
 
         # 2. Creates the request cache
         mock_request_cache = OrderedDict(
@@ -550,3 +600,113 @@ class TestVllmUtils(unittest.TestCase):
                         _compare_tokens(
                             token, actual_sequence.top_tokens[top_tokens_index]
                             [token_index]))
+
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    def test_chunked_prefill_prompt_logprobs(self):
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        parameters = {
+            "max_new_tokens": 3,
+            "details": True,
+            "decoder_input_details": True,
+        }
+        server_parameters = parameters.copy()
+        server_parameters.pop("details", None)
+
+        request_input = TextInput(request_id=0,
+                                  input_text="I am a",
+                                  parameters=parameters.copy(),
+                                  tokenizer=tokenizer)
+        # 1. Creates the request
+        req = Request(request_input)
+        self.assertEqual(
+            repr(
+                TextGenerationOutput(
+                    request_id=0,
+                    input=TextInput(
+                        request_id=0,
+                        input_text="I am a",
+                        parameters=parameters,
+                        server_parameters=server_parameters,
+                        output_formatter=_json_output_formatter,
+                        tokenizer=tokenizer,
+                    ),
+                    sequences={},
+                    finished=False)), repr(req.request_output))
+
+        # 2. Creates the request cache
+        mock_request_cache = OrderedDict({
+            "test_chunked_request_id": {
+                "request_output": req.request_output
+            }
+        })
+
+        # Test update_request_cache_with_output
+        for vllm_request_output in example_chunked_prefill_prompt_logprobs_request_output:
+            djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
+                mock_request_cache, vllm_request_output, tokenizer)
+
+        expected_sequences = {0: Sequence()}
+        self.assertEqual(repr(expected_sequences),
+                         repr(req.request_output.sequences))
+
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    def test_chunked_prefill(self):
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        parameters = {
+            "max_new_tokens": 3,
+        }
+        server_parameters = parameters.copy()
+        server_parameters.pop("details", None)
+
+        request_input = TextInput(request_id=0,
+                                  input_text="I am a",
+                                  parameters=parameters.copy(),
+                                  tokenizer=tokenizer)
+        # 1. Creates the request
+        req = Request(request_input)
+        self.assertEqual(
+            repr(
+                TextGenerationOutput(
+                    request_id=0,
+                    input=TextInput(
+                        request_id=0,
+                        input_text="I am a",
+                        parameters=parameters,
+                        server_parameters=server_parameters,
+                        output_formatter=_json_output_formatter,
+                        tokenizer=tokenizer,
+                    ),
+                    sequences={},
+                    finished=False)), repr(req.request_output))
+
+        # 2. Creates the request cache
+        mock_request_cache = OrderedDict({
+            "test_chunked_request_id": {
+                "request_output": req.request_output
+            }
+        })
+
+        # Test update_request_cache_with_output
+        for vllm_request_output in example_chunked_prefill_request_output:
+            djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
+                mock_request_cache, vllm_request_output, tokenizer)
+
+        expected_sequences = {0: Sequence()}
+        self.assertEqual(repr(expected_sequences),
+                         repr(req.request_output.sequences))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description ##

It also caused dummy tokens to be returned to client with `(token_id=-1, text="", logprob=null)`, which is mostly harmless but does cause some tools (including awscurl) to report an incorrect TTFT with chunked prefill, since the TTFB will be after just the first chunk is processed due to the returned dummy token.

Added a couple of tests for the above cases, shown below failing before the change and passing after.

Before:
```
$ time python -m unittest -v djl_python.tests.test_rb_vllm_utils
test_chunked_prefill (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... FAIL
test_chunked_prefill_prompt_logprobs (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... ERROR
test_multiple_sequences (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... ok

======================================================================
ERROR: test_chunked_prefill_prompt_logprobs (djl_python.tests.test_rb_vllm_utils.TestVllmUtils)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/mock.py", line 1379, in patched
    return func(*newargs, **newkeywargs)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  [Previous line repeated 1 more time]
  File "/home/ubuntu/workspace/djl-serving/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py", line 647, in test_chunked_prefill_prompt_logprobs
    djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
  File "/home/ubuntu/workspace/djl-serving/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py", line 62, in update_request_cache_with_output
    log_prob = vllm_request_output.prompt_logprobs[index][
IndexError: list index out of range

======================================================================
FAIL: test_chunked_prefill (djl_python.tests.test_rb_vllm_utils.TestVllmUtils)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/mock.py", line 1379, in patched
    return func(*newargs, **newkeywargs)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  File "/usr/lib/python3.10/unittest/mock.py", line 1833, in _inner
    return f(*args, **kw)
  [Previous line repeated 1 more time]
  File "/home/ubuntu/workspace/djl-serving/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py", line 702, in test_chunked_prefill
    self.assertEqual(repr(expected_sequences), repr(req.request_output.sequences))
AssertionError: '{0: Sequence(tokens=[], top_tokens=[], c[160 chars]0))}' != "{0: Sequence(tokens=[Token({'id': -1, 't[256 chars]0))}"
Diff is 689 characters long. Set self.maxDiff to None to see it.

----------------------------------------------------------------------
Ran 3 tests in 0.990s

FAILED (failures=1, errors=1)

real    0m2.547s
user    0m2.365s
sys     0m4.580s
```

After:
```
$ time python -m unittest -v djl_python.tests.test_rb_vllm_utils
test_chunked_prefill (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... ok
test_chunked_prefill_prompt_logprobs (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... ok
test_multiple_sequences (djl_python.tests.test_rb_vllm_utils.TestVllmUtils) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.960s

OK

real    0m2.512s
user    0m2.431s
sys     0m4.498s
```