### PR TITLE
[ci] stop the g6 instance for multi-node integration test

### DIFF
--- a/.github/workflows/multi_node_integration.yml
+++ b/.github/workflows/multi_node_integration.yml
@@ -106,3 +106,4 @@ jobs:
         run: |
           cd /home/ubuntu/djl_benchmark_script/scripts
           instance_id=${{ needs.create-runners.outputs.gpu_instance_id_1 }}
+          ./stop_instance.sh $instance_id


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
