### PR TITLE
[ci] remove precompiled trt tests because of switch from g5 to g6

### DIFF
--- a/.github/workflows/llm_integration.yml
+++ b/.github/workflows/llm_integration.yml
@@ -194,17 +194,18 @@ jobs:
           python3 llm/client.py trtllm llama2-13b
           rm -rf docker_env
           docker rm -f $(docker ps -aq)
-      - name: falcon-7b triton repo with tp=1
-        working-directory: tests/integration
-        run: |
-          rm -rf models
-          echo -en "CUDA_VISIBLE_DEVICES=0" > docker_env
-          python3 llm/prepare.py trtllm falcon-7b
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
-          serve
-          python3 llm/client.py trtllm falcon-7b
-          rm -rf docker_env
-          docker rm -f $(docker ps -aq)
+# TODO (maybe): model is compiled for g5, needs recompile for g6
+#      - name: falcon-7b triton repo with tp=1
+#        working-directory: tests/integration
+#        run: |
+#          rm -rf models
+#          echo -en "CUDA_VISIBLE_DEVICES=0" > docker_env
+#          python3 llm/prepare.py trtllm falcon-7b
+#          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
+#          serve
+#          python3 llm/client.py trtllm falcon-7b
+#          rm -rf docker_env
+#          docker rm -f $(docker ps -aq)
       - name: internlm-7b HF model with tp=4
         working-directory: tests/integration
         run: |
@@ -341,17 +342,18 @@ jobs:
           python3 llm/client.py trtllm qwen-7b
           rm -rf docker_env
           docker rm -f $(docker ps -aq)
-      - name: flan-t5-xxl pre-compiled model with python backend
-        working-directory: tests/integration
-        run: |
-          rm -rf models
-          echo -en "CUDA_VISIBLE_DEVICES=0,1,2,3" > docker_env
-          python3 llm/prepare.py trtllm flan-t5-xxl
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
-          serve
-          python3 llm/client.py trtllm-python flan-t5-xxl
-          rm -rf docker_env
-          docker rm -f $(docker ps -aq)
+# TODO (maybe): model is compiled for g5, needs recompile for g6
+#      - name: flan-t5-xxl pre-compiled model with python backend
+#        working-directory: tests/integration
+#        run: |
+#          rm -rf models
+#          echo -en "CUDA_VISIBLE_DEVICES=0,1,2,3" > docker_env
+#          python3 llm/prepare.py trtllm flan-t5-xxl
+#          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models trtllm \
+#          serve
+#          python3 llm/client.py trtllm-python flan-t5-xxl
+#          rm -rf docker_env
+#          docker rm -f $(docker ps -aq)
       - name: On fail step
         if: ${{ failure() }}
         working-directory: tests/integration


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
