### PR TITLE
[rolling-batch] Reset IdCounter every million requests instead of whe…

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -149,7 +149,4 @@ class RollingBatch(ABC):
             req for req in self.active_requests if not req.is_last_token()
         ]
 
-        if len(self.active_requests) == 0:
-            self.req_id_counter.reset()
-
         return results

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -17,6 +17,7 @@ from djl_python.inputs import Input
 
 
 class IdCounter:
+    MAX_ID = 999999
 
     def __init__(self):
         self.id = 0
@@ -26,7 +27,7 @@ class IdCounter:
 
     def next_id(self):
         current_id = self.id
-        self.id += 1
+        self.id = (self.id + 1) % self.MAX_ID
         return current_id
 
     def reset(self):


### PR DESCRIPTION
…never there are no active requests

## Description ##

This is less confusing. For example, if you ran one request at a time, the old logic would use request id 0 for every request.

This new logic is correct as long as there are never more than a million outstanding active requests.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
