### PR TITLE
[fix] prevent requests being sent to python model until model is full…

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
@@ -63,7 +63,7 @@ class PyPredictor<I, O> extends Predictor<I, O> {
     @Override
     @SuppressWarnings("unchecked")
     public List<O> batchPredict(List<I> inputs) throws TranslateException {
-        if (process.isStopped()) {
+        if (!process.isReady()) {
             // TODO: wait for restart
             throw new TranslateException("Backend Python process is stopped.");
         }

--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -50,6 +50,7 @@ class PyProcess {
     private List<Connection> connections;
     private CountDownLatch latch;
     private volatile boolean started; // NOPMD
+    private volatile boolean modelLoaded; // NOPMD
     private AtomicInteger restartCount;
     private CompletableFuture<Void> restartFuture;
     private boolean trtLlmMode;
@@ -156,6 +157,7 @@ class PyProcess {
 
     synchronized void startPythonProcess() {
         try {
+            modelLoaded = false;
             int id = restartCount.get();
             int port = connections.get(0).getPort();
             logger.info("Start process: {} - retry: {}", port, id);
@@ -191,6 +193,7 @@ class PyProcess {
             Input init = new Input();
             init.setProperties(pyEnv.getInitParameters());
             predict(init, pyEnv.getModelLoadingTimeout(), true);
+            modelLoaded = true;
         } catch (EngineException e) {
             started = false;
             throw e;
@@ -256,8 +259,8 @@ class PyProcess {
         }
     }
 
-    boolean isStopped() {
-        return !started;
+    boolean isReady() {
+        return started && modelLoaded;
     }
 
     private static String[] getHosts(int clusterSize) {


### PR DESCRIPTION
…y loaded and warmup request has completed

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
