### PR TITLE
[secure-mode] Allow untrusted channels env var to be empty string

### DIFF
--- a/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeUtils.java
+++ b/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeUtils.java
@@ -94,11 +94,13 @@ final class SecureModeUtils {
         }
 
         Set<String> controls = new HashSet<>(Arrays.asList(securityControls.split("\\s*,\\s*")));
-        String[] untrustedPathList = untrustedChannels.split(",");
 
         validateProperties(modelInfo, SecureModeAllowList.PROPERTIES_ALLOWLIST);
         checkOptions(modelInfo, controls);
-        scanForbiddenFiles(untrustedPathList, controls);
+        if (!untrustedChannels.isEmpty()) {
+            String[] untrustedPathList = untrustedChannels.split(",");
+            scanForbiddenFiles(untrustedPathList, controls);
+        }
     }
 
     /**

--- a/plugins/secure-mode/src/test/java/ai/djl/serving/plugins/securemode/SecureModePluginTest.java
+++ b/plugins/secure-mode/src/test/java/ai/djl/serving/plugins/securemode/SecureModePluginTest.java
@@ -121,6 +121,26 @@ public class SecureModePluginTest {
         }
     }
 
+    @Test
+    void testEmptyUntrustedChannels() throws IOException, ModelException {
+        try (MockedStatic<Utils> mockedUtils = Mockito.mockStatic(Utils.class)) {
+            mockedUtils
+                    .when(() -> Utils.getenv(SecureModeUtils.SECURE_MODE_ENV_VAR))
+                    .thenReturn("true");
+            mockedUtils
+                    .when(() -> Utils.getenv(SecureModeUtils.SECURITY_CONTROLS_ENV_VAR))
+                    .thenReturn("bar");
+            mockedUtils
+                    .when(() -> Utils.getenv(SecureModeUtils.UNTRUSTED_CHANNELS_ENV_VAR))
+                    .thenReturn("");
+            mockedUtils
+                    .when(() -> Utils.getNestedModelDir(Mockito.any()))
+                    .thenReturn(TEST_MODEL_DIR);
+
+            validateSecurity("Python");
+        }
+    }
+
     @Test(expectedExceptions = IllegalConfigurationException.class)
     void testUntrustedPickle() throws IOException, ModelException {
         mockSecurityEnv(


### PR DESCRIPTION
In certain valid cases, Hosting platform will pass an empty string as the untrusted channels env var. This PR ensures errors will not be thrown as a result.