### PR TITLE
[lmi][v12][docs] update lmi documentation for v12

### DIFF
--- a/serving/docs/configurations_model.md
+++ b/serving/docs/configurations_model.md
@@ -177,7 +177,8 @@ To enable rolling batch for Python engine:
 
 ```
 # lmi-dist requires running mpi mode
-engine=MPI
+engine=Python
+option.mpi_mode=true
 option.rolling_batch=auto
 # use FlashAttention
 #option.rolling_batch=lmi-dist

--- a/serving/docs/lmi/README.md
+++ b/serving/docs/lmi/README.md
@@ -25,11 +25,12 @@ LMI containers provide many features, including:
 * Multi GPU inference using Tensor Parallelism
 * Serving LoRA fine-tuned models
 * Text Embedding to convert text data into numerical vectors 
+* Speculative Decoding support to decrease latency
 
 LMI containers provide these features through integrations with popular inference libraries.
 A unified configuration format enables users to easily leverage the latest optimizations and technologies across libraries.
 We will refer to each of these libraries as `backends` throughout the documentation. 
-The term backend refers to a combination of Engine (LMI uses the Python and MPI Engines) and inference library.
+The term backend refers to a combination of Engine (LMI uses the Python Engine) and inference library.
 You can learn more about the components of LMI [here](deployment_guide/README.md#components-of-lmi).
 
 ## QuickStart
@@ -47,7 +48,7 @@ It also provides sample code to deploy your model using LMI on SageMaker.
 
 ### Advanced Deployment Guide
 
-We have put together a comprehensive [deployment guide](deployment_guide/README.md) that takes you through the steps needed to deploy a model using LMI containers on SageMaker.
+The [advanced deployment guide](deployment_guide/README.md) takes you through the steps needed to deploy a model using LMI containers on SageMaker.
 The document covers the phases from storing your model artifacts through benchmarking your SageMaker endpoint.
 It is intended for users moving towards deploying LLMs in production settings.
 
@@ -73,9 +74,9 @@ This information is also available on the SageMaker DLC [GitHub repository](http
 
 | Backend                | SageMakerDLC    | Example URI                                                                               |
 |------------------------|-----------------|-------------------------------------------------------------------------------------------|
-| `vLLM`                 | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.29.0-lmi11.0.0-cu124         |
-| `lmi-dist`             | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.29.0-lmi11.0.0-cu124         |
-| `hf-accelerate`        | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.29.0-lmi11.0.0-cu124         |
+| `vLLM`                 | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.30.0-lmi12.0.0-cu124         |
+| `lmi-dist`             | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.30.0-lmi12.0.0-cu124         |
+| `hf-accelerate`        | djl-lmi         | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.30.0-lmi12.0.0-cu124         |
 | `tensorrt-llm`         | djl-tensorrtllm | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.29.0-tensorrtllm0.11.0-cu124 |
 | `transformers-neuronx` | djl-neuronx     | 763104351884.dkr.ecr.us-east-1.amazonaws.com/djl-inference:0.29.0-neuronx-sdk2.19.1       |
 

--- a/serving/docs/lmi/announcements/breaking_changes.md
+++ b/serving/docs/lmi/announcements/breaking_changes.md
@@ -9,7 +9,7 @@ This document details breaking changes for LMI container version releases.
 #### Summary
 Starting in LMI v12 (0.30.0), the default behavior for `option.max_rolling_batch_prefill_tokens` when using the lmi-dist 
 rolling-batch backend has changed.
-This configuration maps to vLLM's `max_num_batched_tokens` configuration.
+This configuration maps to vLLM's `max_num_batched_tokens` configuration, and will be updated to match this name in a future version.
 In previous versions (v11 and earlier), this value would default to 4096 tokens.
 Starting in v12, the default behavior for lmi-dist will rely on vLLM's default behavior.
 vLLM's default behavior is described [here](https://github.com/vllm-project/vllm/blob/9cc373f39036af789fb1ffc1e06b23766996d3f4/vllm/config.py#L959C9-L988).
@@ -29,19 +29,24 @@ This change means that if `option.max_rolling_batch_prefill_tokens` is not speci
 with v11 and earlier may start failing in v12 due to higher memory requirements during model loading and warmup 
 for models with greater than a supported sequence length greater than 4096 tokens.
 
+In v12, the default behavior is to allocate enough memory to store the KV-cache for `option.max_model_len` tokens.
+For models with large context lengths (or any context length above 4096 tokens), more memory will be required by default
+during model load and startup time. As a result, some previous configurations when deployed with v12 will require
+additional memory by default, which can lead to failures at startup.
+
 #### Guidance
 As a result of this change, we recommend you take the following actions:
 
-* Enable chunked-prefill. You can do this by setting `option.enable_chunked_prefill=true`.
+* Enable chunked-prefill. You can do this by setting `option.enable_chunked_prefill=true`. 
   * You can learn more about chunked prefill here https://docs.vllm.ai/en/latest/models/performance.html#chunked-prefill.
   * We expect that chunked prefill will be beneficial for most users and use-cases. But, you should confirm this for your specific use-case.
   * With chunked-prefill, the default value for `option.max_rolling_batch_prefill_tokens` is 512, which is set to optimize inter token latency (ITL).
   * Starting in LMI v12 (0.30.0), the default value for `option.enable_chunked_prefill` is `None` rather than `False`. This brings LMI default
-    in line with OSS vllm default, which results in chunked prefill being enabled by default for Llama-3.1 models (when not using speculative
-    decoding), but disabled by default for most other models. The actual rule is that it is enabled by default only for models with very large
-    `max_model_len`, when not using speculative decoding.
-* Tune `option.max_rolling_batch_prefill_tokens` and/or `option.max_model_len` based on available accelerator memory (instance type), use-case, and model. 
+    in line with OSS vllm default, which results in chunked prefill being enabled by default for models with a context length greater than 32k.
+  * The default logic in vLLM is described [here](https://github.com/vllm-project/vllm/blob/9cc373f39036af789fb1ffc1e06b23766996d3f4/vllm/config.py#L959C9-L988).
+* Tune `option.max_rolling_batch_prefill_tokens` and `option.max_model_len` based on available accelerator memory (instance type), use-case, and model. 
   * `option.max_model_len` should be set to the maximum input + output token count you expect to support at inference time.
+    * If you are unable to use a certain `option.max_model_len` for a model on an instance, you will need to reduce this value, use an instance type with more gpu memory, or explore techniques like quantization to reduce the memory required for the model.
   * `option.max_rolling_batch_prefill_tokens` depends on whether you use chunked prefill.
     * With chunked prefill, you can typically expect higher throughput with larger values, and better latency with lower values.
     * Without chunked prefill, you should set this to the maximum input length you aim to support.

--- a/serving/docs/lmi/conceptual_guide/lmi_engine.md
+++ b/serving/docs/lmi/conceptual_guide/lmi_engine.md
@@ -5,12 +5,13 @@ In LMI, we offer two different running modes to operate the backend engine:
 - Distributed Environment (MPI): Used to operate on single machine multi-gpu or multiple machines multi-gpu use cases
 - Standard Python process (Python): Start a standalone python process to run the engine
 
-Depends on the engine architecture, settings and use case you are pursuing into, you can choose one of the options to run with LMI.
-Here we are providing the common Engine selection for different backends we offer:
+You specify this operating mode through the `option.mpi_mode=<true|false>` configuration.
+
+The operating modes for the built-in inference engines are described below.
 
 - TensorRT-LLM (MPI): Use multiple MPI processes to run the backends
 - LMI-Dist (MPI): Launching using multiple MPI processes to control for different GPUs
-- vLLM (Python): vLLM internally will use Ray to spin up multiple processes, so managed at vLLM layer
+- vLLM (Python): vLLM internally will use Ray to spin up multiple processes
 - HuggingFace Accelerate (Python): HF Accelerate internally managed the process workflow
 - TransformerNeuronX (Python): The Neuron backend engine, internally it will use multi-threading to run with Neuron cores.
 
@@ -20,10 +21,10 @@ In the next section, we will introduce a detailed breakdown on how we run those 
 
 ![python image](../imgs/python_mode.jpg)
 
-DJLServing could operate with our Python Engine. In Python operating mode, we will spin up a python process
-from the system environment and allocate Accelerators (GPU/Neuron) for each processes through `CUDA_VISIBLE_DEVICES`. During auto-scaling mode,
-DJLServing could manage workers' Accelerators allocation and spin up process with different Accelerators (GPU/Neuron).
-Under python Engine mode, DJLServing will establish socket connection and talk to the python process.
+In Python operating mode, LMI launches Python processes based on scanning
+the system environment and number of Accelerators (GPU/Neuron) for each process through `CUDA_VISIBLE_DEVICES`. During auto-scaling mode,
+LMI manages Accelerators allocation and spins up processes with different Accelerators (GPU/Neuron).
+Under python Engine mode, LMI will establish socket connection and talk to the python process.
 
 ### Enablement
 
@@ -33,9 +34,15 @@ serving.properties
 
 ```
 engine=Python
