### PR TITLE
[lmi][lmi-dist] Add pipeline-parallel support to lmi-dist, and use_passive_workers by default

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
@@ -64,6 +64,7 @@ class LmiDistRbProperties(Properties):
     enable_prefix_caching: Optional[bool] = False
     disable_sliding_window: Optional[bool] = False
     limit_mm_per_prompt: Optional[Mapping[str, int]] = None
+    use_passive_workers: Optional[bool] = True
 
     @model_validator(mode='after')
     def validate_mpi(self):

--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -37,6 +37,7 @@ class VllmRbProperties(Properties):
     load_format: Optional[str] = "auto"
     quantize: Optional[VllmQuantizeMethods] = None
     tensor_parallel_degree: Optional[int] = None
+    pipeline_parallel_degree: int = 1
     max_rolling_batch_prefill_tokens: Optional[int] = None
     # Adjustable prefix model length for certain 32k or longer model
     max_model_len: Optional[int] = None
@@ -109,5 +110,13 @@ class VllmRbProperties(Properties):
         if self.speculative_model is not None and not self.use_v2_block_manager:
             raise ValueError(
                 "Speculative decoding requires usage of the V2 block manager. Enable it with option.use_v2_block_manager=true."
+            )
+        return self
+
+    @model_validator(mode='after')
+    def validate_pipeline_parallel(self):
+        if self.pipeline_parallel_degree != 1:
+            raise ValueError(
+                "Pipeline parallelism is not supported in vLLM's LLMEngine used in rolling_batch implementation"
             )
         return self

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -87,6 +87,7 @@ class LmiDistRollingBatch(RollingBatch):
             enable_prefix_caching=self.lmi_dist_config.enable_prefix_caching,
             disable_sliding_window=self.lmi_dist_config.disable_sliding_window,
             limit_mm_per_prompt=self.lmi_dist_config.limit_mm_per_prompt,
