### PR TITLE
[lmi-dist][breaking] remove default 4096 token number for prefill - a…

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -28,7 +28,6 @@ from djl_python.rolling_batch.rolling_batch_vllm_utils import (
 from djl_python.telemetry import telemetry_manager
 from djl_python.properties_manager.lmi_dist_rb_properties import LmiDistRbProperties
 
-_WARMUP_PREFILL_TOKENS = 4096
 LMI_DIST_GENERATION_PARAMS = set(RequestParams().__dict__.keys()).union(
     set(SamplingParams().__struct_fields__))
 
@@ -92,7 +91,14 @@ class LmiDistRollingBatch(RollingBatch):
         logging.info(f"engine_args: {engine_args}, kwargs: {kwargs}")
 
         if self.lmi_dist_config.max_rolling_batch_prefill_tokens is None:
-            kwargs["warmup_prefill_tokens"] = _WARMUP_PREFILL_TOKENS
+            logging.warning(
+                "djl-serving/lmi has changed the default behavior for max_rolling_batch_prefill_tokens in 0.30.0 (lmi v12). "
+                "Previously, when max_rolling_batch_prefill_tokens was unset, djl-serving would use a warmup prefill limit of 4096 tokens. "
+                "This behavior differs from vLLM's default behavior, which (essentially) defaults to max_model_len. As a result of this change, "
+                "model deployments that worked previously may fail due to higher memory requirements at model loading time for the warmup phase. "
+                "For more information on this change, and guidance on what configurations to set, please see "
+                "https://github.com/deepjavalibrary/djl-serving/tree/master/serving/docs/lmi/announcements/breaking_changes.md"
+            )
         self.engine = engine_from_args(engine_args, **kwargs)
         self.request_cache = OrderedDict()
         self.lora_ids = defaultdict(lambda: len(self.lora_ids) + 1)

--- a/serving/docs/lmi/announcements/breaking_changes.md
+++ b/serving/docs/lmi/announcements/breaking_changes.md
@@ -1,0 +1,43 @@
+# LMI Breaking Changes
+
+This document details breaking changes for LMI container version releases.
+
+## LMI Container v12 (0.30.0)
+
+### Changes to model loading/warmup behavior.
+
+#### Summary
+Starting in LMI v12 (0.30.0), the default behavior for `option.max_rolling_batch_prefill_tokens` when using the lmi-dist 
+rolling-batch backend has changed.
+This configuration maps to vLLM's `max_num_batched_tokens` configuration.
+In previous versions (v11 and earlier), this value would default to 4096 tokens.
+Starting in v12, the default behavior for lmi-dist will rely on vLLM's default behavior.
+vLLM's default behavior is described [here](https://github.com/vllm-project/vllm/blob/9cc373f39036af789fb1ffc1e06b23766996d3f4/vllm/config.py#L959C9-L988).
+The previous behavior was implemented to improve the default experience for model loading, 
+especially on memory-constrained instances. 
+vLLM's default behavior is to set this value to `option.max_model_len`, and use this as part of the warmup phase. 
+After the warmup phase, lmi-dist would set this value back to `option.max_model_len`.
+This allowed users to deploy models with long context lengths on smaller instances without needing
+to configure `option.max_rolling_batch_prefill_tokens` or `option.max_model_len`. 
+However, if users attempted requests with longer than 4096 tokens of prefill, 
+there was a chance this could lead to out-of-memory scenarios.
+
+#### What to expect
+We have decided to make this change because of chunked prefill, our observation that more users are leveraging longer prompts, 
+and our belief that the previous motivation is no longer the correct default experience.
+This change means that if `option.max_rolling_batch_prefill_tokens` is not specified, some deployments that worked previously
+with v11 and earlier may start failing in v12 due to higher memory requirements during model loading and warmup 
+for models with greater than a supported sequence length greater than 4096 tokens.
+
+#### Guidance
+As a result of this change, we recommend you take the following actions:
+
+* Enable chunked-prefill. You can do this by setting `option.enable_chunked_prefill=true`.
+  * You can learn more about chunked prefill here https://docs.vllm.ai/en/latest/models/performance.html#chunked-prefill.
+  * We expect that chunked prefill will be beneficial for most users and use-cases. But, you should confirm this for your specific use-case.
+  * With chunked-prefill, the default value for max_rolling_batch_prefill_tokens is 512, which is set to optimize inter token latency (ITL).
+* Tune `option.max_rolling_batch_prefill_tokens` and/or `option.max_model_len` based on available accelerator memory (instance type), use-case, and model. 
+  * `option.max_model_len` should be set to the maximum input + output token count you expect to support at inference time.
+  * `option.max_rolling_batch_prefill_tokens` depends on whether you use chunked prefill.
+    * With chunked prefill, you can typically expect higher throughput with larger values, and better latency with lower values.
+    * Without chunked prefill, you should set this to the maximum input length you aim to support.


### PR DESCRIPTION
…lign with vllm default behavior

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
