### PR TITLE
[python] allow debug logging in python engine

### DIFF
--- a/engines/python/setup/djl_python/arg_parser.py
+++ b/engines/python/setup/djl_python/arg_parser.py
@@ -86,6 +86,11 @@ class ArgParser(object):
                             type=str,
                             dest="recommended_entry_point",
                             help="Lmi recommended entry point")
+        parser.add_argument('--log-level',
+                            required=False,
+                            type=str,
+                            default="info",
+                            help="log level to use for djl_python logging")
         return parser
 
     @staticmethod

--- a/engines/python/setup/djl_python_engine.py
+++ b/engines/python/setup/djl_python_engine.py
@@ -187,13 +187,13 @@ def main():
 
     # noinspection PyBroadException
     try:
+        args = ArgParser.python_engine_args().parse_args()
         logging.basicConfig(stream=sys.stdout,
-                            format="%(message)s",
-                            level=logging.INFO)
+                            format="%(levelname)s::%(message)s",
+                            level=args.log_level.upper())
         configure_sm_logging()
         logging.info(
             f"{pid} - djl_python_engine started with args: {sys.argv[1:]}")
-        args = ArgParser.python_engine_args().parse_args()
         rank = os.environ.get("OMPI_COMM_WORLD_RANK")
         sock_type = args.sock_type
         sock_name = args.sock_name if rank is None else f"{args.sock_name}.{rank}"

--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -129,6 +129,7 @@ class Connection {
         int pipelineParallelDegree = pyEnv.getPipelineParallelDegree();
         String entryPoint = pyEnv.getEntryPoint();
         String recommendedEntryPoint = pyEnv.getRecommendedEntryPoint();
+        String pythonLogLevel = pyEnv.getPythonLogLevel();
 
         if (PyEnv.isMultiNode()) {
             int worldSize = tensorParallelDegree * pipelineParallelDegree;
@@ -159,7 +160,7 @@ class Connection {
                 }
                 sb.append(host).append(':').append(localSize);
             }
-            String[] args = new String[48];
+            String[] args = new String[50];
             args[0] = "mpirun";
             args[1] = "-np";
             args[2] = String.valueOf(worldSize);
@@ -208,11 +209,13 @@ class Connection {
             args[45] = String.valueOf(clusterSize);
             args[46] = "--recommended-entry-point";
             args[47] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
+            args[48] = "--log-level";
+            args[49] = pythonLogLevel;
             return args;
         } else if (pyEnv.isMpiMode()) {
             String cudaDevices = getVisibleDevices(workerId, tensorParallelDegree);
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);
-            String[] args = new String[42];
+            String[] args = new String[44];
             args[0] = "mpirun";
             args[1] = "-np";
             args[2] = String.valueOf(tensorParallelDegree);
@@ -255,6 +258,8 @@ class Connection {
             args[39] = String.valueOf(tensorParallelDegree);
             args[40] = "--recommended-entry-point";
             args[41] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
+            args[42] = "--log-level";
+            args[43] = pythonLogLevel;
             return args;
         }
 
@@ -276,7 +281,7 @@ class Connection {
             logger.info("Set OMP_NUM_THREADS={}", neuronThreads);
         }
         boolean uds = Epoll.isAvailable() || KQueue.isAvailable();
-        String[] args = new String[16];
+        String[] args = new String[18];
         args[0] = pyEnv.getPythonExecutable();
         args[1] = PyEnv.getEngineCacheDir() + "/djl_python_engine.py";
         args[2] = "--sock-type";
@@ -293,6 +298,8 @@ class Connection {
         args[13] = String.valueOf(clusterSize);
         args[14] = "--recommended-entry-point";
         args[15] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
+        args[16] = "--log-level";
+        args[17] = pythonLogLevel;
         return args;
     }
 

--- a/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
@@ -537,6 +537,18 @@ public class PyEnv {
         this.modelLoadingTimeout = modelLoadingTimeout;
     }
 
+    /**
+     * Returns the log level to use in the djl_python logger.
+     *
+     * @return the log level to use.
+     */
+    public String getPythonLogLevel() {
+        if (logger.isDebugEnabled()) {
+            return "debug";
+        }
+        return "info";
+    }
+
     String[] getEnvironmentVars(Model model) {
         ArrayList<String> envList = new ArrayList<>();
         StringBuilder pythonPath = new StringBuilder();


### PR DESCRIPTION
## Description ##

This PR enables specification of the log level in djl_python_engine.

For now, we only switch between info/debug based on whether debug logging is enabled on the java side.

While we could allow for more log levels here (in pyenv), we rely on certain info level logs from python to execute the engine successfully on the java side.

This also slightly adjusts the format of the python log message to indicate the level we are logging at
