### PR TITLE
[TRTLLM] Bump up dockerfile

### DIFF
--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -9,26 +9,26 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-ARG version=12.4.1-devel-ubuntu22.04
+ARG version=12.5.1-devel-ubuntu22.04
 FROM nvidia/cuda:$version
-ARG cuda_version=cu124
+ARG cuda_version=cu125
 ARG python_version=3.10
-ARG TORCH_VERSION=2.3.1
+ARG TORCH_VERSION=2.4.0
 ARG djl_version=0.30.0~SNAPSHOT
 ARG transformers_version=4.44.2
 ARG accelerate_version=0.32.1
 ARG tensorrtlibs_version=10.1.0
 # %2B is the url escape for the '+' character
-ARG trtllm_toolkit_version=0.11.0%2Bnightly
-ARG trtllm_version=v0.11.0
-ARG cuda_python_version=12.4
+ARG trtllm_toolkit_version=0.12.0%2Bnightly
+ARG trtllm_version=v0.12.0
+ARG cuda_python_version=12.5
 ARG peft_version=0.10.0
 ARG triton_version=r24.04
 ARG trtllm_toolkit_wheel="https://publish.djl.ai/tensorrt-llm/toolkit/tensorrt_llm_toolkit-${trtllm_toolkit_version}-py3-none-any.whl"
-ARG trtllm_wheel="https://publish.djl.ai/tensorrt-llm/${trtllm_version}/tensorrt_llm-0.11.0-cp310-cp310-linux_x86_64.whl"
+ARG trtllm_wheel="https://publish.djl.ai/tensorrt-llm/${trtllm_version}/tensorrt_llm-0.12.0-cp310-cp310-linux_x86_64.whl"
 ARG triton_toolkit_wheel="https://publish.djl.ai/tritonserver/${triton_version}/tritontoolkit-24.4-py310-none-any.whl"
 ARG pydantic_version=2.6.1
-ARG modelopt_version=0.13.1
+ARG modelopt_version=0.15.0
 ARG janus_version=1.0.0
 ARG pynvml_verison=11.5.0
 ARG numpy_version=1.26.4


### PR DESCRIPTION
## Description ##

Bumps up Dockerfile to TRTLLM v0.12.

Important information
This bump up is different from earlier ones - there are some things that I could not test yet due to some technical issues with installing tensorrt_llm for breaking changes that require new binaries. It seemed to be missing a binary I could not provide. Hence, due to this change, our nightly container is prematurely sent to v12, so it may have some bugs for around a day or so - I will fix all remaining issues and test as quickly as possible.

To clarify, the bugs left are related to how the code for tp_size, pp_size, etc. is written. It should work regardless, but I just need to double check.

I have found that the other breaking changes including use_custom_all_reduce and max_output_len are non-blocking pending changes (they do not affect functionality but I will be cleaning up the code later).