+            use_passive_workers=self.lmi_dist_config.use_passive_workers,
             **engine_kwargs)
 
         kwargs = {}

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -245,6 +245,7 @@ def get_engine_args_from_config(config: VllmRbProperties) -> EngineArgs:
         return EngineArgs(
             model=config.model_id_or_path,
             tensor_parallel_size=config.tensor_parallel_degree,
+            pipeline_parallel_size=config.pipeline_parallel_degree,
             dtype=DTYPE_MAPPER[config.dtype],
             seed=0,
             max_model_len=config.max_model_len,

--- a/engines/python/src/main/java/ai/djl/python/engine/Connection.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/Connection.java
@@ -127,13 +127,13 @@ class Connection {
         int clusterSize = PyEnv.getClusterSize();
         int tensorParallelDegree = pyEnv.getTensorParallelDegree();
         int pipelineParallelDegree = pyEnv.getPipelineParallelDegree();
+        int worldSize = tensorParallelDegree * pipelineParallelDegree;
         String entryPoint = pyEnv.getEntryPoint();
         String recommendedEntryPoint = pyEnv.getRecommendedEntryPoint();
         String pythonLogLevel = pyEnv.getPythonLogLevel();
 
         if (PyEnv.isMultiNode()) {
-            int worldSize = tensorParallelDegree * pipelineParallelDegree;
-            if (tensorParallelDegree * pipelineParallelDegree % clusterSize != 0) {
+            if (worldSize % clusterSize != 0) {
                 throw new IllegalArgumentException(
                         "Error: Cannot use cluster size: "
                                 + clusterSize
@@ -141,7 +141,7 @@ class Connection {
                                 + worldSize);
             }
 
-            int localSize = (tensorParallelDegree * pipelineParallelDegree) / clusterSize;
+            int localSize = worldSize / clusterSize;
 
             String cudaDevices = getVisibleDevices(workerId, localSize);
             logger.info("Set before mpirun CUDA_VISIBLE_DEVICES={}", cudaDevices);
@@ -195,6 +195,7 @@ class Connection {
             args[31] = model.getModelPath().toAbsolutePath().toString();
             args[32] = "--entry-point";
             args[33] = entryPoint == null ? "" : entryPoint;
+            // TODO: Use mix of Unix and TCP sockets for local/remote processes
             args[34] = "--sock-type";
             args[35] = "tcp";
             args[36] = "--sock-name";
@@ -213,12 +214,12 @@ class Connection {
             args[49] = pythonLogLevel;
             return args;
         } else if (pyEnv.isMpiMode()) {
-            String cudaDevices = getVisibleDevices(workerId, tensorParallelDegree);
+            String cudaDevices = getVisibleDevices(workerId, worldSize);
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);
-            String[] args = new String[44];
+            String[] args = new String[46];
             args[0] = "mpirun";
             args[1] = "-np";
-            args[2] = String.valueOf(tensorParallelDegree);
+            args[2] = String.valueOf(worldSize);
             args[3] = "--allow-run-as-root";
             args[4] = "--bind-to";
             args[5] = "none";
@@ -256,21 +257,27 @@ class Connection {
             args[37] = getSocketPath(port);
             args[38] = "--tensor-parallel-degree";
             args[39] = String.valueOf(tensorParallelDegree);
-            args[40] = "--recommended-entry-point";
-            args[41] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
-            args[42] = "--log-level";
-            args[43] = pythonLogLevel;
+            args[40] = "--pipeline-parallel-degree";
+            args[41] = String.valueOf(pipelineParallelDegree);
+            args[42] = "--recommended-entry-point";
+            args[43] = recommendedEntryPoint == null ? "" : recommendedEntryPoint;
+            args[44] = "--log-level";
+            args[45] = pythonLogLevel;
             return args;
         }
 
-        // TP settings
-        if (tensorParallelDegree > 0 && device.isGpu()) {
-            String cudaDevices = getVisibleDevices(deviceId, tensorParallelDegree);
+        // TP/PP settings
+        if (worldSize > 0 && device.isGpu()) {
+            String cudaDevices = getVisibleDevices(deviceId, worldSize);
             deviceId = 0; // re-map logic device to 0
             pyEnv.addEnv("CUDA_VISIBLE_DEVICES", cudaDevices);
             logger.info("Set CUDA_VISIBLE_DEVICES={}", cudaDevices);
         }
         if ("nc".equals(device.getDeviceType())) {
+            if (pipelineParallelDegree > 1) {
+                throw new IllegalArgumentException(
+                        "Error: Neuron does not currently support pipeline parallel degree > 1");
+            }
             String visibleCores = getNeuronVisibleCores(deviceId, tensorParallelDegree);
             // TODO: re-map logic device once neuron fixed bug
             pyEnv.addEnv("NEURON_RT_VISIBLE_CORES", visibleCores);
@@ -303,19 +310,19 @@ class Connection {
         return args;
     }
 
-    private static String getVisibleDevices(int deviceId, int tensorParallelDegree) {
+    private static String getVisibleDevices(int deviceId, int localDevicesPerWorker) {
         StringBuilder sb = new StringBuilder(20);
         // CUDA_VISIBLE_DEVICES=0,2,3,7 TP2
         // -> 0,2 and 3,7
         if (Utils.getenv("CUDA_VISIBLE_DEVICES") != null) {
             String[] devices = Utils.getenv("CUDA_VISIBLE_DEVICES").split(",");
             sb.append(devices[deviceId]);
-            for (int i = 1; i < tensorParallelDegree; ++i) {
+            for (int i = 1; i < localDevicesPerWorker; ++i) {
                 sb.append(',').append(devices[deviceId + i]);
             }
         } else {
             sb.append(deviceId);
-            for (int i = 1; i < tensorParallelDegree; ++i) {
+            for (int i = 1; i < localDevicesPerWorker; ++i) {
                 sb.append(',').append(deviceId + i);
             }
         }

--- a/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
@@ -339,7 +339,7 @@ public class PyEnv {
         if (tensorParallelDegree == 0) {
             String value = Utils.getenv("TENSOR_PARALLEL_DEGREE");
             if ("max".equals(value)) {
-                tensorParallelDegree = getDefaultTensorParallelDegree();
+                tensorParallelDegree = getDefaultTensorParallelDegree() / getPipelineParallelDegree();
             } else if (value != null) {
                 tensorParallelDegree = Integer.parseInt(value);
             }
@@ -350,7 +350,7 @@ public class PyEnv {
     static int getDefaultTensorParallelDegree() {
         int gpus = CudaUtils.getGpuCount();
         if (gpus > 0) {
-            return gpus;
+            return gpus * clusterSize;
         }
         return NeuronUtils.getNeuronCores();
     }
@@ -375,6 +375,7 @@ public class PyEnv {
             if (value != null) {
                 pipelineParallelDegree = Integer.parseInt(value);
             } else {
+                // TODO: Use clusterSize as default value of pipelineParallelDegree, but only when supported
                 pipelineParallelDegree = 1;
             }
         }

--- a/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyEnv.java
@@ -339,7 +339,8 @@ public class PyEnv {
         if (tensorParallelDegree == 0) {
             String value = Utils.getenv("TENSOR_PARALLEL_DEGREE");
             if ("max".equals(value)) {
-                tensorParallelDegree = getDefaultTensorParallelDegree() / getPipelineParallelDegree();
+                tensorParallelDegree =
+                        getDefaultTensorParallelDegree() / getPipelineParallelDegree();
             } else if (value != null) {
                 tensorParallelDegree = Integer.parseInt(value);
             }
@@ -375,7 +376,8 @@ public class PyEnv {
             if (value != null) {
                 pipelineParallelDegree = Integer.parseInt(value);
             } else {
-                // TODO: Use clusterSize as default value of pipelineParallelDegree, but only when supported
+                // TODO: Use clusterSize as default value of pipelineParallelDegree, but only when
+                // supported
                 pipelineParallelDegree = 1;
             }
         }

--- a/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyModel.java
@@ -21,7 +21,6 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.translate.Translator;
 import ai.djl.util.Utils;
-import ai.djl.util.cuda.CudaUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +78,8 @@ public class PyModel extends BaseModel {
         String entryPoint = null;
         String recommendedEntryPoint = null;
         if (options != null) {
-            // If tp_degree set to "max", we defer and set it at the end to ensure we take pp degree into account.
+            // If tp_degree set to "max", we defer and set it at the end to ensure we take pp degree
+            // into account.
             boolean setTensorParallelDegreeToMax = false;
             logger.debug("options in serving.properties for model: {}", modelName);
             for (Map.Entry<String, ?> entry : options.entrySet()) {
@@ -154,7 +154,8 @@ public class PyModel extends BaseModel {
             }
 
             if (setTensorParallelDegreeToMax) {
-                int tpDegree = PyEnv.getDefaultTensorParallelDegree() / pyEnv.getPipelineParallelDegree();
+                int tpDegree =
+                        PyEnv.getDefaultTensorParallelDegree() / pyEnv.getPipelineParallelDegree();
                 pyEnv.setTensorParallelDegree(tpDegree);
             }
         }
@@ -223,9 +224,14 @@ public class PyModel extends BaseModel {
                 setProperty("tensor_parallel_degree", String.valueOf(tpDegree));
                 setProperty("pipeline_parallel_degree", String.valueOf(ppDegree));
                 logger.info(
-                        "No tensor parallel degree specified. Defaulting to use all available GPUs.");
+                        "No tensor parallel degree specified. Defaulting to use all available"
+                                + " GPUs.");
             }
-            logger.info("Loading model in MPI mode with world size {} (TP {}, PP {}).", partitions, tpDegree, ppDegree);
+            logger.info(
+                    "Loading model in MPI mode with world size {} (TP {}, PP {}).",
+                    partitions,
+                    tpDegree,
+                    ppDegree);
 
             int mpiWorkers = pyEnv.getMpiWorkers();
             if (mpiWorkers <= 0) {

--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -73,12 +73,7 @@ class PyProcess {
                 hosts = getHosts(clusterSize);
                 for (int i = 0; i < worldSize; ++i) {
                     int connectionsPerHost = worldSize / clusterSize;
-                    connections.add(
-                            new Connection(
-                                    pyEnv,
-                                    port,
-                                    i,
-                                    hosts[i / connectionsPerHost]));
+                    connections.add(new Connection(pyEnv, port, i, hosts[i / connectionsPerHost]));
                 }
             } else {
                 for (int i = 0; i < worldSize; ++i) {
@@ -94,7 +89,9 @@ class PyProcess {
         // TODO: avoid using this hack when TRT-LLM improve its behavior
         // Note: Now, by default, we use passive worker behavior in MPI mode.
         // We can get the old behavior by setting OPTION_USE_PASSIVE_WORKERS=false.
-        passiveWorkersMode = "trtllm".equals(model.getProperty("rolling_batch")) || Boolean.parseBoolean(model.getProperty("use_passive_workers", "true"));
+        passiveWorkersMode =
+                "trtllm".equals(model.getProperty("rolling_batch"))
+                        || Boolean.parseBoolean(model.getProperty("use_passive_workers", "true"));
     }
 
     Output predict(Input inputs, int timeout, boolean initialLoad) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -92,7 +92,8 @@ public final class LmiConfigRecommender {
             return;
         }
         String tpDegree = Utils.getenv("TENSOR_PARALLEL_DEGREE", "max");
-        int ppDegree = Integer.parseInt(lmiProperties.getProperty("option.pipeline_parallel_degree"));
+        int ppDegree =
+                Integer.parseInt(lmiProperties.getProperty("option.pipeline_parallel_degree"));
         if ("max".equals(tpDegree)) {
             int numGpus = CudaUtils.getGpuCount();
             if (numGpus > 0) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -38,8 +38,8 @@ public final class LmiConfigRecommender {
         setRollingBatch(lmiProperties, modelConfig, features);
         setMpiMode(lmiProperties);
         setHeuristicDefaults(lmiProperties, modelConfig);
-        setTensorParallelDegree(lmiProperties);
         setPipelineParallelDegree(lmiProperties);
+        setTensorParallelDegree(lmiProperties);
         setRollingBatchSize(lmiProperties);
     }
 
@@ -92,10 +92,11 @@ public final class LmiConfigRecommender {
             return;
         }
         String tpDegree = Utils.getenv("TENSOR_PARALLEL_DEGREE", "max");
+        int ppDegree = Integer.parseInt(lmiProperties.getProperty("option.pipeline_parallel_degree"));
         if ("max".equals(tpDegree)) {
             int numGpus = CudaUtils.getGpuCount();
             if (numGpus > 0) {
-                tpDegree = String.valueOf(numGpus);
+                tpDegree = String.valueOf(numGpus / ppDegree);
             } else if (NeuronUtils.hasNeuron()) {
                 int numAccelerators = NeuronUtils.getNeuronCores();
                 if (numAccelerators > 0) {

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -1006,6 +1006,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
             int tpDegree;
             if ("max".equals(v)) {
                 if (gpuCount > 0) {
+                    // TODO pipeline parallel?
                     tpDegree = gpuCount;
                 } else {
                     tpDegree = NeuronUtils.getNeuronCores();
@@ -1013,13 +1014,18 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
             } else {
                 tpDegree = Integer.parseInt(v);
             }
+
+            v = Utils.getenv("PIPELINE_PARALLEL_DEGREE", "1");
+            v = prop.getProperty("option.pipeline_parallel_degree", v);
+            int ppDegree = Integer.parseInt(v);
+
             if (gpuCount > 0) {
                 int gpuPerWorker = 1;
                 if (Boolean.parseBoolean(prop.getProperty("option.mpi_mode"))) {
                     return new String[] {"0"};
                 } else if ("Python".equals(engineName)) {
                     if (tpDegree > 0) {
-                        gpuPerWorker = tpDegree;
+                        gpuPerWorker = tpDegree * ppDegree;
                         int procs = gpuCount / gpuPerWorker;
                         if (procs == 0) {
                             throw new EngineException(
@@ -1045,6 +1051,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
                 int ncPerWorker;
                 if (tpDegree > 0) {
                     // Assume user understand TP only works on inf2
+                    // TODO Pipeline parallel?
                     ncPerWorker = tpDegree;
                     int procs = neurons / ncPerWorker;
                     if (procs == 0) {


### PR DESCRIPTION
## Description ##

This adds pipeline-parallel support to lmi-dist rolling batch, whether multi-node or not. It also updates logic on the java side for how to handle pipeline parallel degree and tensor parallel degree. Finally, it switches to a passive worker mode when using MPI, where the frontend only sends inference messages to rank 0 after model load--trtllm already worked this way, but it's extra important when running with pipeline parallelism to not synchronize the worker processes after each iteration.
