### PR TITLE
[ci][lmi] remove output formatter from model configurations, test str…

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -190,7 +190,6 @@ transformers_neuronx_handler_list = {
         "option.max_rolling_batch_size": 4,
         "option.model_loading_timeout": 2400,
         "option.load_split_model": True,
-        "option.output_formatter": "jsonlines"
     },
     "llama-3-8b-rb-vllm": {
         "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
@@ -199,7 +198,6 @@ transformers_neuronx_handler_list = {
         "option.max_rolling_batch_size": 4,
         "option.rolling_batch": 'vllm',
         "option.model_loading_timeout": 2400,
-        "option.output_formatter": "jsonlines"
     },
     "tiny-llama-rb-vllm": {
         "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
@@ -209,7 +207,6 @@ transformers_neuronx_handler_list = {
         "option.rolling_batch": 'vllm',
         "option.model_loader": 'vllm',
         "option.model_loading_timeout": 1200,
-        "option.output_formatter": "jsonlines"
     },
     "mistral-7b-rb": {
         "option.model_id": "s3://djl-llm/mistral-7b-instruct-v02/",
@@ -225,7 +222,6 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 12,
         "option.max_rolling_batch_size": 1,
         "option.model_loading_timeout": 3600,
-        "option.output_formatter": "jsonlines"
     },
     "llama-speculative-compiled-rb": {
         "option.model_id": "s3://djl-llm/llama-2-13b-hf/",
@@ -238,7 +234,6 @@ transformers_neuronx_handler_list = {
         "option.tensor_parallel_degree": 12,
         "option.max_rolling_batch_size": 1,
         "option.model_loading_timeout": 3600,
-        "option.output_formatter": "jsonlines"
     },
     "tiny-llama-rb-aot": {
         "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
@@ -603,13 +598,11 @@ vllm_model_list = {
         "option.model_id": "s3://djl-llm/llama-2-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.max_rolling_batch_size": 32,
-        "option.output_formatter": "jsonlines"
     },
     "mixtral-8x7b": {
         "option.model_id": "s3://djl-llm/mixtral-8x7b/",
         "option.tensor_parallel_degree": 8,
         "option.max_rolling_batch_size": 32,
-        "option.output_formatter": "jsonlines"
     },
     "qwen2-7b-fp8": {
         "option.model_id": "neuralmagic/Qwen2-7B-Instruct-FP8",
@@ -807,7 +800,6 @@ trtllm_handler_list = {
         "option.model_id": "s3://djl-llm/llama-2-13b-hf/",
         "option.tensor_parallel_degree": 4,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
     },
     "llama2-7b-smoothquant": {
         "option.model_id": "s3://djl-llm/meta-llama-Llama-2-7b-chat-hf/",
@@ -816,25 +808,21 @@ trtllm_handler_list = {
         "option.smoothquant_per_token": "True",
         "option.smoothquant_per_channel": "True",
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
     },
     "internlm-7b": {
         "option.model_id": "internlm/internlm-7b",
         "option.tensor_parallel_degree": 4,
-        "option.output_formatter": "jsonlines",
         "option.trust_remote_code": True
     },
     "baichuan2-13b": {
         "option.model_id": "s3://djl-llm/baichuan2-13b/",
         "option.tensor_parallel_degree": 4,
         "option.baichuan_model_version": "v2_13b",
-        "option.output_formatter": "jsonlines",
         "option.trust_remote_code": True
     },
     "chatglm3-6b": {
         "option.model_id": "s3://djl-llm/chatglm3-6b/",
         "option.tensor_parallel_degree": 4,
-        "option.output_formatter": "jsonlines",
         "option.trust_remote_code": True,
         "option.chatglm_model_version": "chatglm3"
     },
@@ -842,7 +830,6 @@ trtllm_handler_list = {
         "option.model_id": "s3://djl-llm/mistral-7b/",
         "option.tensor_parallel_degree": 4,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines"
     },
     "gpt-j-6b": {
         "option.model_id": "s3://djl-llm/gpt-j-6b/",
@@ -851,13 +838,11 @@ trtllm_handler_list = {
         "option.max_output_len": 256,
         "option.max_rolling_batch_size": 16,
         "option.rolling_batch": "auto",
-        "option.output_formatter": "jsonlines"
     },
     "qwen-7b": {
         "option.model_id": "Qwen/Qwen-7B",
         "option.tensor_parallel_degree": 4,
         "option.trust_remote_code": True,
-        "option.output_formatter": "jsonlines"
     },
     "gpt2": {
         "option.model_id": "gpt2",
@@ -865,7 +850,6 @@ trtllm_handler_list = {
         "option.max_rolling_batch_size": 16,
         "option.trust_remote_code": True,
         "option.max_draft_len": 20,
-        "option.output_formatter": "jsonlines"
     },
     "santacoder": {
         "option.model_id": "bigcode/santacoder",
@@ -873,21 +857,18 @@ trtllm_handler_list = {
         "option.max_rolling_batch_size": 16,
         "option.trust_remote_code": True,
         "option.gpt_model_version": "santacoder",
-        "option.output_formatter": "jsonlines"
     },
     "llama2-70b": {
         "option.model_id": "s3://djl-llm/llama-2-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.use_custom_all_reduce": True,
         "option.max_rolling_batch_size": 32,
-        "option.output_formatter": "jsonlines"
     },
     "mixtral-8x7b": {
         "option.model_id": "s3://djl-llm/mixtral-8x7b/",
         "option.tensor_parallel_degree": 8,
         "option.use_custom_all_reduce": False,
         "option.max_rolling_batch_size": 32,
-        "option.output_formatter": "jsonlines"
     },
     "llama2-7b-chat": {
         "option.model_id": "s3://djl-llm/meta-llama-Llama-2-7b-chat-hf/",
@@ -984,54 +965,46 @@ trtllm_neo_list = {
         "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
         "option.tensor_parallel_degree": 1,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines"
     },
     "llama3-8b-tp4-awq": {
         "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
         "option.tensor_parallel_degree": 4,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "awq"
     },
     "llama3-8b-tp4-fp8": {
         "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
         "option.tensor_parallel_degree": 4,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "fp8"
     },
     "llama3-8b-tp4-smoothquant": {
         "option.model_id": "s3://djl-llm/llama-3-8b-hf/",
         "option.tensor_parallel_degree": 4,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "smoothquant"
     },
     "llama3-70b-tp8-fp16": {
         "option.model_id": "s3://djl-llm/llama-3-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines"
     },
     "llama3-70b-tp8-awq": {
         "option.model_id": "s3://djl-llm/llama-3-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "awq"
     },
     "llama3-70b-tp8-fp8": {
         "option.model_id": "s3://djl-llm/llama-3-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "fp8"
     },
     "llama3-70b-tp8-smoothquant": {
         "option.model_id": "s3://djl-llm/llama-3-70b-hf/",
         "option.tensor_parallel_degree": 8,
         "option.rolling_batch": "trtllm",
-        "option.output_formatter": "jsonlines",
         "option.quantize": "smoothquant"
     }
 }
@@ -1289,7 +1262,6 @@ def build_lmi_dist_model(model):
     options = lmi_dist_model_list[model]
     options["engine"] = "MPI"
     options["option.rolling_batch"] = "lmi-dist"
-    options["option.output_formatter"] = "jsonlines"
 
     adapter_ids = options.pop("adapter_ids", [])
     adapter_names = options.pop("adapter_names", [])
@@ -1307,7 +1279,6 @@ def build_vllm_model(model):
     options = vllm_model_list[model]
     options["engine"] = "Python"
     options["option.rolling_batch"] = "vllm"
-    options["option.output_formatter"] = "jsonlines"
 
     adapter_ids = options.pop("adapter_ids", [])
     adapter_names = options.pop("adapter_names", [])
@@ -1336,7 +1307,6 @@ def build_lmi_dist_aiccl_model(model):
     options["option.task"] = "text-generation"
     options["option.tensor_parallel_degree"] = 8
     options["option.rolling_batch"] = "lmi-dist"
-    options["option.output_formatter"] = "jsonlines"
     options["option.max_rolling_batch_size"] = 16
     write_model_artifacts(options)
 
@@ -1379,7 +1349,6 @@ def build_correctness_model(model):
             f"{model} is not one of the supporting handler {list(correctness_model_list.keys())}"
         )
     options = correctness_model_list[model]
-    options["option.output_formatter"] = "json"
     write_model_artifacts(options)
 
 


### PR DESCRIPTION
…eaming/non-streaming on client side

## Description ##

This changes our integration testing behavior to ensure we test both streaming and non-streaming cases for as many models as possible. This is achieved by removing the hardcoded output_formatter from prepare.py. When using a specified output_formatter, that always takes precedence over the payload "stream" parameter. This means we were only testing streaming output for the rolling batch use-cases.


