### PR TITLE
[fix] prevent requests being sent to python model until model is full…

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
@@ -63,7 +63,7 @@ class PyPredictor<I, O> extends Predictor<I, O> {
     @Override
     @SuppressWarnings("unchecked")
     public List<O> batchPredict(List<I> inputs) throws TranslateException {
-        if (process.isStopped()) {
+        if (!process.isReady()) {
             // TODO: wait for restart
             throw new TranslateException("Backend Python process is stopped.");
         }

--- a/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
@@ -14,6 +14,7 @@ package ai.djl.python.engine;
 
 import ai.djl.Device;
 import ai.djl.Model;
+import ai.djl.engine.EngineException;
 import ai.djl.inference.Predictor;
 import ai.djl.modality.Input;
 import ai.djl.modality.Output;
@@ -66,6 +67,9 @@ class PyPredictor<I, O> extends Predictor<I, O> {
         if (!process.isReady()) {
             // TODO: wait for restart
             throw new TranslateException("Backend Python process is stopped.");
+        }
+        if (process.isModelUnrecoverable()) {
+            throw new EngineException("Backend Python process is unrecoverable.");
         }
         Object first = inputs.get(0);
         if (first instanceof Input) {

--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -48,6 +48,7 @@ class PyProcess {
     private CountDownLatch latch;
     private volatile boolean started; // NOPMD
     private volatile boolean modelLoaded; // NOPMD
+    private volatile boolean modelUnrecoverable; // NOPMD
     private AtomicInteger restartCount;
     private CompletableFuture<Void> restartFuture;
     private boolean trtLlmMode;
@@ -124,6 +125,8 @@ class PyProcess {
             if (!initialLoad) {
                 logger.info("Restart python process ...");
                 restartFuture = CompletableFuture.runAsync(this::startPythonProcess);
+            } else {
+                modelUnrecoverable = true;
             }
             if (e instanceof EngineException) {
                 throw (EngineException) e;
@@ -238,6 +241,10 @@ class PyProcess {
 
     boolean isReady() {
         return started && modelLoaded;
+    }
+
+    boolean isModelUnrecoverable() {
+        return modelUnrecoverable;
     }
 
     static final class ReaderThread extends Thread {

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -392,6 +392,15 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                         // SIGKILL (9 + 128)
                         System.exit(137); // NOPMD
                     }
+                    boolean isHealthCheckOverrideEnabled =
+                            Boolean.parseBoolean(
+                                    Utils.getEnvOrSystemProperty("SERVING_HEALTH_CHECK_OVERRIDE"));
+                    if (isHealthCheckOverrideEnabled) {
+                        logger.error(
+                                "SERVING_HEALTH_CHECK_OVERRIDE is enabled. At least 1 model worker"
+                                    + " has exhausted all retries. Not marking model as failed");
+                        return Status.READY;
+                    }
 
                     return Status.FAILED;
                 }


### PR DESCRIPTION
…y loaded and warmup request has completed

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
