### PR TITLE
[ci] Fix awscurl run headers

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -975,7 +975,7 @@ def awscurl_run(data,
                 json_results=False,
                 random_delay=False):
     find_awscurl()
-    headers = "Content-type: application/json"
+    headers = "Content-type:application/json"
     endpoint = f"http://127.0.0.1:8080/invocations"
     if dataset:
         dataset_dir = os.path.join(os.path.curdir, "dataset")

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -975,7 +975,7 @@ def awscurl_run(data,
                 json_results=False,
                 random_delay=False):
     find_awscurl()
-    headers = "Content-type:application/json"
+    headers = "'Content-type: application/json'"
     endpoint = f"http://127.0.0.1:8080/invocations"
     if dataset:
         dataset_dir = os.path.join(os.path.curdir, "dataset")


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix awscurl run headers: Remove space because it's string.