### PR TITLE
[python] fix last token fetch logic

### DIFF
--- a/engines/python/setup/djl_python/output_formatter.py
+++ b/engines/python/setup/djl_python/output_formatter.py
@@ -20,8 +20,6 @@ from typing_extensions import deprecated
 from djl_python.request_io import TextGenerationOutput
 from djl_python.utils import wait_till_generation_finished
 
-ERR_MSG = "Inference error occurred. Check CloudWatch metrics or model server logs for more details."
-
 
 def output_formatter(function):
     """
@@ -122,7 +120,7 @@ def _json_output_formatter(request_output: TextGenerationOutput):
         # partial generation response that may exist
         result = {
             "generated_text": None,
-            "error": final_token.error_msg if final_token else ERR_MSG,
+            "error": final_token.error_msg,
             "code": 400,
             "details": details,
         }

--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -122,7 +122,7 @@ class Sequence:
         return None, False, False
 
     def get_last_token(self) -> Optional[Token]:
-        if self._last_token_index:
+        if self._last_token_index is not None:
             return self.tokens[self._last_token_index]
         return None
 


### PR DESCRIPTION
## Description ##

When exception occurs in inference, we catch it and set the last token as dummy token. So atleast one token should be set, even if exception occurred. 

But to check whether last_token_index is set or not, we check `if _last_token_index` will be false when `last_token_index=0`. 

This PR reverts the yesterday's PR. 

Tested it manually in my ec2 machine
