### PR TITLE
[fix] Propagate RollingBatch predict output code to request outputs (…

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/RollingBatch.java
@@ -174,6 +174,11 @@ class RollingBatch implements Runnable {
                     BytesSupplier err = BytesSupplier.wrap(JsonUtils.GSON.toJson(out));
                     for (Request req : list) {
                         req.last = true;
+
+                        // Note: This will only change the HTTP response code if the first chunk
+                        // has not yet been sent
+                        req.output.setCode(code);
+
                         req.data.appendContent(err, true);
                     }
                     list.clear();


### PR DESCRIPTION
…#2490)

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
