### PR TITLE
[fix] Format input text to avoid error

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -10,6 +10,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
+import json
 from collections import OrderedDict
 from typing import Any
 
@@ -279,7 +280,9 @@ def get_multi_modal_data(request: Request) -> dict:
 
 
 def get_prompt_inputs(request: Request):
-    prompt_inputs: PromptInputs = {"prompt": request.request_input.input_text}
+    prompt_inputs: PromptInputs = {
+        "prompt": json.dumps(request.request_input.input_text)
+    }
     multi_modal_data = get_multi_modal_data(request)
     if multi_modal_data:
         prompt_inputs["multi_modal_data"] = multi_modal_data


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

I got error below: 

INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.30.0-SNAPSHOT/djl_python/rolling_batch/rolling_batch.py", line 48, in try_catch_handling
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    return func(self, *args, **kwargs)
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.30.0-SNAPSHOT/djl_python/rolling_batch/lmi_dist_rolling_batch.py", line 179, in inference
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    self.engine.add_request(lmi_dist_request)
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/engine.py", line 5, in add_request
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    def add_request(A,request:Request):B=request;A.preprocessor.preprocess(B);A.scheduler.add_request(B)
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/vllm_engine.py", line 26, in preprocess
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    A.prompt_token_ids=C.tokenizer.encode(A.prompt,lora_request=A.lora_request)
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/transformers_utils/tokenizer_group/tokenizer_group.py", line 60, in encode
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    ret = tokenizer.encode(prompt)
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils_base.py", line 2843, in encode
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    encoded_inputs = self.encode_plus(
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils_base.py", line 3255, in encode_plus
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    return self._encode_plus(
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils_fast.py", line 601, in _encode_plus
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    batched_output = self._batch_encode_plus(
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils_fast.py", line 528, in _batch_encode_plus
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:    encodings = self._tokenizer.encode_batch(
INFO  PyProcess W-215-model-stdout: [1,0]<stdout>:TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]


The payload has single quotes and double quotes. So add json.dumps() to avoid error.

`
["With Tristran's next step he was standing beside a lake, and the candlelight shone brightly on the water; and then he was walking through the mountains, through lonely crags, where the candlelight was reflected in the eyes of the creatures of the high snows; and then he was walking through the clouds, which, while not entirely substantial, still supported his weight in comfort; and then, holding tightly to his candle, he was underground, and the candlelight glinted back at him from the wet cave walls; now he was in the mountains once more; and then he was on a road through wild forest, and he glimpsed a chariot being pulled by two goats, being driven by a woman in a red dress who looked, for the glimpse he got of her, the way Boadicea was drawn in his history books; and another step and he was in a leafy glen, and he could hear the chuckle of water as it splashed and sang its way into a small brook.\n\nHe took another step, but he was still in the glen", 'He was small, even for a dwarf, and his poor taste in sorcerous robes contrasted awkwardly with D?jebee?s elegant attire; her long, diaphanous gown and his chemical-stained, star-spangled robe clashed almost as much as her vacuous expression alongside his own visage, alive as it was with cunning and a twisted intelligence.\n\nD?jebee sighed with boredom.\n\n?What is it, my love?? Poldanyelz oozed with ersatz concern.\n\n?I?m bored,? D?jebee complained undiplomatically. ?No one ever comes here. I never see anyone except you.?\n\nA shuffling from the main arch alerted her to the inaccuracy of her statement', 'The Librarian thumbed through the bundle of pages, stopping on the final sheet and began reading, ?It is our conclusion that much of the work that is currently done in the Library can be out-sourced to contractors, particularly non-skill specific work such as shelving, stacking...?\nLucy gulped and Gillian began to open her mouth to protest again, but the Librarian carried on regardless, his voice becoming louder in order to drown out any potentially dissenting voices, ?... blah, blah, blah.  It is our recommendation that a downsizing of the non-essential and part-time members of staff would bring instant economy of scale benefits and would allow for the implementation of a new middle management structure.?\n?You mean sacrifice the troops to pay for the generals,? said Gillian', 'There had been himself, Gillian Dawson, the assistant librarian in charge of acquisitions, Chege Gomez, who did something unspecific in the archive section, and a new employee whose name Art had yet to discover, but who turned out to be called Lucy something and who stacked shelves and ran various errands for the deputy librarian, all nervously seated around in a circle, in the surprisingly comfortable chairs in the Librarian?s spacious office, awaiting the arrival of the Main Man.  The delay allowed plenty of time for idle speculation.\n?What do you think he wants?? asked Chege, fidgeting nervously in his chair like a cat on hot bricks.\n?It?s not going to be good news,? said Gillian', 'But I digresseth, for it was the manner of Corgley?s death which did draw suche greate attention from ye populace, for he was walking as normale down the center streete, when suddenly a gashe of large proportiones did appear upon his neck and arms, and he did vanish in a fountain of bloode, from which his bodie could not be founde. The terrible power of ye Daemon of Gorey?s Hollow has become apparent, and it seems as if his power doth extend beyond the Hollow itselfe.\n\nReinhouer flipped ahead three more pages, to the next entry:\n\nThree more have met their endes at my request at the handes of ye Daemon of Gorey?s Hollow', 'The girls all stopped what they were doing, which had been preparing-in various states of distress or, in Sophronia\'s case, delight-to try their own versions of the somersault, and began patting about for handkerchiefs.\n\n"What did I tell you yesterday? A lady always has her handkerchief on her person. A handker[1,0]<stdout>:chief is endlessly useful. Not only is it a communication device, but it can also be dropped as a distraction, scented with various perfumes and noxious gases for discombobulation, used to wipe the forehead of a gentleman, or even bandage a wound, and, of course, you may dab at the eyes or nose if it is still clean', '"Oh yes," he added, seeing Laurence\'s surprise, "the Tsar decided he would not throw a good army after bad, in the end, and perhaps that he did not want to spend the rest of his life as a French prisoner; there is an armistice, and they are negotiating a treaty in Warsaw, the two Emperors, as the best of friends." He gave a bark of laughter. "So you see, they may not bother getting us out; by the end of this month I may be a citoyen myself."\n\nHe had only just escaped the final destruction of Prince Hohenlohe\'s corps, having been ordered to Danzig by courier to secure the fortress against just such a siege', 'The marines could perceive the young people to be friendly (the marines themselves were only 19-year-olds), but, at a distance of about 30 yards, it was as if a warning shot rang out?some of the marines made as if to reach for their weapons.  Mills started from the midst of the group?dark spots under his arms marked where the perspiration had soaked into his shirt.\n"None of us know how we got here," Ray explained, taking on a leadership role.  He had, after all, saved John Henry\'s life, so, although he was younger than John Henry, he had a certain serendipitous good fortune going for him which plucked him out to be leader', 'The Archbishop was due to begin prowling the hallways straight after recess and as there was every chance that more than one of us would get filthy in the twenty-minute break, any thought of outside activity on this day was quietly cancelled. Instead, our daily dose of government-issued milk was to be taken in our classrooms. The crates were dragged inside and deposited in the wide hallway so that each class could troop out in turn, grab a bottle and return to their desks to drink it.\nMrs Payne, consumed with the fear that a spill was inevitable, kept a hawk-like vigil over the entire class as we sipped from the wide-mouthed bottles', 'Additionally, he would like for you to know that he is prepared to appoint you to your father\'s seat in the US Senate, as this authority has just been vested in him by the state legislature."\n\nI\'m beginning to realize how the McCoys could hate these snakes so much. Henry Hatfield is the nephew of Devil Hatfield, the leader of the infamous Hatfield Clan. The governor can\'t run for a second term. He had himself set up for that US Senate seat two years ago, but the states ratified the Seventeenth Amendment the year before, allowing for direct election of US Senators, yanking the power away from the corrupt state legislatures and manipulators like Hatfield', "He guided her inside, barely touching her except for his grip on her hand, but the heat from his body hovered and invaded her until she leaned into his side, wanting that wonderful jolt of awareness all over again.\n\nConversation stopped when she and Dillon re-entered the living room, and once again there was open speculation on the faces of the Colters.\n\nSeth's gaze dropped to her and Dillon's linked hands. His expression remained neutral, but his eyes told a different story. There was uncertainty there, and forgetting that Dillon was going to inform him that she was taking a ride with him, she dropped Dillon's hand and went straight to Seth", 'I look over at her, and they are gone.\n\nTHE FIRST NIGHT IT HAPPENED\n\nThe first night it happened, I followed them into the strip mall parking lot. They were all stuffed into a silver-gray Honda-all thousand of them. This was back in November. Charlie had only been dead two months then.\n\nOne minute I was sitting on the side of a country road, taking shots of Smirnoff and counting my tips before I went back to the store to close, the next minute I was in the middle of a science fiction movie, complete with a jet-powered Honda Civic and[1,0]<stdout>: a thousand translucent zombielike beings who looked like Charlie', 'And the moon would have told him more, and perhaps she did, but the moon became the glimmer of moonlight on water far below him, and then he became aware of a small spider walking across his face, and of a crick in his neck, and he raised a hand and brushed the spider carefully from his cheek, and the morning sun was in his eyes and the world was gold and green.\n\n"You were dreaming," said a young woman\'s voice from somewhere above him. The voice was gentle and oddly accented. He could hear leaves rustle in the copper beech tree overhead.\n\n"Yes," he said, to whoever was in the tree, "I was dreaming', 'Oh, it was petty of her, she knew, to fault them for their infinite ambition when she was the one left filing papers-again-but Alice also knew without any doubt at all that each of them would happily stab the other in the back and trample all over the bleeding body to get ahead. Like some other people...\n\nAs she gathered up her papers and retreated to her attic, Alice wondered again how she could have been so wrong about Ella. Of all her friends, she would never have expected her to be the one to let her down-Cassie, in an episode of single-minded selfishness, perhaps; Flora, out of thoughtlessness; but Ella', 'Their mission had four parts: (1) find Russian antiques they could get their hands on, (2) find cronies that would help in the purchase or theft of these items, (3) surreptitiously get these items into large shipping containers and onto ships bound for the States, and (4) make contact with newly rich Russians who hated Russian winters as much as he did, and convince them Charleston was the place for them to spend a few months each year.  As he delineated the mission, Roger wrote it down in short bullet points on the easel pad, then sat down on the sofa next to Gwen, and the three of them looked at the easel', "My eyes fly open, and I feel they're engulfed in the Ult L-E as I recite a poem as if someone else is controlling me,\n?Though the clouds darken the sun,\nand the rain becomes tainted,\nalways know there will be\na love that will not die.\nThough hope seems a distant memory,\nand human machines walk the land,\nknow no one can destroy\na love that will not die.?\n\n?What are you babbling about?? the Rogue asks.\nI surface from my unconscious state, and I sit up, stand, walk to the PPK, pick up the gun, and aim it for the Rogue"]`