### PR TITLE
[fix][vllm][lmi] pass batch size to vllm engine args

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -265,6 +265,7 @@ def get_engine_args_from_config(config: VllmRbProperties) -> EngineArgs:
             cpu_offload_gb=config.cpu_offload_gb_per_gpu,
             enable_prefix_caching=config.enable_prefix_caching,
             disable_sliding_window=config.disable_sliding_window,
+            max_num_seqs=config.max_rolling_batch_size,
         )
 
 


### PR DESCRIPTION
## Description ##

I am not sure why we were not doing this before - seems like we just missed it.

With the planned updates on lmi-dist, not passing in the batch size is going to cause issues with the vllm warmup phase as it uses batch size, max model len, and max prefill tokens to structure the warmup. Without passing in the batch size here, we default to the vllm 256 (which is conviently our default), but we don't respect any overrides on the vllm side.

We do this for neuron already, need to have this for gpu as well.
