### PR TITLE
[lmi][neuron] Add smart defaults to LMI Neuron

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -82,6 +82,7 @@ transformers_neuronx_handler_list = {
         "max_dynamic_batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600
     },
@@ -90,6 +91,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600,
         "option.quantize": "static_int8"
@@ -99,6 +101,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600
     },
@@ -107,6 +110,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 4,
         "option.tensor_parallel_degree": 8,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp32",
         "option.model_loading_timeout": 2400
     },
@@ -115,6 +119,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 4,
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 900
     },
@@ -123,6 +128,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 256,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 1200
     },
@@ -130,6 +136,7 @@ transformers_neuronx_handler_list = {
         "option.model_id": "s3://djl-llm/mixtral-8x7b/",
         "option.tensor_parallel_degree": 8,
         "option.n_positions": 1024,
+        "option.rolling_batch": 'disable',
         "batch_size": 4,
         "option.model_loading_timeout": 3600,
     },
@@ -138,6 +145,7 @@ transformers_neuronx_handler_list = {
         "batch_size": 2,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
+        "option.rolling_batch": 'disable',
         "option.dtype": "fp16",
         "option.model_loading_timeout": 600,
         "option.enable_streaming": True,
@@ -180,7 +188,6 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 512,
         "option.max_rolling_batch_size": 4,
-        "option.rolling_batch": 'auto',
         "option.model_loading_timeout": 2400,
         "option.load_split_model": True,
         "option.output_formatter": "jsonlines"
@@ -206,7 +213,6 @@ transformers_neuronx_handler_list = {
     },
     "mistral-7b-rb": {
         "option.model_id": "s3://djl-llm/mistral-7b-instruct-v02/",
-        "option.rolling_batch": "auto",
         "option.max_rolling_batch_size": 4,
         "option.tensor_parallel_degree": 4,
         "option.n_positions": 1024,
@@ -217,7 +223,6 @@ transformers_neuronx_handler_list = {
         "option.speculative_draft_model": "s3://djl-llm/llama-2-tiny/",
         "option.speculative_length": 7,
         "option.tensor_parallel_degree": 12,
-        "option.rolling_batch": "auto",
         "option.max_rolling_batch_size": 1,
         "option.model_loading_timeout": 3600,
         "option.output_formatter": "jsonlines"
@@ -231,7 +236,6 @@ transformers_neuronx_handler_list = {
         "s3://djl-llm/inf2-compiled-graphs/llama-2-tiny/",
         "option.speculative_length": 4,
         "option.tensor_parallel_degree": 12,
-        "option.rolling_batch": "auto",
         "option.max_rolling_batch_size": 1,
         "option.model_loading_timeout": 3600,
         "option.output_formatter": "jsonlines"
@@ -241,7 +245,6 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 1024,
         "option.max_rolling_batch_size": 4,
-        "option.rolling_batch": 'auto',
         "option.model_loading_timeout": 1200,
     },
     "tiny-llama-rb-aot-quant": {
@@ -250,7 +253,6 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 2,
         "option.n_positions": 1024,
         "option.max_rolling_batch_size": 4,
-        "option.rolling_batch": 'auto',
         "option.model_loading_timeout": 1200,
     }
 }

--- a/wlm/build.gradle.kts
+++ b/wlm/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     testImplementation(libs.testng) {
         exclude(group = "junit", module = "junit")
     }
+    testImplementation("org.mockito:mockito-core:5.11.0")
 
     testRuntimeOnly("ai.djl:model-zoo")
     testRuntimeOnly("ai.djl.pytorch:pytorch-engine")

--- a/wlm/src/main/java/ai/djl/serving/wlm/NeuronSmartDefaultUtils.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/NeuronSmartDefaultUtils.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.serving.wlm.LmiUtils.HuggingFaceModelConfig;
+import ai.djl.util.NeuronUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/** A utility class to auto configure LMI Neuron model properties. */
+public class NeuronSmartDefaultUtils {
+
+    private static final float BILLION = 1_000_000_000.0F;
+    private static final int MAX_ROLLING_BATCH = 128; // Current cap for NeuronSDK 2.19.1
+    private static final float MEMORY_PER_CORE =
+            16.0F; // Currently there is only one config w/ 16 gb per core
+
+    private int availableCores;
+    private float modelSizeInGb;
+    private float sequenceSizeInGb;
+
+    /**
+     * Applies smart defaults for Neuron models.
+     *
+     * <p>This method sets the following properties if not already set:
+     *
+     * <ul>
+     *   <li>option.n_positions: The default n_positions for the model.
+     *   <li>option.tensor_parallel_degree: A heuristic based on available memory.
+     *   <li>option.max_rolling_batch_size: A heuristic based on available memory.
+     * </ul>
+     *
+     * @param prop the properties to update
+     * @param modelConfig the model configuration to use
+     */
+    public void applySmartDefaults(Properties prop, HuggingFaceModelConfig modelConfig) {
+        if (!prop.containsKey("option.n_positions")) {
+            prop.setProperty(
+                    "option.n_positions", String.valueOf(modelConfig.getDefaultNPositions()));
+        }
+        setInternalSettings(prop, modelConfig);
+        setHeuristicNeuronTPDegree(prop);
+        setHeuristicNeuronMaxRollingBatch(prop);
+    }
+
+    /**
+     * Sets the internal settings for the NeuronSmartDefaultUtils instance.
+     *
+     * @param prop the properties to retrieve settings from
+     * @param modelConfig the model configuration to use for calculations
+     */
+    private void setInternalSettings(Properties prop, HuggingFaceModelConfig modelConfig) {
+        // Internal settings
+        int nPositions = Integer.parseInt(prop.getProperty("option.n_positions", "0"));
+        if (NeuronUtils.hasNeuron()) {
+            availableCores = NeuronUtils.getNeuronCores();
+        } else {
+            availableCores = 1;
+        }
+        int paramBytes = prop.containsKey("option.quantize") ? 1 : 2;
+        modelSizeInGb = (paramBytes * modelConfig.getModelParameters()) / BILLION;
+        sequenceSizeInGb =
+                modelConfig.getApproxMemoryForSingleSequence(nPositions, paramBytes)
+                        / (1024.0F * 1024.0F * 1024.0F);
+    }
+
+    /**
+     * Calculates the adjusted model size in GB, given a tensor parallel degree.
+     *
+     * <p>This method takes the model size in GB and adjusts it based on the tensor parallel degree.
+     * The adjustment is a linear relationship between the model size and the tensor parallel
+     * degree. The adjustment is based on the estimated memory increase due to the tensor parallel
+     * degree.
+     *
+     * @param tpDegree the tensor parallel degree
+     * @return the adjusted model size in GB
+     */
+    private float getAdjustedModelSizeInGb(int tpDegree) {
+        return modelSizeInGb * (1.0F + ((tpDegree * 2 - 2) / 100.0F));
+    }
+
+    /**
+     * Sets a heuristic value for tensor parallel degree if not already set in model properties.
+     *
+     * <p>This method sets the value of tensor parallel degree by iterating through the available
+     * core configurations and checks if the current core configuration can support the maximum
+     * rolling batch size that can fit in the available memory. If the current configuration can
+     * support the maximum rolling batch size, then the current core configuration is used as the
+     * tensor parallel degree.
+     *
+     * <p>If the maximum rolling batch size is not set, then the maximum instance concurrency is
+     * used as the maximum rolling batch size.
+     *
+     * <p>This method is called by the LMI model server when it is starting up and is used to set
+     * the tensor parallel degree if it is not already set in the model properties.
+     *
+     * @param prop the model properties
+     */
+    private void setHeuristicNeuronTPDegree(Properties prop) {
+        int tpDegree = availableCores;
+        float totalMemory = tpDegree * MEMORY_PER_CORE;
+        // Disambiguate "max" and available cores
+        if (prop.containsKey("option.tensor_parallel_degree")
+                && "max".equals(prop.getProperty("option.tensor_parallel_degree"))) {
+            prop.setProperty("option.tensor_parallel_degree", String.valueOf(availableCores));
+            return;
+        }
+
+        List<Integer> coreConfigs = availableCoreConfigs();
+        if (!prop.containsKey("option.tensor_parallel_degree")
+                && !prop.containsKey("option.max_rolling_batch_size")) {
+            // Set tensor parallel degree based off of maximizing instance concurrency with variable
+            // rolling batch size
+            int totalInstanceConcurrency = getMaxConcurrency(totalMemory, tpDegree);
+            for (int coreConfig : coreConfigs) {
+                float maxMemory = coreConfig * MEMORY_PER_CORE;
+                int maxConcurrency = getMaxConcurrency(maxMemory, coreConfig);
+                if (maxConcurrency >= totalInstanceConcurrency && coreConfig <= tpDegree) {
+                    tpDegree = coreConfig;
+                    totalInstanceConcurrency = maxConcurrency;
+                }
+            }
+            prop.setProperty("option.tensor_parallel_degree", String.valueOf(tpDegree));
+        } else if (!prop.containsKey("option.tensor_parallel_degree")) {
+            // Set tensor parallel degree by minimizing TP degree that supports fixed batch size
+            int batchSize = Integer.parseInt(prop.getProperty("option.max_rolling_batch_size"));
+            int totalInstanceConcurrency =
+                    getMaxConcurrencyWithBatch(totalMemory, tpDegree, batchSize);
+            for (int coreConfig : coreConfigs) {
+                float maxMemory = coreConfig * MEMORY_PER_CORE;
+                int maxConcurrency = getMaxConcurrencyWithBatch(maxMemory, coreConfig, batchSize);
+                if (maxConcurrency >= totalInstanceConcurrency && coreConfig <= tpDegree) {
+                    tpDegree = coreConfig;
+                    totalInstanceConcurrency = maxConcurrency;
+                }
+            }
+            prop.setProperty("option.tensor_parallel_degree", String.valueOf(tpDegree));
+        }
+    }
+
+    /**
+     * Finds the largest power of 2 less than or equal to n.
+     *
+     * @param n the input number
+     * @return the largest power of 2 less than or equal to n
+     */
+    private int getMaxPowerOf2(int n) {
+        if (n != 0 && (n & (n - 1)) == 0) {
+            return n;
+        }
+        int maxPowerOf2 = 1;
+        while (maxPowerOf2 < n) {
+            maxPowerOf2 *= 2;
+        }
+        return maxPowerOf2 / 2;
+    }
+
+    /**
+     * Calculates the maximum number of concurrent requests that can be served by a model given the
+     * total memory available for the model and the sequence size.
+     *
+     * <p>The maximum number of concurrent requests is calculated as the largest power of 2 less
+     * than or equal to the total memory divided by the sequence size.
+     *
+     * @param totalMemory the total memory available for the model
+     * @param tpDegree the tensor parallel degree
+     * @return the maximum number of concurrent requests
+     */
+    private int getMaxConcurrency(float totalMemory, int tpDegree) {
+        int maxConcurrency =
+                (int) ((totalMemory - getAdjustedModelSizeInGb(tpDegree)) / sequenceSizeInGb);
+        maxConcurrency = getMaxPowerOf2(maxConcurrency);
+        return Math.min(maxConcurrency, MAX_ROLLING_BATCH);
+    }
+
+    /**
+     * Calculates the maximum number of concurrent requests that can be served by a model given the
+     * total memory available for the model and the sequence size.
+     *
+     * @param totalMemory the total memory available for the model
+     * @param tpDegree the tensor parallel degree
+     * @param batchSize the maximum number of requests that can be processed in a single batch
+     * @return the maximum number of concurrent requests that can be served
+     */
+    private int getMaxConcurrencyWithBatch(float totalMemory, int tpDegree, int batchSize) {
+        int maxConcurrency =
+                (int) ((totalMemory - getAdjustedModelSizeInGb(tpDegree)) / sequenceSizeInGb);
+        maxConcurrency = getMaxPowerOf2(maxConcurrency);
+        maxConcurrency = Math.min(maxConcurrency, batchSize);
+        if (maxConcurrency == batchSize) {
+            return maxConcurrency;
+        }
+        return 0;
+    }
+
+    /**
+     * Builds the available core configurations for a given number of cores.
+     *
+     * <p>The available core configurations are those that are less than or equal to the total
+     * number of cores. This method returns a list of available core configurations for the given
+     * number of cores.
+     *
+     * @return the list of available core configurations
+     */
+    private List<Integer> availableCoreConfigs() {
+        List<Integer> coreConfigs = new ArrayList<>();
+        List<Integer> availableCoreConfigs = buildCoreConfigs(availableCores);
+        int coresPerModel = (int) Math.ceil(modelSizeInGb / MEMORY_PER_CORE);
+        for (int coreConfig : availableCoreConfigs) {
+            if (coresPerModel >= coreConfig) {
+                coreConfigs.add(coreConfig);
+            }
+        }
+        return coreConfigs;
+    }
+
+    /**
+     * Builds the available core configurations for a given number of cores.
+     *
+     * <p>The available core configurations are those that are less than or equal to the total
+     * number of cores. This method returns a list of available core configurations for the given
+     * number of cores.
+     *
+     * @param nCores the number of cores to build the configurations for
+     * @return the list of available core configurations
+     */
+    private List<Integer> buildCoreConfigs(int nCores) {
+        List<Integer> coreConfigs = new ArrayList<>();
+        // Add all powers of 2 up to the given number of cores
+        for (int i = 1; i <= 8; i *= 2) {
+            // Skip TP=4 for nCores=32 as it is not supported
+            if (i != 4 || nCores != 32) {
+                coreConfigs.add(i);
+            }
+        }
+        // Add the given number of cores to the list
+        coreConfigs.add(nCores);
+        return coreConfigs;
+    }
+
+    /**
+     * Sets the max rolling batch size based on the TP degree and the model memory size.
+     *
+     * <p>If the max rolling batch size is not set, this method sets it to the maximum number of
+     * concurrent requests that can be served by a model given the total memory available for the
+     * model and the sequence size.
+     *
+     * @param prop the properties to set the max rolling batch size to
+     */
+    private void setHeuristicNeuronMaxRollingBatch(Properties prop) {
+        int tpDegree =
+                Integer.parseInt(
+                        prop.getProperty(
+                                "option.tensor_parallel_degree", String.valueOf(availableCores)));
+        if (!prop.containsKey("option.max_rolling_batch_size")) {
+            int maxRollingBatchSize = getMaxConcurrency(tpDegree * MEMORY_PER_CORE, tpDegree);
+            if (maxRollingBatchSize > 0) {
+                prop.setProperty(
+                        "option.max_rolling_batch_size", String.valueOf(maxRollingBatchSize));
+            }
+        }
+    }
+}

--- a/wlm/src/test/java/ai/djl/serving/wlm/NeuronSmartDefaultUtilsTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/NeuronSmartDefaultUtilsTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.wlm;
+
+import ai.djl.serving.wlm.LmiUtils.HuggingFaceModelConfig;
+import ai.djl.util.JsonUtils;
+import ai.djl.util.NeuronUtils;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * {@link NeuronSmartDefaultUtils}.
+ *
+ * @author tyoster @ Amazon.com, Inc.
+ */
+public class NeuronSmartDefaultUtilsTest {
+
+    // Known model parameter tests for LMI Utils HuggingFaceModelConfig
+    @Test
+    public void testModelConfigParametersLlama() throws IOException {
+        LmiUtils.HuggingFaceModelConfig modelConfig = get70BLlamaHuggingFaceModelConfig();
+        Assert.assertEquals(modelConfig.getDefaultNPositions(), 4096);
+        Assert.assertEquals(modelConfig.getModelParameters(), 71895883776L);
+    }
+
+    @Test
+    public void testModelConfigParametersDefault() throws IOException {
+        LmiUtils.HuggingFaceModelConfig modelConfig = getDefaultHuggingFaceModelConfig();
+        Assert.assertEquals(modelConfig.getDefaultNPositions(), 1);
+        Assert.assertEquals(modelConfig.getModelParameters(), 19L);
+    }
+
+    @Test
+    public void testModelConfigParametersNoParameters() throws IOException {
+        LmiUtils.HuggingFaceModelConfig modelConfig = getNoParametersHuggingFaceModelConfig();
+        Assert.assertEquals(modelConfig.getDefaultNPositions(), 1);
+        Assert.assertEquals(modelConfig.getModelParameters(), 0L);
+    }
+
+    // Standard use tests on without Neuron device available
+    @Test
+    public void testApplySmartDefaults70BModel() throws IOException {
+        Properties prop = new Properties();
+        LmiUtils.HuggingFaceModelConfig modelConfig = get70BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "4096");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertFalse(prop.containsKey("option.max_rolling_batch_size"));
+    }
+
+    @Test
+    public void testApplySmartDefaultsQuantize8BModel() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.quantize", "static_int8");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get8BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "4096");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "8");
+    }
+
+    @Test
+    public void testApplySmartDefaults2BModel() throws IOException {
+        Properties prop = new Properties();
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "2048");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "64");
+    }
+
+    @Test
+    public void testApplySmartDefaultsQuantize2BModel() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.quantize", "static_int8");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "2048");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "128");
+    }
+
+    @Test
+    public void testApplySmartDefaultsWithNPositions() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.n_positions", "128");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "128");
+    }
+
+    @Test
+    public void testApplySmartDefaultsWithTPDegree() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.tensor_parallel_degree", "1");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "2048");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "64");
+    }
+
+    @Test
+    public void testApplySmartDefaultsWithMaxRollingBatch() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.max_rolling_batch_size", "64");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "2048");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+    }
+
+    @Test
+    public void testApplySmartDefaultsWithTPMax() throws IOException {
+        Properties prop = new Properties();
+        prop.setProperty("option.tensor_parallel_degree", "max");
+        LmiUtils.HuggingFaceModelConfig modelConfig = get2BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(false);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "2048");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "1");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "64");
+    }
+
+    @Test
+    public void testApplySmartDefaultsWithNeuron() throws IOException {
+        Properties prop = new Properties();
+        LmiUtils.HuggingFaceModelConfig modelConfig = get70BLlamaHuggingFaceModelConfig();
+        try (MockedStatic<NeuronUtils> mockedStatic = Mockito.mockStatic(NeuronUtils.class)) {
+            mockedStatic.when(NeuronUtils::hasNeuron).thenReturn(true);
+            mockedStatic.when(NeuronUtils::getNeuronCores).thenReturn(32);
+            NeuronSmartDefaultUtils smartDefaultUtils = new NeuronSmartDefaultUtils();
+            smartDefaultUtils.applySmartDefaults(prop, modelConfig);
+        }
+        Assert.assertEquals(prop.getProperty("option.n_positions"), "4096");
+        Assert.assertEquals(prop.getProperty("option.tensor_parallel_degree"), "32");
+        Assert.assertEquals(prop.getProperty("option.max_rolling_batch_size"), "32");
+    }
+
+    // Helper methods
+    public HuggingFaceModelConfig get2BLlamaHuggingFaceModelConfig() throws IOException {
+        try (Reader reader =
+                Files.newBufferedReader(
+                        Paths.get("src/test/resources/smart-default-model/2b/config.json"))) {
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
+        }
+    }
+
+    public HuggingFaceModelConfig get8BLlamaHuggingFaceModelConfig() throws IOException {
+        try (Reader reader =
+                Files.newBufferedReader(
+                        Paths.get("src/test/resources/smart-default-model/8b/config.json"))) {
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
+        }
+    }
+
+    public HuggingFaceModelConfig get70BLlamaHuggingFaceModelConfig() throws IOException {
+        try (Reader reader =
+                Files.newBufferedReader(
+                        Paths.get("src/test/resources/smart-default-model/70b/config.json"))) {
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
+        }
+    }
+
+    public HuggingFaceModelConfig getDefaultHuggingFaceModelConfig() throws IOException {
+        try (Reader reader =
+                Files.newBufferedReader(
+                        Paths.get("src/test/resources/smart-default-model/unit/config.json"))) {
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
+        }
+    }
+
+    public HuggingFaceModelConfig getNoParametersHuggingFaceModelConfig() throws IOException {
+        try (Reader reader =
+                Files.newBufferedReader(
+                        Paths.get("src/test/resources/smart-default-model/empty/config.json"))) {
+            return JsonUtils.GSON.fromJson(reader, HuggingFaceModelConfig.class);
+        }
+    }
+}

