### PR TITLE
[fix] Propagate RollingBatch predict output code to request outputs

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -174,6 +174,11 @@ class RollingBatch implements Runnable {
                     BytesSupplier err = BytesSupplier.wrap(JsonUtils.GSON.toJson(out));
                     for (Request req : list) {
                         req.last = true;
+
+                        // Note: This will only change the HTTP response code if the first chunk
+                        // has not yet been sent
+                        req.output.setCode(code);
+
                         req.data.appendContent(err, true);
                     }
                     list.clear();


### PR DESCRIPTION
## Description ##
This is a forward port of PR #2481 

Example using awscurl below.

Before:
```
timestamp: 1729797995533
input: {"inputs": "list all the names which start with the letter r","parameters":{"max_new_tokens":10,"seed":2,"do_sample":true}}
output: > POST //invocations HTTP/1.1
>
> Accept: */*
> User-Agent: awscurl/1.0.0
> Host: 127.0.0.1:8094
> Content-Type: application/json
>
< HTTP/1.1 200 OK
<
< Content-Type: application/json
< x-request-id: f5c33cdf-2313-4f81-895b-ac8c0c9eb91d
< Pragma: no-cache
< Cache-Control: no-cache; no-store, must-revalidate, private
< Expires: Thu, 01 Jan 1970 00:00:00 UTC
< transfer-encoding: chunked
< connection: keep-alive
<
{"code":424,"message":"Batch inference failed","properties":{},"content":{"keys":[],"values":[]},"cancelled":false}
```

After:
```
timestamp: 1729803208359
input: {"inputs": "list all the names which start with the letter r","parameters":{"max_new_tokens":10,"seed":2,"do_sample":true}}
output: > POST //invocations HTTP/1.1
>
> Accept: */*
> User-Agent: awscurl/1.0.0
> Host: 127.0.0.1:8094
> Content-Type: application/json
>
< HTTP/1.1 424 OK
<
< Content-Type: application/json
< requestId: 29dd9a28-9520-4c98-9043-572b456db579
< x-request-id: 29dd9a28-9520-4c98-9043-572b456db579
< Pragma: no-cache
< Cache-Control: no-cache; no-store, must-revalidate, private
< Expires: Thu, 01 Jan 1970 00:00:00 UTC
< transfer-encoding: chunked
< connection: keep-alive
<
{"code":424,"message":"Batch inference failed","properties":{},"content":{"keys":[],"values":[]},"cancelled":false}
```