+option.mpi_mode=false
 ```
 
-Environment variable (no need to set)
+Environment variables
+
+```
+OPTION_ENGINE=Python
+OPTION_MPI_MODE=false
+```
 
 We use python mode by default as long as you specify `option.model_id`.
 
@@ -44,14 +51,14 @@ We use python mode by default as long as you specify `option.model_id`.
 ![mpi image](../imgs/mpi_mode.jpg)
 
 MPI in general means "Multi-Process-Interface". In LMI domain, you could also read as "Multi-Process-Inference".
-DJLServing internally will use `mpirun` to spin up multiple processes depends on the setup.
-The number of process for LLM applications following `tensor_parallel_degree`. 
-To operate in this model, DJLServing established multiple socket connects to each process for communication and health check.
-During each operation call (e.g. inference), DJLServing will send the same request to each process. At response back time, 
-DJLServing will just receive 1 result from rank 0 of the total processes.
+DJLServing internally uses `mpirun` to spin up multiple processes depends on the setup.
+The number of processes for LLM applications follows the `tensor_parallel_degree` configuration. 
+LMI establishes multiple socket connects to each process for communication and health check.
+During each operation call (e.g. inference), LMI will send the same request to each process. At response back time, 
+LMI will just receive 1 result from rank 0 of the total processes.
 
-MPI model also works well with DJLServing auto-scaling feature, user could specify multiple workers using different GPUs.
-DJLServing could spin up the corresponding copies in MPI environment.
+MPI model also works well with LMI auto-scaling feature, user could specify multiple workers using different GPUs.
+LMI will spin up the corresponding copies in MPI environment.
 
 ### Enablement
 
@@ -60,12 +67,14 @@ You can use the following ways to enable MPI Engine:
 serving.properties
 
 ```
