### PR TITLE
[lmi][wlm] improve the handling of peft models, and update lora test …

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/hf_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/hf_properties.py
@@ -64,6 +64,7 @@ class HuggingFaceProperties(Properties):
     device: Optional[str] = None
     kwargs: Optional[dict] = {}
     data_type: Optional[str] = None
+    is_peft_model: bool = False
 
     @field_validator('load_in_4bit')
     def validate_load_in_4bit(cls, load_in_4bit):

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -70,7 +70,7 @@ hf_model_spec = {
         "worker": 1,
         "stream": [True],
     },
-    "gpt4all-lora": {
+    "llama3-tiny-random-lora": {
         "max_memory_per_gpu": [10.0, 12.0],
         "batch_size": [1, 4],
         "seq_length": [16, 32],

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -45,8 +45,8 @@ hf_handler_list = {
         "option.device_map": "auto",
         "option.enable_streaming": True,
     },
-    "gpt4all-lora": {
-        "option.model_id": "s3://djl-llm/gpt4all-lora/",
+    "llama3-tiny-random-lora": {
+        "option.model_id": "llamafactory/tiny-random-Llama-3-lora",
         "option.tensor_parallel_degree": 4,
         "option.device_map": "auto",
         "option.task": "text-generation",

--- a/tests/integration/rb_client.py
+++ b/tests/integration/rb_client.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import subprocess as sp
 import logging
+import os
 
 logging.basicConfig(level=logging.INFO)
 
@@ -115,6 +116,7 @@ def test_concurrent_with_same_reqs(model, test_spec, spec_name):
         "inputs": spec["input_texts"],
         "parameters": spec.get("parameters", {})
     }
+    os.makedirs("outputs/", exist_ok=True)
     output_file = f"outputs/{model}-{spec_name}-output.txt"
     concurrent_clients = spec.get("concurrent_clients", 1)
     process = send_json(data=data,
@@ -142,6 +144,7 @@ def test_concurrent_with_mul_reqs(model, test_spec, spec_name):
 
     processes = []
     spec = test_spec[model]
+    os.makedirs("outputs/", exist_ok=True)
     for index in range(len(spec.get("input_texts"))):
         input_text = spec["input_texts"][index]
         parameter = spec.get("parameters", [{}])[index]

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -227,7 +227,7 @@ class TestAarch64:
 class TestHfHandler:
 
     def test_gpt_neo(self):
-        with Runner('lmi', 'test_gpt4all_lora') as r:
+        with Runner('lmi', 'test_gpt_neo_2.7b') as r:
             prepare.build_hf_handler_model("gpt-neo-2.7b")
             r.launch()
             client.run("huggingface gpt-neo-2.7b".split())
@@ -250,11 +250,11 @@ class TestHfHandler:
             r.launch()
             client.run("huggingface gpt-j-6b".split())
 
-    def test_gpt4all_lora(self):
-        with Runner('lmi', 'gpt4all-lora') as r:
-            prepare.build_hf_handler_model("gpt4all-lora")
+    def test_llama3_lora(self):
+        with Runner('lmi', 'llama3-tiny-random-lora') as r:
+            prepare.build_hf_handler_model("llama3-tiny-random-lora")
             r.launch()
-            client.run("huggingface gpt4all-lora".split())
+            client.run("huggingface llama3-tiny-random-lora".split())
 
     def test_streaming_bigscience_bloom_3b(self):
         with Runner('lmi', 'bigscience/bloom-3b') as r:

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -41,6 +41,7 @@ public final class LmiConfigRecommender {
         setTensorParallelDegree(lmiProperties);
         setPipelineParallelDegree(lmiProperties);
         setRollingBatchSize(lmiProperties);
+        setIsPeftModel(lmiProperties, modelConfig);
     }
 
     private static void setRollingBatch(
@@ -137,6 +138,13 @@ public final class LmiConfigRecommender {
         }
         lmiProperties.setProperty(
                 "option.max_rolling_batch_size", String.valueOf(rollingBatchSize));
+    }
+
+    private static void setIsPeftModel(
+            Properties lmiProperties, LmiUtils.HuggingFaceModelConfig modelConfig) {
+        if (modelConfig.isPeftModel()) {
+            lmiProperties.setProperty("option.is_peft_model", "true");
+        }
     }
 
     private static boolean isVllmEnabled(String features) {


### PR DESCRIPTION
## Description ##

This PR changes the way we handle peft models. The previous implementation relied on some fragile logic, where if we couldn't create the config via AutoConfig, we expected an OSError to be thrown to indicate the model was likely a peft model. That logic heavily reliant on the implementation of peft, and not very understandable. Also, the upgrade to peft completely broke it.

Instead, I've made some changes on the frontend to also look for an adapter_config.json file in the model artifacts. If that config file exists, we set a new attribute is_peft_model to instruct the python code how to load the model.

The changes I've made:
- include adapter_config.json as a possible config file to look for in LmiUtils (indicating a peft model)
- refactor config file parsing in LmiUtils. We iterate over the known options (config.json, adapter_config.json, model_index.json) rather than handling them in if/else in multiple places
- add new attribute in HuggingFaceModelConfig to indicate whether a model is peft or not (similar to what we do for stable diffusion)
- change the logic for parsing configs on the python side by relying on the explicit is_peft_model attribute
- change the model we use for testing lora with vanilla huggingface to one that has a valid config for the newer version of peft
- ensure we can run tests that leverage rb_client.py locally by making the necessary directory for awscurl outputs