--- a/wlm/src/test/resources/smart-default-model/2b/config.json
+++ b/wlm/src/test/resources/smart-default-model/2b/config.json
@@ -1,0 +1,26 @@
+{
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 5632,
+  "max_position_embeddings": 2048,
+  "model_type": "llama",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 22,
+  "num_key_value_heads": 4,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": null,
+  "rope_theta": 10000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.35.0",
+  "use_cache": true,
+  "vocab_size": 32000
+}

--- a/wlm/src/test/resources/smart-default-model/70b/config.json
+++ b/wlm/src/test/resources/smart-default-model/70b/config.json
@@ -1,0 +1,38 @@
+{
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 128000,
+  "eos_token_id": [
+    128001,
+    128008,
+    128009
+  ],
+  "hidden_act": "silu",
+  "hidden_size": 8192,
+  "initializer_range": 0.02,
+  "intermediate_size": 28672,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 64,
+  "num_hidden_layers": 80,
+  "num_key_value_heads": 8,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": {
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3"
+  },
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.42.3",
+  "use_cache": true,
+  "vocab_size": 128256
+}

--- a/wlm/src/test/resources/smart-default-model/8b/config.json
+++ b/wlm/src/test/resources/smart-default-model/8b/config.json
@@ -1,0 +1,34 @@
+{
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 128000,
+  "eos_token_id": 128001,
+  "hidden_act": "silu",
+  "hidden_size": 4096,
+  "initializer_range": 0.02,
+  "intermediate_size": 14336,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "num_key_value_heads": 8,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": {
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3"
+  },
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.43.0.dev0",
+  "use_cache": true,
+  "vocab_size": 128256
+}