-engine=MPI
+engine=Python
+option.mpi_mode=true
 ```
 
 Environment variable
 
 ```
+OPTION_ENGINE=Python
 OPTION_MPI_MODE=true
 ```
 

--- a/serving/docs/lmi/tutorials/seq_scheduler_tutorial.md
+++ b/serving/docs/lmi/tutorials/seq_scheduler_tutorial.md
@@ -11,7 +11,8 @@ used as an example.
 ```
 # serving.properties
 
-engine=MPI
+engine=Python
+option.mpi_mode=true
 option.model_id=/workspace/llama-2-70b-hf/
 option.tensor_parallel_degree=1
 option.dtype=fp16

--- a/serving/docs/lmi/tutorials/trtllm_manual_convert_tutorial.md
+++ b/serving/docs/lmi/tutorials/trtllm_manual_convert_tutorial.md
@@ -262,7 +262,8 @@ OPTION_MAX_ROLLING_BATCH_SIZE=64
 ### 2. `serving.properties`:
 
 ```
-engine=MPI
+engine=Python
+option.mpi_mode=true
 option.model_id=s3://lmi-llm/trtllm/0.5.0/baichuan-13b-tp2/
 option.tensor_parallel_degree=2
 option.max_rolling_batch_size=64
@@ -272,7 +273,8 @@ option.max_rolling_batch_size=64
 
 `serving.properties`:
 ```
