### PR TITLE
[lora] Set properties for Lora

### DIFF
--- a/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/LmiConfigRecommender.java
@@ -42,7 +42,7 @@ public final class LmiConfigRecommender {
         setTensorParallelDegree(lmiProperties);
         setRollingBatchSize(lmiProperties);
         setIsPeftModel(lmiProperties, modelConfig);
-        setWorkers(lmiProperties);
+        setPropertiesForLora(lmiProperties);
     }
 
     private static void setRollingBatch(
@@ -150,12 +150,17 @@ public final class LmiConfigRecommender {
         }
     }
 
-    private static void setWorkers(Properties lmiProperties) {
-        // If option.enable_lora=true, set maxWorkers to 1 because we only support one worker thread
+    private static void setPropertiesForLora(Properties lmiProperties) {
+        // If option.enable_lora=true, set load_on_devices=0 and maxWorkers=1 because we only
+        // support one worker thread
         // for LoRA.
+        // TODO: Support multiple worker threads for LoRA.
         boolean enableLora = Boolean.parseBoolean(lmiProperties.getProperty("option.enable_lora"));
         if (enableLora) {
-            logger.info("option.enable_lora is set to true, setting maxWorkers to 1");
+            logger.info(
+                    "option.enable_lora is set to true, setting load_on_devices=0 and"
+                            + " maxWorkers=1");
+            lmiProperties.setProperty("load_on_devices", "0");
             lmiProperties.setProperty("maxWorkers", "1");
         }
     }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Set properties load_on_devices=0 for Lora case, in order to make sure vllm rolling batch has one worker as well.

For vllm rollng batch, setting maxWorkers=1 is not enough, multiple workers will still be launched. Because devices is set to [0] for MPI engine, but not for Python engine. See https://github.com/deepjavalibrary/djl-serving/blob/v0.29.0/wlm/src/main/java/ai/djl/serving/wlm/ModelInfo.java#L1011-L1012.

Therefore, for LoRA case, need to set load_on_devices=0 to avoid launching multiple worker threads for vllm rolling batch.