### PR TITLE
[lmi] expose method on RollingBatch to retrieve huggingface model config

### DIFF
--- a/engines/python/setup/djl_python/huggingface.py
+++ b/engines/python/setup/djl_python/huggingface.py
@@ -133,6 +133,8 @@ class HuggingFaceService(object):
                 self.hf_configs.model_id_or_path, properties,
                 **self.hf_configs.kwargs)
             self.tokenizer = self.rolling_batch.get_tokenizer()
+            self.model_config = self.rolling_batch.get_huggingface_model_config(
+            )
         elif is_streaming_enabled(self.hf_configs.enable_streaming):
             self._read_model_config(self.hf_configs.model_id_or_path,
                                     self.hf_configs.is_peft_model)

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -121,6 +121,11 @@ class LmiDistRollingBatch(RollingBatch):
             return self.engine.preprocessor.tokenizer
         return self.engine.preprocessor.tokenizer.tokenizer
 
+    def get_huggingface_model_config(self):
+        # TODO: this is a hack right now to get the model config from the engine. We should expose this as
+        # an interface method and retrieve it from there after v12
+        return self.engine.preprocessor.model_config.hf_config if not self.is_t5_model else None
+
     def translate_lmi_dist_params(self, parameters: dict):
         """
         Helper function to convert DJL Serving parameter names to parameter names

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch.py
@@ -96,6 +96,13 @@ class RollingBatch(ABC):
         """
         raise RuntimeError("get_tokenizer function not supported")
 
+    def get_huggingface_model_config(self):
+        """
+        :return: the huggingface pretrained config if available
+        """
+        raise RuntimeError(
+            "get_huggingface_model_config must be implemented by subclass")
+
     @abstractmethod
     def inference(self, new_requests: List[Request]) -> List:
         """

--- a/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/scheduler_rolling_batch.py
@@ -322,6 +322,9 @@ class SchedulerRollingBatch(RollingBatch):
     def get_tokenizer(self):
         return self.tokenizer
 
+    def get_huggingface_model_config(self):
+        return self.config
+
 
 def _get_request_ids_tensor(request_ids: List[int]) -> torch.Tensor:
     """

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -56,6 +56,9 @@ class VLLMRollingBatch(RollingBatch):
     def get_tokenizer(self):
         return self.engine.tokenizer.tokenizer
 
+    def get_huggingface_model_config(self):
+        return self.engine.model_config.hf_config
+
     def reset(self) -> None:
         """
         Aborts all requests

--- a/engines/python/setup/djl_python/tests/rolling_batch/fake_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/rolling_batch/fake_rolling_batch.py
@@ -59,6 +59,9 @@ class FakeRollingBatch(RollingBatch):
     def get_tokenizer(self):
         return self.tokenizer
 
+    def get_huggingface_model_config(self):
+        return None
+
     def reset(self):
         self.cache = OrderedDict()
         super().reset()


### PR DESCRIPTION
## Description ##

I was too hasty with https://github.com/deepjavalibrary/djl-serving/pull/2473. While the huggingface model config is not needed in most cases, we are currently relying on it to select the correct image token to use in multi modal use-cases.

We pull this model config directly from the engine, since at least in the case vllm/lmi-dist, there is already logic implemented there to properly pull the model config (especially in cases like mistral where you have to do a bunch of checks and parsing to get it into hf format).

This will fix the ci errors related to multi-modal. I ran all those test cases against this change and it is working. For the previous PR, i only tested pixtral well it seems.