-engine=MPI
+engine=Python
+option.mpi_mode=true
 option.rolling_batch=trtllm
 option.dtype=fp16
 option.tensor_parallel_degree=2

--- a/serving/docs/lmi/user_guides/chat_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/chat_input_output_schema.md
@@ -1,7 +1,7 @@
 # Chat Completions API Schema
 
 This document describes the API schema for the chat completions endpoints (`v1/chat/completions`) when using the built-in inference handlers in LMI containers.
-This schema is applicable to our latest release, v0.29.0, and is compatible with [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create).
+This schema is applicable to our latest release, v0.30.0, and is compatible with [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create).
 Documentation for previous releases is available on our GitHub on the relevant version branch (e.g. 0.28.0-dlc).
 
 On SageMaker, Chat Completions API schema is supported with the `/invocations` endpoint without additional configurations.
@@ -102,7 +102,7 @@ Example response:
 
 Chat Completions API supports streaming, and the response format for streaming differs from the response format for non-streaming.
 
-To use streaming, set `"stream": true`, or `option.output_formatter=jsonlines`.
+To use streaming, set `"stream": true`.
 
 The response is returned token by token as application/jsonlines content-type:
 
@@ -169,6 +169,8 @@ Example:
     ]
 }
 ```
+
+We recommend that you use the base64 encoding to ensure no network failures occur when retrieving the image within the endpoint.
 
 ### Choice
 

--- a/serving/docs/lmi/user_guides/hf_accelerate.md
+++ b/serving/docs/lmi/user_guides/hf_accelerate.md
@@ -1,5 +1,8 @@
 # HuggingFace Accelerate User Guide
 
+**Note: HuggingFace Accelerate support is currently in maintenance mode. New feature development and optimizations for 
+the HuggingFace Accelerate backend are not currently planned.**
+
 The HuggingFace Accelerate backend is only recommended when the model you are deploying is not supported by the other backends.
 It is typically less performant than the other available options.
 You should confirm that your model is not supported by other backends before using HuggingFace Accelerate.

--- a/serving/docs/lmi/user_guides/lmi-dist_user_guide.md
+++ b/serving/docs/lmi/user_guides/lmi-dist_user_guide.md
@@ -12,7 +12,7 @@ The model architecture that we test for lmi-dist (in CI):
 - Falcon
 - Gemma
 - GPT-NeoX
-- Llama (un-quantized and with GPTQ)
+- Llama3.1 (un-quantized and with GPTQ)
 - Mistral (un-quantized and with AWQ)
 - Mixtral
 - MPT
@@ -22,61 +22,18 @@ The model architecture that we test for lmi-dist (in CI):
 - T5
 - LlaVA-NeXT
 - Phi-3-Vision
-- PaliGemma
+- Pixtral
 
 
 ### Complete Model Set
 
-Text Generation Models
+LMI Dist supports the same set of models as vLLM. For LMI v12, we use vLLM 0.6.2. The set of supported models
+for vLLM 0.6.2 can be found [here](https://docs.vllm.ai/en/v0.6.2/models/supported_models.html).
 
-- Aquila & Aquila2 (`BAAI/AquilaChat2-7B`, `BAAI/AquilaChat2-34B`, `BAAI/Aquila-7B`, `BAAI/AquilaChat-7B`, etc.)
-- Arctic (`Snowflake/snowflake-arctic-base`, `Snowflake/snowflake-arctic-instruct`, etc.)
-- Baichuan & Baichuan2 (`baichuan-inc/Baichuan2-13B-Chat`, `baichuan-inc/Baichuan-7B`, etc.)
-- BLOOM (`bigscience/bloom`, `bigscience/bloomz`, etc.)
-- ChatGLM (`THUDM/chatglm2-6b`, `THUDM/chatglm3-6b`, etc.)
-- Command-R (`CohereForAI/c4ai-command-r-v01`, etc.)
-- DBRX (`databricks/dbrx-base`, `databricks/dbrx-instruct` etc.)
-- DeciLM (`Deci/DeciLM-7B`, `Deci/DeciLM-7B-instruct`, etc.)
-- Falcon & Falcon2 (`tiiuae/falcon-7b`, `tiiuae/falcon-11b`, `tiiuae/falcon-40b`, `tiiuae/falcon-rw-7b`, etc.)
-- Gemma (`google/gemma-2b`, `google/gemma-7b`, etc.)
-- Gemma2 (`google/gemma-2-9b`, `google/gemma-2-27b`, etc.)
-- GPT-2 (`gpt2`, `gpt2-xl`, etc.)
-- GPT BigCode (`bigcode/starcoder`, `bigcode/gpt_bigcode-santacoder`, etc.)
-- GPT-J (`EleutherAI/gpt-j-6b`, `nomic-ai/gpt4all-j`, etc.)
-- GPT-NeoX (`EleutherAI/gpt-neox-20b`, `databricks/dolly-v2-12b`, `stabilityai/stablelm-tuned-alpha-7b`, etc.)
-- InternLM (`internlm/internlm-7b`, `internlm/internlm-chat-7b`, etc.)
-- InternLM2 (`internlm/internlm2-7b`, `internlm/internlm2-chat-7b`, etc.)
-- Jais (`core42/jais-13b`, `core42/jais-13b-chat`, `core42/jais-30b-v3`, `core42/jais-30b-chat-v3`, etc.)
-- Jamba (`ai21labs/Jamba-v0.1`, etc.)
-- LLaMA, Llama 2, Llama 3, Llama 3.1 (`meta-llama/Meta-Llama-3.1-405B-Instruct`, `meta-llama/Meta-Llama-3.1-70B`, `meta-llama/Meta-Llama-3-70B-Instruct`, `meta-llama/Llama-2-70b-hf`, `01-ai/Yi-34B`, etc.)
-- MiniCPM (`openbmb/MiniCPM-2B-sft-bf16`, `openbmb/MiniCPM-2B-dpo-bf16`, etc.)
-- Mistral (`mistralai/Mistral-7B-v0.1`, `mistralai/Mistral-7B-Instruct-v0.1`, etc.)
-- Mixtral (`mistralai/Mixtral-8x7B-v0.1`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `mistral-community/Mixtral-8x22B-v0.1`, etc.)
-- MPT (`mosaicml/mpt-7b`, `mosaicml/mpt-30b`, etc.)
-- OLMo (`allenai/OLMo-1B-hf`, `allenai/OLMo-7B-hf`, etc.)
-- OPT (`facebook/opt-66b`, `facebook/opt-iml-max-30b`, etc.)
-- Orion (`OrionStarAI/Orion-14B-Base`, `OrionStarAI/Orion-14B-Chat`, etc.)
-- Phi (`microsoft/phi-1_5`, `microsoft/phi-2`, etc.)
-- Phi-3 (`microsoft/Phi-3-mini-4k-instruct`, `microsoft/Phi-3-mini-128k-instruct`, etc.)
-- Qwen (`Qwen/Qwen-7B`, `Qwen/Qwen-7B-Chat`, etc.)
-- Qwen2 (`Qwen/Qwen1.5-7B`, `Qwen/Qwen1.5-7B-Chat`, etc.)
-- Qwen2MoE (`Qwen/Qwen1.5-MoE-A2.7B`, `Qwen/Qwen1.5-MoE-A2.7B-Chat`, etc.)
-- StableLM(`stabilityai/stablelm-3b-4e1t`, `stabilityai/stablelm-base-alpha-7b-v2`, etc.)
-- Starcoder2(`bigcode/starcoder2-3b`, `bigcode/starcoder2-7b`, `bigcode/starcoder2-15b`, etc.)
-- T5 (`google/flan-t5-xxl`, `google/flan-t5-base`, etc.)
-- Xverse (`xverse/XVERSE-7B-Chat`, `xverse/XVERSE-13B-Chat`, `xverse/XVERSE-65B-Chat`, etc.)
+**Note: MLlama (Llama3.2 multimodal models) are currently not supported in the LMI-Dist backend. 
+You should use the vLLM backend for those models.**
 
-Multi Modal Models
-
-- Chameleon (`facebook/chameleon-7b` etc.)
-- Fuyu (`adept/fuyu-8b` etc.)
-- LlaVA-1.5 (`llava-hf/llava-1.5-7b-hf`, `llava-hf/llava-1.5-13b-hf`, etc.)
-- LlaVA-NeXT (`llava-hf/llava-v1.6-mistral-7b-hf`, `llava-hf/llava-v1.6-vicuna-7b-hf`, etc.)
-- PaliGemma (`google/paligemma-3b-pt-224`, `google/paligemma-3b-mix-224`, etc.)
-- Phi-3-Vision (`microsoft/Phi-3-vision-128k-instruct`, etc.)
-
-We will add more model support for the future versions to have them tested. Please feel free to [file us an issue](https://github.com/deepjavalibrary/djl-serving/issues/new/choose) for more model coverage in CI.
-
+In addition to vLLM's supported models, LMI-Dist also support t5 model architectures like [`flan-t5-xl`](https://huggingface.co/google/flan-t5-xl).
 
 ## Quick Start Configurations
 
@@ -85,7 +42,8 @@ You can leverage `lmi-dist` with LMI using the following starter configurations:
 ### serving.properties
 
 ```
