### PR TITLE
[serving][python] Backport for pull #2173 to v0.28, support for non-2…

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -64,7 +64,8 @@ class RollingBatch implements Runnable {
                         return t;
                     });
 
-    private static boolean isBackportForNonStreamingHttpErrorCodes = getBackportForNonStreamingHttpErrorCodesOption();
+    private static boolean isBackportForNonStreamingHttpErrorCodes =
+            getBackportForNonStreamingHttpErrorCodesOption();
 
     private PyProcess process;
     private int maxRollingBatchSize;
@@ -257,11 +258,12 @@ class RollingBatch implements Runnable {
         // Option the allows non-streaming requests to return non-200 error code on error
         boolean result =
                 Boolean.parseBoolean(
-                        Utils.getEnvOrSystemProperty("SERVING_BACKPORT_FOR_NON_STREAMING_HTTP_ERROR_CODES"));
+                        Utils.getEnvOrSystemProperty(
+                                "SERVING_BACKPORT_FOR_NON_STREAMING_HTTP_ERROR_CODES"));
         if (result) {
             logger.info(
                     "SERVING_BACKPORT_FOR_NON_STREAMING_HTTP_ERROR_CODES is enabled."
-                        + " See https://github.com/deepjavalibrary/djl-serving/pull/2173");
+                            + " See https://github.com/deepjavalibrary/djl-serving/pull/2173");
         }
         return result;
     }

--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -361,7 +361,7 @@ class RollingBatch implements Runnable {
             }
             if (isBackportForNonStreamingHttpErrorCodes && !last) {
                 // in non-streaming cases, do not return content until generation is finished
-                return
+                return;
             }
 
             if (code != null) {


### PR DESCRIPTION
…00 HTTP codes for non-streaming rolling batch requests

## Description ##

This is an opt-in backport of a subset of the behavior added in pull request #2173 to v0.28.0-dlc, so that non-streaming rolling batch requests can return non-200 HTTP response codes on error. It's opt-in to avoid a breaking change for users using v0.28.0 who may require the old behavior.
