### PR TITLE
[python] Fix null pointer for empty output tokens

### DIFF
--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -119,7 +119,7 @@ class Sequence:
             first_token = index == 0
             last_token = index == self._last_token_index
             return self.tokens[index], first_token, last_token
-        return None, False, False
+        return Token(-1, ""), False, False
 
     def get_last_token(self) -> Optional[Token]:
         if self._last_token_index:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Chunked prefill may return empty tokens. Return empty token instead of None to avoid null pointer exception.

`request_output.sequences {0: Sequence(tokens=[], top_tokens=[], cumulative_log_prob=0.0, finish_reason=None, _last_token_index=None, stop_reason=None, _tokens_iterator=Iterator(_index=0), _top_tokens_iterator=Iterator(_index=0))}`