### PR TITLE
[python] Fix backport of rolling batch non-streaming non-200 error code support

### DIFF
--- a/engines/python/setup/djl_python/request.py
+++ b/engines/python/setup/djl_python/request.py
@@ -16,6 +16,7 @@ from typing import Union, Callable, Any
 from djl_python.output_formatter import get_output_formatter, _json_output_formatter, sse_response_formatter, \
     adapt_legacy_output_formatter
 from djl_python.request_io import Token, TextGenerationOutput, TextInput, RequestOutput
+from djl_python.utils import serving_backport_for_non_streaming_http_error_codes_enabled
 
 
 class Request(object):
@@ -114,6 +115,9 @@ class Request(object):
         self.request_output.set_finish_reason(finish_reason)
         self.request_output.prompt_tokens_details = prompt_tokens_details
         self.last_token = last_token
+        if (last_token and
+                serving_backport_for_non_streaming_http_error_codes_enabled()):
+            self.request_output.finished = True
 
     def get_next_token(self) -> str:
         """

--- a/engines/python/setup/djl_python/utils.py
+++ b/engines/python/setup/djl_python/utils.py
@@ -11,6 +11,7 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
 import logging
+import os
 from typing import Union, Callable, Any, List
 
 from djl_python.inputs import Input
@@ -192,3 +193,7 @@ def profile_objects(func):
         return result
 
     return apply_profiling
+
+
+def serving_backport_for_non_streaming_http_error_codes_enabled():
+    return os.getenv("SERVING_BACKPORT_FOR_NON_STREAMING_HTTP_ERROR_CODES")

--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -374,9 +374,19 @@ class RollingBatch implements Runnable {
 
             if (code != null) {
                 Map<String, Object> map = new ConcurrentHashMap<>(2);
-                map.put("code", Integer.parseInt(code));
+                int httpStatusCode = Integer.parseInt(code);
+                map.put("code", httpStatusCode);
                 if (error != null) {
                     map.put("error", error);
+                }
+                if (isBackportForNonStreamingHttpErrorCodes) {
+                    // Update http status code and any error message to the values here, so
+                    // that non-streaming case can return non-200 on errors encountered during
+                    // inference.
+                    output.setCode(httpStatusCode);
+                    if (error != null) {
+                        output.setMessage(error);
+                    }
                 }
                 byte[] buffer = JsonUtils.GSON.toJson(map).getBytes(StandardCharsets.UTF_8);
                 data.appendContent(buffer, true);


### PR DESCRIPTION
## Description ##

With further testing, we found that pull request #2466 was incomplete. This adds the rest of what was needed.

I ran with this `model.py` script to cause exceptions to be thrown randomly, as well as a variant that overrides `postprocess_results` to not set `code` or `error`, to ensure that `@stop_on_any_exception` works as expected.

I also verified that it does not change the behavior unless enabling the feature flag.

model.py:
``` python
import djl_python.rolling_batch.lmi_dist_rolling_batch
_update_request_cache_with_output = djl_python.rolling_batch.lmi_dist_rolling_batch.update_request_cache_with_output

_ctr = 0

def update_request_cache_with_output(*args, **kwargs):
    global _ctr
    _ctr += 1
    if _ctr % 20 == 0:
        raise RuntimeError("Uh oh")
    return _update_request_cache_with_output(*args, **kwargs)

djl_python.rolling_batch.lmi_dist_rolling_batch.update_request_cache_with_output = update_request_cache_with_output

import djl_python.huggingface
handle = djl_python.huggingface.handle
```

``` bash
$ env | sort | grep SERVING_
SERVING_BACKPORT_FOR_NON_STREAMING_HTTP_ERROR_CODES=true
SERVING_FEATURES=vllm,lmi-dist

$ env | sort | grep OPTION_
OPTION_ENFORCE_EAGER=true
OPTION_MODEL_ID=TheBloke/Llama-2-7B-fp16
OPTION_MPI_MODE=true
OPTION_PIPELINE_PARALLEL_DEGREE=1
OPTION_TENSOR_PARALLEL_DEGREE=4
```

``` bash
$ time awscurl -c 1 -N 1 -X POST http://127.0.0.1:8080/invocations --connect-timeout 60 -H Content-type: application/json -v --data {"inputs": "list all the names which start with the letter r","parameters":{"max_new_tokens":10,"seed":2,"do_sample":true}}

WARN Client 0 delay: 0

timestamp: 1729579725060
input: {"inputs": "list all the names which start with the letter r","parameters":{"max_new_tokens":10,"seed":2,"do_sample":true}}
output: > POST //invocations HTTP/1.1
>
> Accept: */*
> User-Agent: awscurl/1.0.0
> Host: 127.0.0.1:8094
> Content-Type: application/json
>
< HTTP/1.1 424 Uh oh
<
< Content-Type: application/json
< x-request-id: c667f402-1df9-4134-92af-923c21071c30
< Pragma: no-cache
< Cache-Control: no-cache; no-store, must-revalidate, private
< Expires: Thu, 01 Jan 1970 00:00:00 UTC
< transfer-encoding: chunked
< connection: keep-alive
<
{"error":"Uh oh","code":424}
real    0m0.539s
user    0m0.812s
sys     0m0.054s
```