### PR TITLE
[fix] Propagate predict output code to batch request output codes in …

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -180,6 +180,11 @@ class RollingBatch implements Runnable {
                     BytesSupplier err = BytesSupplier.wrap(JsonUtils.GSON.toJson(out));
                     for (Request req : list) {
                         req.last = true;
+                        if (isBackportForNonStreamingHttpErrorCodes) {
+                            // Note: This will only change the HTTP response code if the first chunk
+                            // has not yet been sent
+                            req.output.setCode(code);
+                        }
                         req.data.appendContent(err, true);
                     }
                     list.clear();


### PR DESCRIPTION
…RollingBatch

## Description ##

If the Output that comes back from a rolling batch predict call has a non-200 error code, it was not propagated to the request Output for requests in the batch.
