### PR TITLE
[python] add on_device_embedding=True to save and load preshareded weights

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -216,7 +216,7 @@ class TNXModelLoader(ModelLoader):
             neuron_config["cast_logits_dtype"] = self.config.cast_logits_dtype
         if self.config.on_device_embedding:
             neuron_config[
-                "on_device_embedding"] = self.config.on_device_generation
+                "on_device_embedding"] = self.config.on_device_embedding
         if self.config.on_device_generation:
             if len(self.config.on_device_generation.keys()) > 0:
                 neuron_config["on_device_generation"] = NeuronGenerationConfig(
@@ -354,17 +354,14 @@ class TNXModelLoader(ModelLoader):
         """
         if "neuron" in self.model_config.to_dict(
         ) and not self.safetensors_format:
-            self.split_model_path = os.path.join(self.get_load_path(),
-                                                 "checkpoint")
             self.compiled_graph_path = os.path.join(self.get_load_path(),
                                                     "compiled")
-            if self.is_safetensors(self.split_model_path):
-                self.model = self.load_auto_model(self.split_model_path)
+            if self.is_safetensors(self.compiled_graph_path):
+                self.model = self.load_auto_model(self.compiled_graph_path)
                 self.load_path = self.get_load_path()
             else:
-                # Load legacy split model optimum format
                 self.config.load_split_model = True
-                self.load_path = self.split_model_path
+                self.load_path = self.compiled_graph_path
                 self.model = self.load_inf2_model_from_disk()
         elif self.config.load_split_model:
             self.load_path = self.config.model_id_or_path

--- a/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
@@ -50,7 +50,8 @@ class NeuronSmartDefaultUtils:
         self.model_size_in_gb = model_size_in_gb
         self.sequence_size_in_gb = sequence_size_in_gb
 
-    def apply_smart_defaults(self, properties: Dict[str, Any],
+    def apply_smart_defaults(self,
+                             properties: Dict[str, Any],
                              model_config: Dict[str, Any],
                              is_partition: bool = False) -> None:
         """

--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -316,3 +316,9 @@ class TransformerNeuronXProperties(Properties):
                 )
         else:
             raise on_device_generation_value
+
+    @model_validator(mode='after')
+    def set_on_device_embedding(self):
+        if self.load_split_model:
+            self.on_device_embedding = True
+        return self

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -145,7 +145,9 @@ class TransformersNeuronXService(object):
                     f"VllmModelLoader does not support this config: {self.config}"
                 )
 
-    def set_configs(self, properties: dict, is_partition: bool = False) -> None:
+    def set_configs(self,
+                    properties: dict,
+                    is_partition: bool = False) -> None:
         """
         Sets the model configuration properties and performs necessary setup for model loading.
 

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -145,12 +145,14 @@ class TransformersNeuronXService(object):
                     f"VllmModelLoader does not support this config: {self.config}"
                 )
 
-    def set_configs(self, properties: dict) -> None:
+    def set_configs(self, properties: dict, is_partition: bool = False) -> None:
         """
         Sets the model configuration properties and performs necessary setup for model loading.
 
         Args:
             properties (dict): A dictionary containing model configuration properties.
+            is_partition (bool): indicates whether we are saving pre-sharded checkpoints or not.
+                                 We set some smart defaults for it.
 
         Returns:
             None
@@ -162,7 +164,8 @@ class TransformersNeuronXService(object):
 
         utils = NeuronSmartDefaultUtils()
         utils.apply_smart_defaults(properties,
-                                   copy.deepcopy(self.model_config.__dict__))
+                                   copy.deepcopy(self.model_config.__dict__),
+                                   is_partition=is_partition)
 
         self.config = TransformerNeuronXProperties(**properties)
         if self.config.rolling_batch != "disable":
@@ -385,7 +388,7 @@ class TransformersNeuronXService(object):
             None
         """
         self.pre_model_load(properties)
-        self.set_configs(properties)
+        self.set_configs(properties, is_partition=True)
         self.set_tokenizer()
         self.set_model_loader()
         self.model = self.model_loader.partition(


### PR DESCRIPTION
## Description ##

> The saving and loading of presharded weights is only available when on_device_embedding is true.

https://awsdocs-neuron.readthedocs-hosted.com/en/latest/libraries/transformers-neuronx/transformers-neuronx-developer-guide.html#serialization-support

Since neuron 2.20 artifacts, we need to enable on_device_embedding for pre-sharded weights. So enabling this smart default, so our UX compatibility would not break. This should also fix the neo neuron CI failures https://github.com/deepjavalibrary/lmi-distro/actions/runs/11484522981/job/31962540314