-engine=MPI
+engine=Python
+option.mpi_mode=True
 option.tensor_parallel_degree=max
 option.rolling_batch=lmi-dist
 option.model_id=<your model id>

--- a/serving/docs/lmi/user_guides/starting-guide.md
+++ b/serving/docs/lmi/user_guides/starting-guide.md
@@ -36,8 +36,8 @@ model = DJLModel(
 )
 
 # Deploy your model to a SageMaker Endpoint and create a Predictor to make inference requests
-endpoint_name = sagemaker.utils.name_from_base("llama-7b-endpoint")
-predictor = model.deploy(instance_type="ml.g5.2xlarge", initial_instance_count=1, endpoint_name=endpoint_name)
+endpoint_name = sagemaker.utils.name_from_base("llama-8b-endpoint")
+predictor = model.deploy(instance_type="ml.g5.12xlarge", initial_instance_count=1, endpoint_name=endpoint_name)
 
 # Make an inference request against the llama2-7b endpoint
 outputs = predictor.predict({

--- a/serving/docs/lmi/user_guides/trt_llm_user_guide.md
+++ b/serving/docs/lmi/user_guides/trt_llm_user_guide.md
@@ -37,7 +37,8 @@ You can leverage `tensorrtllm` with LMI using the following starter configuratio
 ### serving.properties
 
 ```
-engine=MPI
+engine=Python
+option.mpi_mode=true
 option.tensor_parallel_degree=max
 option.model_id=<your model id>
 # Adjust the following based on model size and instance type

--- a/serving/docs/lmi/user_guides/vision_language_models.md
+++ b/serving/docs/lmi/user_guides/vision_language_models.md
@@ -1,10 +1,7 @@
 # Vision Language Models in LMI
 
-> [!WARNING]
-> Vision Language Model support is currently experimental in v0.29.0.
-> LMI currently only supports using VLMs with the lmi-dist and vllm backends.
 
-Starting with v0.29.0, LMI supports deploying the following types of Vision Language Models:
+LMI supports deploying the following types of Vision Language Models:
 
 * llava (e.g. llava-hf/llava-1.5-7b-hf)
 * llava_next (e.g. llava-hf/llava-v1.6-mistral-7b-hf)
@@ -12,6 +9,8 @@ Starting with v0.29.0, LMI supports deploying the following types of Vision Lang
 * paligemma (e.g. google/paligemma-3b-mix-224)
 * chameleon (facebook/chameleon-7b etc.)
 * fuyu (adept/fuyu-8b etc.)
+* pixtral (mistralai/Pixtral-12B-2409)
+* mLlama (meta-llama/Llama-3.2-11B-Vision-Instruct)
 
 ## Request Format
 

--- a/serving/docs/lmi/user_guides/vllm_user_guide.md
+++ b/serving/docs/lmi/user_guides/vllm_user_guide.md
@@ -6,77 +6,40 @@ vLLM expects the model artifacts to be in the [standard HuggingFace format](../d
 
 ## Supported Model architecture
 
-LMI is shipping vLLM 0.4.2 with 0.28.0 containers, 
-so technically we support all LLM that [vLLM 0.4.2 support](https://github.com/vllm-project/vllm/tree/v0.4.2?tab=readme-ov-file#about).
+LMI is shipping vLLM 0.6.2 with 0.30.0 containers, 
+so technically we support all LLM that [vLLM 0.6.2 support](https://github.com/vllm-project/vllm/tree/v0.6.2?tab=readme-ov-file#about).
 
 The model architecture that we carefully tested for vLLM (in CI):
 
+- DBRX
 - Falcon
 - Gemma
 - GPT-NeoX
-- LLAMA
-- LLAMA with AWQ
-- Mistral
+- Llama3.1 (un-quantized and with GPTQ)
+- Mistral (un-quantized and with AWQ)
 - Mixtral
+- MPT
+- Octocoder
 - Phi
 - Starcoder
+- T5
+- LlaVA-NeXT
+- Phi-3-Vision
+- Pixtral
 
 ### Complete model set
 
-Text Generation Models
-
-- Aquila & Aquila2 (`BAAI/AquilaChat2-7B`, `BAAI/AquilaChat2-34B`, `BAAI/Aquila-7B`, `BAAI/AquilaChat-7B`, etc.)
-- Arctic (`Snowflake/snowflake-arctic-base`, `Snowflake/snowflake-arctic-instruct`, etc.)
-- Baichuan & Baichuan2 (`baichuan-inc/Baichuan2-13B-Chat`, `baichuan-inc/Baichuan-7B`, etc.)
-- BLOOM (`bigscience/bloom`, `bigscience/bloomz`, etc.)
-- ChatGLM (`THUDM/chatglm2-6b`, `THUDM/chatglm3-6b`, etc.)
-- Command-R (`CohereForAI/c4ai-command-r-v01`, etc.)
-- DBRX (`databricks/dbrx-base`, `databricks/dbrx-instruct` etc.)
-- DeciLM (`Deci/DeciLM-7B`, `Deci/DeciLM-7B-instruct`, etc.)
-- Falcon & Falcon2 (`tiiuae/falcon-7b`, `tiiuae/falcon-11b`, `tiiuae/falcon-40b`, `tiiuae/falcon-rw-7b`, etc.)
-- Gemma (`google/gemma-2b`, `google/gemma-7b`, etc.)
-- Gemma2 (`google/gemma-2-9b`, `google/gemma-2-27b`, etc.)
-- GPT-2 (`gpt2`, `gpt2-xl`, etc.)
-- GPT BigCode (`bigcode/starcoder`, `bigcode/gpt_bigcode-santacoder`, etc.)
-- GPT-J (`EleutherAI/gpt-j-6b`, `nomic-ai/gpt4all-j`, etc.)
-- GPT-NeoX (`EleutherAI/gpt-neox-20b`, `databricks/dolly-v2-12b`, `stabilityai/stablelm-tuned-alpha-7b`, etc.)
-- InternLM (`internlm/internlm-7b`, `internlm/internlm-chat-7b`, etc.)
-- InternLM2 (`internlm/internlm2-7b`, `internlm/internlm2-chat-7b`, etc.)
-- Jais (`core42/jais-13b`, `core42/jais-13b-chat`, `core42/jais-30b-v3`, `core42/jais-30b-chat-v3`, etc.)
-- Jamba (`ai21labs/Jamba-v0.1`, etc.)
-- LLaMA, Llama 2, Llama 3, Llama 3.1 (`meta-llama/Meta-Llama-3.1-405B-Instruct`, `meta-llama/Meta-Llama-3.1-70B`, `meta-llama/Meta-Llama-3-70B-Instruct`, `meta-llama/Llama-2-70b-hf`, `01-ai/Yi-34B`, etc.)
-- MiniCPM (`openbmb/MiniCPM-2B-sft-bf16`, `openbmb/MiniCPM-2B-dpo-bf16`, etc.)
-- Mistral (`mistralai/Mistral-7B-v0.1`, `mistralai/Mistral-7B-Instruct-v0.1`, etc.)
-- Mixtral (`mistralai/Mixtral-8x7B-v0.1`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `mistral-community/Mixtral-8x22B-v0.1`, etc.)
-- MPT (`mosaicml/mpt-7b`, `mosaicml/mpt-30b`, etc.)
-- OLMo (`allenai/OLMo-1B-hf`, `allenai/OLMo-7B-hf`, etc.)
-- OPT (`facebook/opt-66b`, `facebook/opt-iml-max-30b`, etc.)
-- Orion (`OrionStarAI/Orion-14B-Base`, `OrionStarAI/Orion-14B-Chat`, etc.)
-- Phi (`microsoft/phi-1_5`, `microsoft/phi-2`, etc.)
-- Phi-3 (`microsoft/Phi-3-mini-4k-instruct`, `microsoft/Phi-3-mini-128k-instruct`, etc.)
-- Qwen (`Qwen/Qwen-7B`, `Qwen/Qwen-7B-Chat`, etc.)
-- Qwen2 (`Qwen/Qwen1.5-7B`, `Qwen/Qwen1.5-7B-Chat`, etc.)
-- Qwen2MoE (`Qwen/Qwen1.5-MoE-A2.7B`, `Qwen/Qwen1.5-MoE-A2.7B-Chat`, etc.)
-- StableLM(`stabilityai/stablelm-3b-4e1t`, `stabilityai/stablelm-base-alpha-7b-v2`, etc.)
-- Starcoder2(`bigcode/starcoder2-3b`, `bigcode/starcoder2-7b`, `bigcode/starcoder2-15b`, etc.)
-- Xverse (`xverse/XVERSE-7B-Chat`, `xverse/XVERSE-13B-Chat`, `xverse/XVERSE-65B-Chat`, etc.)
-
-Multi Modal Models
-
-- Chameleon (`facebook/chameleon-7b` etc.)
-- Fuyu (`adept/fuyu-8b` etc.)
-- LlaVA-1.5 (`llava-hf/llava-1.5-7b-hf`, `llava-hf/llava-1.5-13b-hf`, etc.)
-- LlaVA-NeXT (`llava-hf/llava-v1.6-mistral-7b-hf`, `llava-hf/llava-v1.6-vicuna-7b-hf`, etc.)
-- PaliGemma (`google/paligemma-3b-pt-224`, `google/paligemma-3b-mix-224`, etc.)
-- Phi-3-Vision (`microsoft/Phi-3-vision-128k-instruct`, etc.)
+The vLLM list of supported models in 0.6.2 can be found [here](https://docs.vllm.ai/en/v0.6.2/models/supported_models.html).
 
 We will add more model support for the future versions to have them tested. Please feel free to [file us an issue](https://github.com/deepjavalibrary/djl-serving/issues/new/choose) for more model coverage in CI.
 
 ### Quantization
 
-Currently, we allow customer to use `option.quantize=awq` or `OPTION_QUANTIZE=awq` to load an AWQ quantized model in VLLM.
+If the model artifacts are pre-quantized, vLLM will be able to detect the quantization technique used and load the model in that format.
 
-We will have GPTQ supported for vLLM in the upcoming version.
+If you want to explicitly set the quantization technique, you can set:
+
+  * `option.quantize=<quant_format>` in serving.properties, or `OPTION_QUANTIZE=<quant_format>` environment variable.
 
 ## Quick Start Configurations 
 


### PR DESCRIPTION
## Description ##

Changes:
- Move all usages of `engine=MPI` to `engine=Python, option.mpi_mode=true`
- updates to the LMI-Dist breaking changes doc
- Removes the hardcoded list of supported models in lmi-dist/vllm in favor of a link to vllm's docs.

This is the first PR related to updating LMI docs for v12. There will be additional PRs that address:
- TensorRT-LLM update
- Neuron update

Additionally, after these release we need to do the following:
- Update the deployment guide with guidance for v12+
- Move configuration usages to either all Environment variables, or all serving.properties. We should still describe that both configuration mechanisms are supported, but there's no need to duplicate these configurations everywhere.
