### PR TITLE
[fix] fix typo in t5 integration test

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -471,7 +471,7 @@ class TestLmiDist1:
         with Runner('lmi', 'flan-t5-xl') as r:
             prepare.build_lmi_dist_model("flan-t5-xl")
             r.launch()
-            client.run("lmi_dist flan-t5-xl")
+            client.run("lmi_dist flan-t5-xl".split())
 
 
 @pytest.mark.lmi_dist


### PR DESCRIPTION
## Description ##

Fixing a typo. I want to make some changes to how we specify args in the tests here, but will do that in a follow up PR since that impacts all tests.
