### PR TITLE
[ci] fix device_map auto change in hf handler

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1176,6 +1176,7 @@ def build_hf_handler_model(model):
     options["option.entryPoint"] = "djl_python.huggingface"
     options["option.predict_timeout"] = 240
     options["option.rolling_batch"] = "disable"
+    options["option.device_map"] = "auto"
 
     adapter_ids = options.pop("adapter_ids", [])
     adapter_names = options.pop("adapter_names", [])


### PR DESCRIPTION
## Description ##

In the previous PR, we decided to set device_map to None, as some models like object detection does not work with pipeline parallelism. Before that, we default device_map = auto always, which is not good. 

Now, we need to enable it whenever we want to use pipeline parallelism. [This will be a breaking change in V12]
