### PR TITLE
[docker] fix typo vllm_version -> vllm_wheel

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -115,7 +115,7 @@ RUN pip3 install ${seq_scheduler_wheel} peft==${peft_version} protobuf==${protob
     && git clone https://github.com/neuralmagic/AutoFP8.git && cd AutoFP8 && git reset --hard 4b2092c && pip3 install . && cd .. && rm -rf AutoFP8 \
     && pip3 cache purge
 
-RUN pip3 install ${flash_attn_2_wheel} ${lmi_dist_wheel} ${vllm_version} ${flash_infer_wheel} \
+RUN pip3 install ${flash_attn_2_wheel} ${lmi_dist_wheel} ${vllm_wheel} ${flash_infer_wheel} \
     && pip3 cache purge
 
 # Add CUDA-Compat


### PR DESCRIPTION
## Description ##

the docker build kept installing vllm 0.6.2 instead of the patch build from my fork. could not figure out why and in the end it was just a typo. this now installs the correct vllm patch with support for MLlama. i validated it works and will raise the pr for tests
