### PR TITLE
[lmi] Ensure 'sampling_params' is not in LMI_DIST_GENERATION_PARAMS

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -30,7 +30,7 @@ from djl_python.properties_manager.lmi_dist_rb_properties import LmiDistRbProper
 
 _WARMUP_PREFILL_TOKENS = 4096
 LMI_DIST_GENERATION_PARAMS = set(RequestParams().__dict__.keys()).union(
-    set(SamplingParams().__struct_fields__))
+    set(SamplingParams().__struct_fields__)) - {"sampling_params"}
 
 
 class LmiDistRollingBatch(RollingBatch):


### PR DESCRIPTION
## Description ##

Ensure 'sampling_params' is not in LMI_DIST_GENERATION_PARAMS. This could happen with the old code due to the use of the delegation pattern for lmi_dist RequestParams.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
