### PR TITLE
[fix] forward compatibility for transformers_neuronx_scheduler

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
+++ b/engines/python/setup/djl_python/transformers_neuronx_scheduler/optimum_neuron_scheduler.py
@@ -140,8 +140,7 @@ class NeuronGenerator(ABC):
         return {
             "input_ids": inputs.input_ids,
             "cache_ids": inputs.cache_ids,
-            "start_ids": inputs.seq_ids,
-            "attention_mask": inputs.attention_mask
+            "start_ids": inputs.seq_ids
         }
 
     def make_generations(


### PR DESCRIPTION
## Description ##

Removing attention mask from prepare inputs - it is now handled by the optimum modeling prepare decode and prepare prefill functions which homogenize the model inputs to the generic forward call of input ids, cache ids, seq ids.  This should fix the new failures in the LMI Neuron CI where OptimumForCausalLM forward is getting an unexpected keyword argument 'attention_mask'.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
