### PR TITLE
[feat] lmi neuronx add smart defaults context length estimates

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -25,7 +25,7 @@ from transformers_neuronx import NeuronAutoModelForCausalLM
 from transformers_neuronx.config import NeuronConfig, QuantizationConfig, ContinuousBatchingConfig, GenerationConfig as NeuronGenerationConfig
 from djl_python.properties_manager.tnx_properties import TnXGenerationStrategy, TnXModelSchema, TnXMemoryLayout
 from transformers_neuronx.module import save_pretrained_split
-from djl_python.neuron_utils.utils import NeuronXModelAdapter, get_neuronxcc_version
+from djl_python.neuron_utils.utils import NeuronXModelAdapter, get_neuronxcc_version, build_context_length_estimates
 from huggingface_hub import hf_hub_download
 
 # Temporary Fix: These loggers are disabled during vLLM import.
@@ -222,13 +222,19 @@ class TNXModelLoader(ModelLoader):
         # Continuous batching requires positions and estimates as lists instead of int
         if self.use_continuous_batching:
             model_kwargs["n_positions"] = [self.config.n_positions]
-            if self.config.context_length_estimate is None:
+            if self.config.context_length_estimate is None and self.config.cache_layout == TnXMemoryLayout.LAYOUT_BSH:
                 model_kwargs["context_length_estimate"] = [
                     self.config.n_positions
                 ]
-            elif self.config.context_length_estimate != [
-                    self.config.n_positions
-            ] and self.config.cache_layout == TnXMemoryLayout.LAYOUT_BSH:
+            elif self.config.context_length_estimate is None:
+                model_kwargs[
+                    "context_length_estimate"] = build_context_length_estimates(
+                        self.config.n_positions)
+                logging.info(
+                    f"Setting context_length_estimate to {model_kwargs['context_length_estimate']}"
+                )
+            elif self.config.context_length_estimate is not None and self.config.context_length_estimate[
+                    0] != self.config.n_positions and self.config.cache_layout == TnXMemoryLayout.LAYOUT_BSH:
                 raise RuntimeError(
                     f"context_length_estimate {self.config.context_length_estimate}"
                     f" need to be the same as n_positions {self.config.n_positions}"

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
@@ -21,6 +21,7 @@ try:
     from djl_python.properties_manager.tnx_properties import TransformerNeuronXProperties, TnXGenerationStrategy
     from djl_python.neuron_utils.model_loader import TNXModelLoader, OptimumModelLoader
     from djl_python.rolling_batch.neuron_rolling_batch import NeuronRollingBatch
+    from djl_python.neuron_utils.utils import build_context_length_estimates
     SKIP_TEST = False
 except ImportError:
     SKIP_TEST = True
@@ -236,6 +237,29 @@ class TestTransformerNeuronXService(unittest.TestCase):
     def tearDown(self):
         del self.service
         del self.default_properties
+
+
+@parameterized
+@unittest.skipIf(SKIP_TEST, "Neuron dependencies are not available")
+class TestTransformersNeuronXUtils(unittest.TestCase):
+
+    @parameters([{
+        "initial_value": 64,
+        "smart_default": [64]
+    }, {
+        "initial_value": 512,
+        "smart_default": [128, 512]
+    }, {
+        "initial_value": 8192,
+        "smart_default": [128, 1024, 2048, 4096, 8192]
+    }])
+    def test_build_context_length_estimate(self, params):
+        # Setup
+        # Test
+        output = build_context_length_estimates(params['initial_value'])
+
+        # Evaluate
+        self.assertListEqual(output, params['smart_default'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##

Adds smart defaults for context length estimates when using continuous batching. 
