### PR TITLE
[lora] Add adapter config jobs to job queue

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -199,7 +199,7 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
         }
         Adapter.unregister(wp, adapterName);
 
-        String msg = "Adapter " + adapterName + " registered";
+        String msg = "Adapter " + adapterName + " unregistered";
         NettyUtils.sendJsonResponse(ctx, new StatusResponse(msg));
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -42,6 +42,7 @@ public final class LmiConfigRecommender {
         setTensorParallelDegree(lmiProperties);
         setRollingBatchSize(lmiProperties);
         setIsPeftModel(lmiProperties, modelConfig);
+        setWorkers(lmiProperties);
     }
 
     private static void setRollingBatch(
@@ -146,6 +147,16 @@ public final class LmiConfigRecommender {
             Properties lmiProperties, LmiUtils.HuggingFaceModelConfig modelConfig) {
         if (modelConfig.isPeftModel()) {
             lmiProperties.setProperty("option.is_peft_model", "true");
+        }
+    }
+
+    private static void setWorkers(Properties lmiProperties) {
+        // If option.enable_lora=true, set maxWorkers to 1 because we only support one worker thread
+        // for LoRA.
+        boolean enableLora = Boolean.parseBoolean(lmiProperties.getProperty("option.enable_lora"));
+        if (enableLora) {
+            logger.info("option.enable_lora is set to true, setting maxWorkers to 1");
+            lmiProperties.setProperty("maxWorkers", "1");
         }
     }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java
@@ -1236,7 +1236,7 @@ public final class ModelInfo<I, O> extends WorkerPoolConfig<I, O> {
 
             synchronized (this) {
                 for (Map.Entry<String, Adapter> adapter : adapters.entrySet()) {
-                    configJobs.add(adapter.getValue().registerJob(ModelInfo.this, this).getJob());
+                    configJobs.add(adapter.getValue().registerJob(ModelInfo.this).getJob());
                 }
             }
         }

--- a/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/PyAdapter.java
@@ -12,10 +12,7 @@
  */
 package ai.djl.serving.wlm;
 
-import ai.djl.inference.Predictor;
 import ai.djl.modality.Input;
-import ai.djl.modality.Output;
-import ai.djl.translate.TranslateException;
 
 import java.util.Map;
 
@@ -35,8 +32,7 @@ public class PyAdapter extends Adapter {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected void registerPredictor(Predictor<?, ?> predictor) {
-        Predictor<Input, Output> p = (Predictor<Input, Output>) predictor;
+    protected <I> I getRegisterAdapterInput() {
         Input input = new Input();
         input.addProperty("handler", "register_adapter");
         input.addProperty("name", name);
@@ -44,24 +40,15 @@ public class PyAdapter extends Adapter {
         for (Map.Entry<String, String> entry : options.entrySet()) {
             input.add(entry.getKey(), entry.getValue());
         }
-        try {
-            p.predict(input);
-        } catch (TranslateException e) {
-            throw new IllegalStateException(e);
-        }
+        return (I) input;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    protected void unregisterPredictor(Predictor<?, ?> predictor) {
-        Predictor<Input, Output> p = (Predictor<Input, Output>) predictor;
+    protected <I> I getUnregisterAdapterInput() {
         Input input = new Input();
         input.addProperty("handler", "unregister_adapter");
         input.addProperty("name", name);
-        try {
-            p.predict(input);
-        } catch (TranslateException e) {
-            throw new IllegalStateException(e);
-        }
+        return (I) input;
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Currently adapter management API requests run together with inference request, see https://github.com/deepjavalibrary/djl-serving/blob/master/wlm/src/main/java/ai/djl/serving/wlm/WorkerThread.java#L90. The requirement is to run adapter management API requests without delay. So this PR add adapter requests to jobQueue to run.