### PR TITLE
[neuron] add smart defaults for aot partition path

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import json
+import logging
+from typing import List, Dict, Any
+import subprocess as sp
+
+logger = logging.getLogger(__name__)
+
+BILLION = 1_000_000_000.0
+MAX_ROLLING_BATCH = 32  # Current best throughput and latency balance batch size
+MEMORY_PER_CORE = 16.0  # Currently there is only one config w/ 16 GB per core
+
+
+class NeuronSmartDefaultUtils:
+    """
+    This class provides the Neuron smart default configurations for the model.
+    Additionally, it mirrors the Java implementation in the same package. Tests are mirrored
+    by ahead of time compilation using Java and loading using this python util.
+    """
+
+    def __init__(self,
+                 available_cores: int = 0,
+                 model_size_in_gb: float = 0,
+                 sequence_size_in_gb: float = 0) -> None:
+        """
+        Initializes the NeuronSmartDefaultUtils class with the given available cores, model size in GB, and sequence size in GB.
+
+        If available_cores is not set, it will be set to the number of available cores on the machine.
+
+        :param available_cores: The number of available cores on the machine
+        :param model_size_in_gb: The size of the model in GB
+        :param sequence_size_in_gb: The size of the sequence in GB
+        """
+        if available_cores:
+            self.available_cores = available_cores
+        else:
+            self.available_cores = self.get_available_cores()
+        self.model_size_in_gb = model_size_in_gb
+        self.sequence_size_in_gb = sequence_size_in_gb
+
+    def apply_smart_defaults(self, properties: Dict[str, Any],
+                             model_config: Dict[str, Any]) -> None:
+        """
+        Applies smart defaults for Neuron models.
+
+        If not already set, this method sets the following properties:
+        - n_positions: The default n_positions for the model.
+        - tensor_parallel_degree: A heuristic based on available memory.
+        - max_rolling_batch_size: A heuristic based on available memory.
+
+        :param properties: The properties to update
+        :param model_config: The model configuration to use
+        """
+        if "n_positions" not in properties:
+            if self.get_model_parameters(
+                    model_config) <= 0 or self.available_cores == 0:
+                # If n positions cannot be determined, skip smart defaults
+                return
+            properties["n_positions"] = min(
+                model_config.get("max_position_embeddings", 4096), 4096)
+            logger.info(
+                f"[Smart Default] N_POSITIONS: {properties['n_positions']}.")
+
+        try:
+            self.set_internal_settings(properties, model_config)
+        except Exception as e:
+            logger.debug(f"Failed to set internal settings: {e}")
+            return
+
+        self.set_heuristic_neuron_tp_degree(properties)
+        self.set_heuristic_neuron_max_rolling_batch(properties)
+
+    @staticmethod
+    def get_available_cores():
+        """
+        Get the number of available Neuron cores.
+
+        Uses the `neuron-ls --json-output` command to get the list of available Neuron cores.
+        If the command fails for any reason, returns 0.
+
+        :return: The number of available Neuron cores
+        """
+        command = "neuron-ls --json-output"
+        try:
+            output = sp.check_output(command, shell=True).decode("utf-8")
+            return len(json.loads(output))
+        except Exception as e:
+            logger.debug(f"Failed to get available cores: {e}")
+        return 0
+
+    def get_model_parameters(self, model_config):
+        """
+        Compute the number of parameters in a model.
+
+        Currently only supports LLaMA-like models. For other models, returns 0.
+
+        :param model_config: The model configuration dictionary
+        :return: The number of parameters in the model
+        """
+        if model_config.get("model_type") == "llama" or model_config.get(
+                "model_type") == "mistral":
+            return self.get_llama_like_parameters(model_config)
+        return 0
+
+    @staticmethod
+    def get_llama_like_parameters(model_config: Dict[str, Any]) -> int:
+        """
+        Compute the number of parameters in a LLaMA-like model.
+
+        The parameter count is computed as follows:
+
+        - embedding size: hidden size * vocab size
+        - qkv size: head dim * hidden size * num key value heads * 3
+        - o proj size: hidden size * hidden size
+        - gate proj size: hidden size * intermediate size * 3
+        - total size: embedding size + num hidden layers * (qkv size + o proj size + gate proj size + 2 * hidden size) + hidden size + embedding size
+
+        :param model_config: The model configuration dictionary
+        :return: The number of parameters in the LLaMA-like model
+        """
+        try:
+            head_dim = model_config["num_attention_heads"] * model_config[
+                "num_key_value_heads"]
+            embedding_size = model_config["hidden_size"] * model_config[
+                "vocab_size"]
+            qkv_size = head_dim * model_config["hidden_size"] * model_config[
+                "num_key_value_heads"] * 3
+            o_proj_size = model_config["hidden_size"] * model_config[
+                "hidden_size"]
+            gate_proj_size = model_config["hidden_size"] * model_config[
+                "intermediate_size"] * 3
+            return embedding_size + model_config["num_hidden_layers"] * (
+                qkv_size + o_proj_size + gate_proj_size +
+                model_config["hidden_size"] + model_config["hidden_size"]
+            ) + model_config["hidden_size"] + embedding_size
+        except Exception as e:
+            logger.debug(f"Failed to get llama-like parameters: {e}")
+            return 0
+
+    @staticmethod
+    def get_single_sequence_size(sequence_length: int, weight_bytes: int,
+                                 model_config: Dict[str, Any]) -> int:
+        """
+        Compute the memory required to store a single sequence of tokens.
+
+        The memory required is computed as the product of the sequence length,
+        hidden size, number of hidden layers, and weight size in bytes.
+
+        :param sequence_length: The length of the sequence in tokens
+        :param weight_bytes: The size of a single model weight in bytes
+        :param model_config: The model configuration dictionary
+        :return: The memory required to store a single sequence of tokens in bytes
+        """
+        try:
+            return sequence_length * model_config["hidden_size"] * model_config[
+                "num_hidden_layers"] * weight_bytes
+        except Exception as e:
+            logger.debug(f"Failed to get single sequence size: {e}")
+            return 0
+
+    def set_internal_settings(self, properties: Dict[str, Any],
+                              model_config: Dict[str, Any]) -> None:
+        """
+        Set the internal settings for this smart default.
+
+        Internal settings include the model size in GB and the sequence size in GB.
+        These are computed based on the model configuration and the presence of
+        quantization.
+
+        :param properties: The properties dictionary
+        :param model_config: The model configuration dictionary
+        :return: None
+        """
+        n_positions = int(properties.get("n_positions", 0))
+        param_bytes = 1 if "option.quantize" in properties else 2
+        self.model_size_in_gb = (
+            param_bytes * self.get_model_parameters(model_config)) / BILLION
+        self.sequence_size_in_gb = (self.get_single_sequence_size(
+            n_positions, param_bytes, model_config) * 0.95 /
+                                    (1024.0 * 1024.0 * 1024.0))
+
+    def get_adjusted_model_size_in_gb(self, tp_degree: int) -> float:
+        return self.model_size_in_gb * (1.0 + ((tp_degree * 2 - 2) / 100.0))
+
+    def set_heuristic_neuron_tp_degree(self, properties: Dict[str,
+                                                              Any]) -> None:
+        """
+        Sets a heuristic value for tensor parallel degree if not already set in model properties.
+
+        There are two scenarios where the tensor parallel degree is set:
+        - If the tensor parallel degree is not set in the properties and the max_rolling_batch_size is not set,
+          then the tensor parallel degree is set based on maximizing instance concurrency with variable rolling batch size.
+          The tensor parallel degree is set to the minimum core configuration that supports the maximum instance concurrency.
+        - If the tensor parallel degree is not set in the properties and the max_rolling_batch_size is set,
+          then the tensor parallel degree is set by minimizing TP degree that supports fixed batch size.
+          The tensor parallel degree is set to the minimum core configuration that supports the maximum instance concurrency given the fixed batch size.
+
+        :param properties: The properties dictionary
+        :return: None
+        """
+        tp_degree = self.available_cores
+        total_memory = tp_degree * MEMORY_PER_CORE
+
+        if "tensor_parallel_degree" in properties and properties[
+                "tensor_parallel_degree"] == "max":
+            properties["tensor_parallel_degree"] = self.available_cores
+            logger.info(
+                f"[Smart Default] TENSOR_PARALLEL_DEGREE: {properties['tensor_parallel_degree']}."
+            )
+            return
+
+        core_configs = self.available_core_configs()
+
+        if "tensor_parallel_degree" not in properties and "max_rolling_batch_size" not in properties:
+            # Set tensor parallel degree based on maximizing instance concurrency with variable rolling batch size
+            total_instance_concurrency = self.get_max_concurrency(
+                total_memory, tp_degree)
+            for core_config in core_configs:
+                max_memory = core_config * MEMORY_PER_CORE
+                max_concurrency = (
+                    self.get_max_concurrency(max_memory, core_config) *
+                    (self.available_cores // core_config))
+                if max_concurrency >= total_instance_concurrency and core_config <= tp_degree:
+                    tp_degree = core_config
+                    total_instance_concurrency = max_concurrency
+            properties["tensor_parallel_degree"] = tp_degree
+            logger.info(
+                f"[Smart Default] TENSOR_PARALLEL_DEGREE: {properties['tensor_parallel_degree']}."
+            )
+        elif "tensor_parallel_degree" not in properties:
+            # Set tensor parallel degree by minimizing TP degree that supports fixed batch size
+            batch_size = int(properties["max_rolling_batch_size"])
+            total_instance_concurrency = self.get_max_concurrency_with_batch(
+                total_memory, tp_degree, batch_size)
+            for core_config in core_configs:
+                max_memory = core_config * MEMORY_PER_CORE
+                max_concurrency = (self.get_max_concurrency_with_batch(
+                    max_memory, core_config, batch_size) *
+                                   (self.available_cores // core_config))
+                if max_concurrency >= total_instance_concurrency and core_config <= tp_degree:
+                    tp_degree = core_config
+                    total_instance_concurrency = max_concurrency
+            properties["tensor_parallel_degree"] = tp_degree
+            logger.info(
+                f"[Smart Default] TENSOR_PARALLEL_DEGREE: {properties['tensor_parallel_degree']}."
+            )
+
+    @staticmethod
+    def get_max_power_of_2(n: int) -> int:
+        """
+        Finds the largest power of 2 less than or equal to n.
+
+        :param n: the input number
+        :return: the largest power of 2 less than or equal to n
+        """
+        n = min(n, MAX_ROLLING_BATCH)
+        if n != 0 and (n & (n - 1)) == 0:
+            return n
+        max_power_of_2 = 1
+        while max_power_of_2 < n:
+            max_power_of_2 *= 2
+        return max_power_of_2 // 2
+
+    def get_max_concurrency(self, total_memory: float, tp_degree: int) -> int:
+        """
+        Calculates the maximum number of concurrent requests that can be served by a model given the
+        total memory available for the model and the sequence size.
+
+        The maximum number of concurrent requests is calculated as the largest power of 2 less
+        than or equal to the total memory divided by the sequence size.
+
+        :param total_memory: the total memory available for the model
+        :param tp_degree: the tensor parallel degree
+        :return: the maximum number of concurrent requests
+        """
+        max_concurrency = int(
+            (total_memory - self.get_adjusted_model_size_in_gb(tp_degree)) /
+            self.sequence_size_in_gb)
+        max_concurrency = self.get_max_power_of_2(max_concurrency)
+        return min(max_concurrency, MAX_ROLLING_BATCH)
+
+    def get_max_concurrency_with_batch(self, total_memory: float,
+                                       tp_degree: int, batch_size: int) -> int:
+        """
+        Calculates the maximum number of concurrent requests that can be served by a model given the
+        total memory available for the model and the sequence size, and the desired batch size.
+
+        :param total_memory: the total memory available for the model
+        :param tp_degree: the tensor parallel degree
+        :param batch_size: the desired batch size
+        :return: the maximum number of concurrent requests
+        """
+        max_concurrency = int(
+            (total_memory - self.get_adjusted_model_size_in_gb(tp_degree)) /
+            self.sequence_size_in_gb)
+        max_concurrency = self.get_max_power_of_2(max_concurrency)
+        max_concurrency = min(max_concurrency, batch_size)
+        return max_concurrency if max_concurrency == batch_size else 0
+
+    def available_core_configs(self) -> List[int]:
+        """
+        Builds the available core configurations for a given number of cores.
+
+        The available core configurations are those that are less than or equal to the total
+        number of cores. This method returns a list of available core configurations for the given
+        number of cores.
+
+        :return: the list of available core configurations
+        """
+        core_configs = self.build_core_configs(self.available_cores)
+        cores_per_model = int(1.1 * self.model_size_in_gb / MEMORY_PER_CORE)
+        return [config for config in core_configs if cores_per_model <= config]
+
+    @staticmethod
+    def build_core_configs(n_cores: int) -> List[int]:
+        """
+        Builds the available core configurations for a given number of cores.
+
+        The available core configurations are those that are less than or equal to the total
+        number of cores. This method returns a list of available core configurations for the given
+        number of cores.
+
+        :param n_cores: the number of cores to build the configurations for
+        :return: the list of available core configurations
+        """
+        core_configs = [1, 2, 8]
+        if n_cores > 8:
+            core_configs.append(n_cores)
+        return core_configs
+
+    def set_heuristic_neuron_max_rolling_batch(
+            self, properties: Dict[str, Any]) -> None:
+        """
+        Sets the max rolling batch size based on the TP degree and the model memory size.
+
+        If the max rolling batch size is not set, this method sets it to the maximum number of
+        concurrent requests that can be served by a model given the total memory available for the
+        model and the sequence size.
+
+        :param properties: The properties dictionary
+        :return: None
+        """
+        tp_degree = int(
+            properties.get("tensor_parallel_degree", self.available_cores))
+        if "max_rolling_batch_size" not in properties:
+            max_rolling_batch_size = self.get_max_concurrency(
+                tp_degree * MEMORY_PER_CORE, tp_degree)
+            if max_rolling_batch_size > 0:
+                properties["max_rolling_batch_size"] = max_rolling_batch_size
+                logger.info(
+                    f"[Smart Default] MAX_ROLLING_BATCH_SIZE: {properties['max_rolling_batch_size']}."
+                )

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_smart_default_utils.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import json
+import copy
+import unittest
+from unittest.mock import patch
+from djl_python.neuron_utils.neuron_smart_default_utils import NeuronSmartDefaultUtils
+
+MODEL_CONFIG_2B = {
+    "hidden_size": 2048,
+    "intermediate_size": 5632,
+    "max_position_embeddings": 2048,
+    "model_type": "llama",
+    "num_attention_heads": 32,
+    "num_hidden_layers": 22,
+    "num_key_value_heads": 4,
+    "vocab_size": 32000
+}
+
+MODEL_CONFIG_8B = {
+    "hidden_size": 4096,
+    "intermediate_size": 14336,
+    "max_position_embeddings": 131072,
+    "model_type": "llama",
+    "num_attention_heads": 32,
+    "num_hidden_layers": 32,
+    "num_key_value_heads": 8,
+    "vocab_size": 128256
+}
+
+MODEL_CONFIG_70B = {
+    "hidden_size": 8192,
+    "intermediate_size": 28672,
+    "max_position_embeddings": 131072,
+    "model_type": "llama",
+    "num_attention_heads": 64,
+    "num_hidden_layers": 80,
+    "num_key_value_heads": 8,
+    "vocab_size": 128256
+}
+
+MODEL_CONFIG_UNIT = {
+    "hidden_size": 1,
+    "intermediate_size": 1,
+    "max_position_embeddings": 1,
+    "model_type": "llama",
+    "num_attention_heads": 1,
+    "num_hidden_layers": 1,
+    "num_key_value_heads": 1,
+    "vocab_size": 1
+}
+
+
+class TestNeuronSmartDefaultUtils(unittest.TestCase):
+
+    def test_get_available_cores(self):
+        with patch('subprocess.check_output') as mock_check_output:
+            mock_check_output.return_value = b'[{"core": 0}, {"core": 1}, {"core": 2}, {"core": 3}]'
+            assert NeuronSmartDefaultUtils.get_available_cores() == 4
+
+    def test_get_available_cores_exception(self):
+        with patch('subprocess.check_output') as mock_check_output:
+            mock_check_output.side_effect = Exception(
+                'Error getting available cores')
+            assert NeuronSmartDefaultUtils.get_available_cores() == 0
+
+    def test_get_llama_like_parameters_exception(self):
+        model_config = {}
+        assert NeuronSmartDefaultUtils.get_llama_like_parameters(
+            model_config) == 0
+
+    def test_apply_smart_defaults_2b_model(self):
+        properties = {}
+        model_config = copy.deepcopy(MODEL_CONFIG_2B)
+        utils = NeuronSmartDefaultUtils(available_cores=4)
+        utils.apply_smart_defaults(properties, model_config)
+        assert properties["n_positions"] == 2048
+        assert properties["tensor_parallel_degree"] == 1
+        assert properties["max_rolling_batch_size"] == 32
+
+    def test_apply_smart_defaults_8b_model(self):
+        properties = {}
+        model_config = copy.deepcopy(MODEL_CONFIG_8B)
+        utils = NeuronSmartDefaultUtils(available_cores=2)
+        utils.apply_smart_defaults(properties, model_config)
+        assert properties["n_positions"] == 4096
+        assert properties["tensor_parallel_degree"] == 2
+        assert properties["max_rolling_batch_size"] == 16
+
+    def test_apply_smart_defaults_70b_model(self):
+        properties = {}
+        model_config = copy.deepcopy(MODEL_CONFIG_70B)
+        utils = NeuronSmartDefaultUtils(available_cores=32)
+        utils.apply_smart_defaults(properties, model_config)
+        assert properties["n_positions"] == 4096
+        assert properties["tensor_parallel_degree"] == 32
+        assert properties["max_rolling_batch_size"] == 32
+
+    def test_apply_smart_defaults_unit_model(self):
+        model_config = copy.deepcopy(MODEL_CONFIG_UNIT)
+        utils = NeuronSmartDefaultUtils(available_cores=1)
+        assert utils.get_model_parameters(model_config) == 12
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -25,6 +25,7 @@ from djl_python.properties_manager.tnx_properties import TransformerNeuronXPrope
     TnXModelLoaders
 from djl_python.properties_manager.properties import StreamingEnum, is_rolling_batch_enabled
 from djl_python.neuron_utils.model_loader import TNXModelLoader, OptimumModelLoader
+from djl_python.neuron_utils.neuron_smart_default_utils import NeuronSmartDefaultUtils
 from djl_python.neuron_utils.utils import task_from_config, build_vllm_rb_properties
 from djl_python.utils import rolling_batch_inference, get_input_details
 from djl_python.input_parser import parse_input_with_formatter
@@ -137,26 +138,6 @@ class TransformersNeuronXService(object):
                     f"VllmModelLoader does not support this config: {self.config}"
                 )
 
-    def set_max_position_embeddings(self) -> None:
-        """
-        Sets the maximum position embeddings for the model configuration.
-
-        If n_positions is not specified in the config, it sets the default value to the minimum of
-        max_position_embeddings from the model config and 4096.
-
-        Args:
-            None
-
-        Returns:
-            None
-        """
-        if self.config.n_positions is None:
-            self.config.n_positions = min(
-                self.model_config.max_position_embeddings, 4096)
-            logging.info(
-                f"Setting default n_positions to {self.config.n_positions} based on model config."
-            )
-
     def set_configs(self, properties: dict) -> None:
         """
         Sets the model configuration properties and performs necessary setup for model loading.
@@ -167,16 +148,19 @@ class TransformersNeuronXService(object):
         Returns:
             None
         """
+        self.model_config = AutoConfig.from_pretrained(
+            properties.get("model_id") or properties.get("model_dir"),
+            revision=properties.get("revision"),
+            trust_remote_code=properties.get("trust_remote_code"))
+
+        utils = NeuronSmartDefaultUtils()
+        utils.apply_smart_defaults(properties,
+                                   copy.deepcopy(self.model_config.__dict__))
+
         self.config = TransformerNeuronXProperties(**properties)
         if self.config.rolling_batch != "disable":
             """batch_size needs to match max_rolling_batch_size for precompiled neuron models running rolling batch"""
             self.config.batch_size = self.config.max_rolling_batch_size
-
-        self.model_config = AutoConfig.from_pretrained(
-            self.config.model_id_or_path,
-            revision=self.config.revision,
-            trust_remote_code=self.config.trust_remote_code)
-        self.set_max_position_embeddings()
 
         if self.config.rolling_batch != "disable" and self.config.rolling_batch_strategy is None:
             if (self.model_config.model_type

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -235,6 +235,11 @@ transformers_neuronx_handler_list = {
         "option.max_rolling_batch_size": 1,
         "option.model_loading_timeout": 3600,
     },
+    "tiny-llama-rb-lcnc": {
+        "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
+        "option.rolling_batch": "auto",
+        "option.model_loading_timeout": 3600,
+    },
     "tiny-llama-rb-aot": {
         "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
         "option.rolling_batch": "auto",

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -727,8 +727,9 @@ class TestNeuronx1:
             r.launch(container='pytorch-inf2-1')
             client.run("transformers_neuronx gpt2-quantize".split())
 
-    @pytest.mark.parametrize("model",
-                             ["tiny-llama-rb-aot", "tiny-llama-rb-aot-quant"])
+    @pytest.mark.parametrize(
+        "model",
+        ["tiny-llama-rb-aot", "tiny-llama-rb-aot-quant", "tiny-llama-lcnc"])
     def test_partition(self, model):
         with Runner('pytorch-inf2', f'partition-{model}') as r:
             try:


### PR DESCRIPTION
## Description ##

Add smart default logic to python only path, specifically AOT compilation.

This knowingly duplicates the logic applied in the wlm -> https://github.com/deepjavalibrary/djl-serving/blob/master/wlm/src/main/java/ai/djl/serving/wlm/NeuronSmartDefaultUtils.java . The reason for this is that when running AOT compilation the model servers default configuration modules are never called. This means that we are finding divergent behavior when defaulting  values while partitioning when compared to runtime compilation through the model server.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
