### PR TITLE
[fix] neuron unit test smart default handler and error handling

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
@@ -191,6 +191,12 @@ class NeuronSmartDefaultUtils:
             n_positions, param_bytes, model_config) * 0.95 /
                                     (1024.0 * 1024.0 * 1024.0))
 
+        if self.model_size_in_gb == 0 or self.sequence_size_in_gb == 0 or n_positions == 0:
+            raise Exception(
+                f"Failed to compute model size or sequence size or n_positions: {n_positions},"
+                f"model_size_in_gb: {self.model_size_in_gb}, sequence_size_in_gb: {self.sequence_size_in_gb}"
+            )
+
     def get_adjusted_model_size_in_gb(self, tp_degree: int) -> float:
         return self.model_size_in_gb * (1.0 + ((tp_degree * 2 - 2) / 100.0))
 

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_transformers_neuronx.py
@@ -210,30 +210,6 @@ class TestTransformerNeuronXService(unittest.TestCase):
                          self.service.config.save_mp_checkpoint_path)
         self.assertTrue(self.service.initialized)
 
-    @parameters([{
-        "initial_value": 512,
-        "smart_default": 512
-    }, {
-        "initial_value": 8192,
-        "smart_default": 4096
-    }])
-    def test_smart_defaults(self, params):
-        # Setup
-        self.default_properties.pop('n_positions')
-        test_properties = self.default_properties
-        self.service.config = self.config_builder(test_properties)
-        self.service.model_config = AutoConfig.from_pretrained(
-            test_properties['model_id'])
-        self.service.model_config.max_position_embeddings = params[
-            'initial_value']
-
-        # Test
-        self.service.set_max_position_embeddings()
-
-        # Evaluate
-        self.assertEqual(self.service.config.n_positions,
-                         params['smart_default'])
-
     def tearDown(self):
         del self.service
         del self.default_properties


### PR DESCRIPTION
## Description ##

Removed smart default test for n_positions from handler as it was moved to the smart default class. Added an exception for 0 value divisors coming out of model size heuristics.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
