### PR TITLE
[ci][tests] adding new multimodal and pipeline parallel tests

### DIFF
--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -213,6 +213,9 @@ elif $is_sm_neo_context; then
     -e SM_NEO_CACHE_DIR=/opt/ml/compilation/cache \
     -e SM_NEO_HF_CACHE_DIR=/opt/ml/compilation/cache \
     -e COMPILER_OPTIONS={} \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     ${env_file} \
     ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
@@ -232,6 +235,9 @@ elif $is_partition; then
     ${nvme:+-v ${nvme}} \
     ${env_file} \
     -e TEST_TELEMETRY_COLLECTION='true' \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
@@ -248,6 +254,9 @@ elif [[ "$docker_image" == *"text-generation-inference"* ]]; then
     -v ~/sagemaker_infra/:/opt/ml/.sagemaker_infra/:ro \
     ${nvme:+-v ${nvme}} \
     ${env_file} \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     "${docker_image}" \
@@ -269,6 +278,9 @@ else
     ${env_file} \
     -e TEST_TELEMETRY_COLLECTION='true' \
     -e SERVING_OPTS='-Dai.djl.logging.level=debug' \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     $uid_mapping \
     ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -384,7 +384,37 @@ lmi_dist_model_spec = {
         "batch_size": [1, 4],
         "seq_length": [256],
         "tokenizer": "NousResearch/Hermes-3-Llama-3.1-8B"
-    }
+    },
+    "llama32-3b-multi-worker-tp1-pp1": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
+    "llama32-3b-multi-worker-tp2-pp1": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
+    "llama32-3b-multi-worker-tp1-pp2": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
+    "llama31-8b-pp-only": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
+    "llama31-8b-tp2-pp2": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
+    "llama31-8b-tp2-pp2-spec-dec": {
+        "max_memory_per_gpu": [23.0],
+        "batch_size": [1, 4],
+        "seq_length": [256],
+    },
 }
 
 lmi_dist_chat_model_spec = {
@@ -870,7 +900,15 @@ multi_modal_spec = {
         "max_memory_per_gpu": [25.0, 25.0],
         "batch_size": [1, 4],
         "tokenizer": "microsoft/Phi-3-vision-128k-instruct"
-    }
+    },
+    "pixtral-12b": {
+        "max_memory_per_gpu": [25.0, 25.0, 25.0],
+        "batch_size": [1, 4],
+    },
+    "llama32-11b-multimodal": {
+        "max_memory_per_gpu": [25.0, 25.0, 25.0],
+        "batch_size": [1],
+    },
 }
 
 text_embedding_model_spec = {

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -388,6 +388,7 @@ lmi_dist_model_list = {
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 2,
         "option.max_rolling_batch_size": 4,
+        "option.max_model_len": 32768,
         "option.quantize": "awq"
     },
     "mistral-7b-marlin": {
@@ -563,13 +564,66 @@ lmi_dist_model_list = {
         "option.model_id": "s3://djl-llm/phi-3-vision-128k-instruct/",
         "option.limit_mm_per_prompt": "image=4",
         "option.trust_remote_code": True,
+        "option.max_model_len": 8192,
     },
     "llama-3.1-8b": {
         "option.model_id": "s3://djl-llm/llama-3.1-8b-hf/",
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 4,
         "option.max_rolling_batch_size": 4
-    }
+    },
+    "pixtral-12b": {
+        "option.model_id": "s3://djl-llm/pixtral-12b/",
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+        "option.tokenizer_mode": "mistral",
+        "option.limit_mm_per_prompt": "image=4",
+        "option.entryPoint": "djl_python.huggingface"
+    },
+    "llama32-3b-multi-worker-tp1-pp1": {
+        "option.model_id": "s3://djl-llm/llama-3-2-3b-instruct/",
+        "option.tensor_parallel_degree": 1,
+        "option.pipeline_parallel_degree": 1,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+    },
+    "llama32-3b-multi-worker-tp2-pp1": {
+        "option.model_id": "s3://djl-llm/llama-3-2-3b-instruct/",
+        "option.tensor_parallel_degree": 2,
+        "option.pipeline_parallel_degree": 1,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+    },
+    "llama32-3b-multi-worker-tp1-pp2": {
+        "option.model_id": "s3://djl-llm/llama-3-2-3b-instruct/",
+        "option.tensor_parallel_degree": 1,
+        "option.pipeline_parallel_degree": 2,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+    },
+    "llama31-8b-pp-only": {
+        "option.model_id": "s3://djl-llm/llama-3.1-8b-instruct-hf/",
+        "option.tensor_parallel_degree": 1,
+        "option.pipeline_parallel_degree": 4,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+    },
+    "llama31-8b-tp2-pp2": {
+        "option.model_id": "s3://djl-llm/llama-3.1-8b-instruct-hf/",
+        "option.tensor_parallel_degree": 2,
+        "option.pipeline_parallel_degree": 2,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+    },
+    "llama31-8b-tp2-pp2-spec-dec": {
+        "option.model_id": "s3://djl-llm/llama-3.1-8b-instruct-hf/",
+        "option.tensor_parallel_degree": 2,
+        "option.pipeline_parallel_degree": 2,
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+        "option.speculative_draft_model_id":
+        "s3://djl-llm/llama-3-2-1b-instruct/",
+    },
 }
 
 vllm_model_list = {
@@ -796,6 +850,34 @@ vllm_model_list = {
         "option.tensor_parallel_degree": 4,
         "option.max_rolling_batch_size": 4,
     },
+    "llava_v1.6-mistral": {
+        "option.model_id": "s3://djl-llm/llava-v1.6-mistral-7b-hf/",
+        "option.limit_mm_per_prompt": "image=4",
+    },
+    "paligemma-3b-mix-448": {
+        "option.model_id": "s3://djl-llm/paligemma-3b-mix-448/",
+        "option.tensor_parallel_degree": 1,
+    },
+    "phi-3-vision-128k-instruct": {
+        "option.model_id": "s3://djl-llm/phi-3-vision-128k-instruct/",
+        "option.limit_mm_per_prompt": "image=4",
+        "option.trust_remote_code": True,
+        "option.max_model_len": 8192,
+    },
+    "pixtral-12b": {
+        "option.model_id": "s3://djl-llm/pixtral-12b/",
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+        "option.tokenizer_mode": "mistral",
+        "option.limit_mm_per_prompt": "image=4",
+        "option.entryPoint": "djl_python.huggingface"
+    },
+    "llama32-11b-multimodal": {
+        "option.model_id": "s3://djl-llm/llama-3-2-11b-vision-instruct/",
+        "option.max_model_len": 8192,
+        "option.max_rolling_batch_size": 16,
+        "option.enforce_eager": True,
+    }
 }
 
 vllm_neo_model_list = {

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -921,17 +921,84 @@ class TestMultiModalLmiDist:
             r.launch()
             client.run("multimodal llava_v1.6-mistral".split())
 
-    def test_paligemma(self):
-        with Runner('lmi', 'paligemma-3b-mix-448') as r:
-            prepare.build_lmi_dist_model('paligemma-3b-mix-448')
-            r.launch()
-            client.run("multimodal paligemma-3b-mix-448".split())
-
     def test_phi3_v(self):
         with Runner('lmi', 'phi-3-vision-128k-instruct') as r:
             prepare.build_lmi_dist_model('phi-3-vision-128k-instruct')
             r.launch()
             client.run("multimodal phi-3-vision-128k-instruct".split())
+
+    def test_pixtral_12b(self):
+        with Runner('lmi', 'pixtral-12b') as r:
+            prepare.build_lmi_dist_model('pixtral-12b')
+            r.launch()
+            client.run("multimodal pixtral-12b".split())
+
+
+class TestMultiModalVllm:
+
+    def test_llava_next(self):
+        with Runner('lmi', 'llava_v1.6-mistral') as r:
+            prepare.build_vllm_model('llava_v1.6-mistral')
+            r.launch()
+            client.run("multimodal llava_v1.6-mistral".split())
+
+    def test_phi3_v(self):
+        with Runner('lmi', 'phi-3-vision-128k-instruct') as r:
+            prepare.build_vllm_model('phi-3-vision-128k-instruct')
+            r.launch()
+            client.run("multimodal phi-3-vision-128k-instruct".split())
+
+    def test_pixtral_12b(self):
+        with Runner('lmi', 'pixtral-12b') as r:
+            prepare.build_vllm_model('pixtral-12b')
+            r.launch()
+            client.run("multimodal pixtral-12b".split())
+
+    # MLlama is only supported by vllm backend currently
+    def test_mllama_11b(self):
+        with Runner('lmi', 'llama32-11b-multimodal') as r:
+            prepare.build_vllm_model('llama32-11b-multimodal')
+            r.launch()
+            client.run("multimodal llama32-11b-multimodal".split())
+
+
+class TestLmiDistPipelineParallel:
+
+    def test_llama32_3b_multi_worker_tp1_pp1(self):
+        with Runner('lmi', 'llama32-3b-multi-worker-tp1-pp1') as r:
+            prepare.build_lmi_dist_model("llama32-3b-multi-worker-tp1-pp1")
+            r.launch()
+            client.run("lmi_dist llama32-3b-multi-worker-tp1-pp1".split())
+
+    def test_llama32_3b_multi_worker_tp2_pp1(self):
+        with Runner('lmi', 'llama32-3b-multi-worker-tp2-pp1') as r:
+            prepare.build_lmi_dist_model("llama32-3b-multi-worker-tp2-pp1")
+            r.launch()
+            client.run("lmi_dist llama32-3b-multi-worker-tp2-pp1".split())
+
+    def test_llama32_3b_multi_worker_tp1_pp2(self):
+        with Runner('lmi', 'llama32-3b-multi-worker-tp1-pp2') as r:
+            prepare.build_lmi_dist_model("llama32-3b-multi-worker-tp1-pp2")
+            r.launch()
+            client.run("lmi_dist llama32-3b-multi-worker-tp1-pp2".split())
+
+    def test_llama31_8b_pp_only(self):
+        with Runner('lmi', 'llama31-8b-pp-only') as r:
+            prepare.build_lmi_dist_model("llama31-8b-pp-only")
+            r.launch()
+            client.run("lmi_dist llama31-8b-pp-only".split())
+
+    def test_llama31_8b_tp2_pp2(self):
+        with Runner('lmi', 'llama31-8b-tp2-pp2') as r:
+            prepare.build_lmi_dist_model('llama31-8b-tp2-pp2')
+            r.launch()
+            client.run("lmi_dist llama31-8b-tp2-pp2".split())
+
+    def test_llama31_8b_tp2_pp2_specdec(self):
+        with Runner('lmi', 'llama31-8b-tp2-pp2-spec-dec') as r:
+            prepare.build_lmi_dist_model('llama31-8b-tp2-pp2-spec-dec')
+            r.launch()
+            client.run("lmi_dist llama31-8b-tp2-pp2-spec-dec".split())
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Description ##

There are a few changes in this PR, mostly related to adding new tests

1. Add multimodal tests for vllm backend (previously we only ran them for lmi-dist)
  - remove paligemma test - this model does not contain a chat template, and we only support multi-modal requests via chat api. It used to work until transformers removed default chat template behavior
3. Add pixtral tests for both lmi-dist and vllm
  - Note that succes of these tests depends on this PR https://github.com/deepjavalibrary/djl-serving/pull/2468/files
4. Add Mllama-11b test for vllm
  - This doesn't work with lmi-dist currently
5. Add a variety of pipeline parallel tests for lmi-dist
  - tp1, pp1, 4 workers
  - tp1, pp2, 2 workers
  - tp2, pp1 2 workers
  - pp4
  - tp2 pp2
  - tp2 pp2 + spec dec
6. Mount aws env vars in launch_container script to make it easy to run these tests with local credentials
