### PR TITLE
[ci] llama-2-13b on inf2 requires additional config removing from LCNC

### DIFF
--- a/.github/workflows/lmi-no-code.yml
+++ b/.github/workflows/lmi-no-code.yml
@@ -359,15 +359,6 @@ jobs:
           serve
           python3 llm/client.py no_code llama-7b
           ./remove_container.sh
-      - name: Llama2-13b lmi container
-        working-directory: tests/integration
-        run: |
-          rm -rf models
-          echo -en "HF_MODEL_ID=s3://djl-llm/llama-2-13b-hf/" > docker_env
-          ./launch_container.sh deepjavalibrary/djl-serving:$DJLSERVING_DOCKER_TAG $PWD/models ${{ matrix.container }}-2 \
-          serve
-          python3 llm/client.py no_code llama-13b
-          ./remove_container.sh
       - name: Mistral-7b lmi container
         working-directory: tests/integration
         run: |


### PR DESCRIPTION
## Description ##

Llama3-13b requires accuracy correction with additional env's and needs to be removed as an LCNC target until it is addressed in the underlying neuron framework.

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
