### PR TITLE
[feat] lmi neuronx add smart defaults n_positions

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -88,7 +88,7 @@ class TransformerNeuronXProperties(Properties):
     enable_mixed_precision_accumulation: Optional[bool] = None
     enable_saturate_infinity: Optional[bool] = None
     dtype: Dtype = Dtype.f16
-    n_positions: int = 128
+    n_positions: Optional[int] = None
     unroll: Optional[str] = None
     load_in_8bit: Optional[bool] = None
     low_cpu_mem_usage: bool = False

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
@@ -209,6 +209,30 @@ class TestTransformerNeuronXService(unittest.TestCase):
                          self.service.config.save_mp_checkpoint_path)
         self.assertTrue(self.service.initialized)
 
+    @parameters([{
+        "initial_value": 512,
+        "smart_default": 512
+    }, {
+        "initial_value": 8192,
+        "smart_default": 4096
+    }])
+    def test_smart_defaults(self, params):
+        # Setup
+        self.default_properties.pop('n_positions')
+        test_properties = self.default_properties
+        self.service.config = self.config_builder(test_properties)
+        self.service.model_config = AutoConfig.from_pretrained(
+            test_properties['model_id'])
+        self.service.model_config.max_position_embeddings = params[
+            'initial_value']
+
+        # Test
+        self.service.set_max_position_embeddings()
+
+        # Evaluate
+        self.assertEqual(self.service.config.n_positions,
+                         params['smart_default'])
+
     def tearDown(self):
         del self.service
         del self.default_properties


### PR DESCRIPTION
## Description ##

This PR updates LMI NeuronX's default logic for `n_positions`, updating it from a naive 128 tokens to being based off of the model configs max embeddings, or 4096 - whichever is smaller.
