### PR TITLE
[python] Update lmi-list generation params after upgrading to vllm 0.5.5

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -30,7 +30,7 @@ from djl_python.properties_manager.lmi_dist_rb_properties import LmiDistRbProper
 
 _WARMUP_PREFILL_TOKENS = 4096
 LMI_DIST_GENERATION_PARAMS = set(RequestParams().__dict__.keys()).union(
-    set(SamplingParams().__dict__.keys()))
+    set(SamplingParams().__struct_fields__))
 
 
 class LmiDistRollingBatch(RollingBatch):


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
