### PR TITLE
[lmi] avoid creating huggingface model config in rolling batch cases …

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -36,7 +36,7 @@ class VllmRbProperties(Properties):
     dtype: Optional[str] = "auto"
     load_format: Optional[str] = "auto"
     quantize: Optional[VllmQuantizeMethods] = None
-    tensor_parallel_degree: Optional[int] = None
+    tensor_parallel_degree: int = 1
     pipeline_parallel_degree: int = 1
     max_rolling_batch_prefill_tokens: Optional[int] = None
     # Adjustable prefix model length for certain 32k or longer model

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -870,7 +870,8 @@ vllm_model_list = {
         "option.max_rolling_batch_size": 16,
         "option.tokenizer_mode": "mistral",
         "option.limit_mm_per_prompt": "image=4",
-        "option.entryPoint": "djl_python.huggingface"
+        "option.entryPoint": "djl_python.huggingface",
+        "option.tensor_parallel_degree": "max"
     },
     "llama32-11b-multimodal": {
         "option.model_id": "s3://djl-llm/llama-3-2-11b-vision-instruct/",


### PR DESCRIPTION
…to avoid issues with mistral type models

## Description ##

Some mistral models are not vended in the HuggingFace pre-trained format (i.e. there is no config.json). They also contain different tokenizers that are not compatible with PreTrainedTokenizer from huggingface.

This change removes the instantiation of the huggingface config from the rolling batch path. The only place the model config is used in our rolling batch path is in lmi-dist to figure out whether the model is t5 or not. This is needed to address the failing pixtral MultiModal tests.

The reason these tests were passing locally is because I was using model artifacts mounted in the container at path `/opt/ml/model/pixtral`. There is logic in AutoConfig.from_pretrained to see if the model_id/path contains a known model type, and if so use that class to create it. In the integ test case we are using an s3 url that gets downloaded and stored in a directory without the pixtral name, so it fails.