### PR TITLE
[python] remove huggingface load and save for tnx

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -412,6 +412,7 @@ class TNXModelLoader(ModelLoader):
         """
         Convert model to Neuron compiled format and save
         """
+        logging.info(f"Saving preshareded model to {save_path}...")
         # Neuron compiler serialization workaround
         path = os.getcwd()
         os.chdir("/tmp")
@@ -479,13 +480,9 @@ class TNXModelLoader(ModelLoader):
 
         :param save_path: Path to which to save the compiled model.
         """
-        self.split_model_path = os.path.join(save_path, "checkpoint")
-        os.mkdir(self.split_model_path)
         self.compiled_graph_path = os.path.join(save_path, "compiled")
         os.mkdir(self.compiled_graph_path)
 
-        self.model = self.load_hf_model()
-        self.model.save_pretrained(self.split_model_path)
         self.model = self.load_auto_model(self.config.model_id_or_path)
         self.compile_and_save(self.compiled_graph_path)
 


### PR DESCRIPTION
## Description ##

Before neuron sdk 2.18 version, we need to load the safetensors model using huggingface on CPU and save it a presharded version, then  load the model using NeuronAutoModel. After 2.18 sdk version, it is not needed anymore. 

Link: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/libraries/transformers-neuronx/transformers-neuronx-developer-guide.html#checkpoint-support-and-automatic-model-selection

```
Both regular and sharded variants of checkpoints are supported. It is no longer recommended to use the save_pretrained_split function which was used in older Transformers Neuron examples.
```
In our code, although, we have been loading the safetensors format in cpu and loading them, but `split_model_path` is not used anywhere when using safetensors format.