--- a/wlm/src/test/resources/smart-default-model/empty/config.json
+++ b/wlm/src/test/resources/smart-default-model/empty/config.json
@@ -1,0 +1,20 @@
+{
+  "architectures": [
+    "DefaultForCausalLM"
+  ],
+  "attention_bias": false,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "hidden_act": "silu",
+  "initializer_range": 0.02,
+  "max_position_embeddings": 1,
+  "model_type": "default",
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": null,
+  "rope_theta": 10000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.35.0",
+  "use_cache": true
+}

--- a/wlm/src/test/resources/smart-default-model/unit/config.json
+++ b/wlm/src/test/resources/smart-default-model/unit/config.json
@@ -1,0 +1,26 @@
+{
+  "architectures": [
+    "DefaultForCausalLM"
+  ],
+  "attention_bias": false,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "hidden_act": "silu",
+  "hidden_size": 1,
+  "initializer_range": 0.02,
+  "intermediate_size": 1,
+  "max_position_embeddings": 1,
+  "model_type": "default",
+  "num_attention_heads": 1,
+  "num_hidden_layers": 1,
+  "num_key_value_heads": 1,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": null,
+  "rope_theta": 10000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.35.0",
+  "use_cache": true,
+  "vocab_size": 1
+}


### PR DESCRIPTION
## Description ##

Part 2 of the smart defaults for Neuron. Updates:
- rolling batch default to auto
- TP degree heuristically determined based on model config
- max rolling batch size heuristically determined based on model config

Smart defaults are determined by the maximum concurrency for the total instance, so in instances where we are will to make a large tradeoff for latency we will need to override the max batch size and lower it.