### PR TITLE
[lmi] Change speculative_length default to 4

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
@@ -49,7 +49,7 @@ class LmiDistRbProperties(Properties):
     gpu_memory_utilization: Optional[float] = 0.9
     # TODO: speculative decoding changes
     speculative_draft_model: Optional[str] = None
-    speculative_length: int = 5
+    speculative_length: int = 4
     draft_model_tp_size: int = 1
     record_acceptance_rate: Optional[bool] = False
     speculative_telemetry: Optional[bool] = True


### PR DESCRIPTION
## Description ##

Given the fact that the bonus token was thrown away in previous versions of lmi_dist, the true number of speculative tokens was effectively off by 1 from how it was configured. Now that we correctly handle bonus token rather than throwing it away, the new version will have the same behavior with speculative_length 4 that the previous versions had with speculative_length 5 (but with better performance!). Thus, we change the default to 4.

We need a followup PR to update the documentation accordingly.
