### PR TITLE
[fix] Fix workflow close order

### DIFF
--- a/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
+++ b/serving/src/main/java/ai/djl/serving/workflow/Workflow.java
@@ -227,11 +227,11 @@ public class Workflow implements AutoCloseable {
     /** {@inheritDoc} */
     @Override
     public void close() {
-        for (WorkerPoolConfig<Input, Output> wpc : getWpcs()) {
-            wpc.close();
-        }
         for (WorkflowFunction f : funcs.values()) {
             f.close();
+        }
+        for (WorkerPoolConfig<Input, Output> wpc : getWpcs()) {
+            wpc.close();
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix workflow close order

Right now we close WorkerPoolConfig first, then close WorkflowFunction.

But WorkflowFunction like AdapterWorkflowFunction is dependent on WorkerPoolConfig, see https://github.com/deepjavalibrary/djl-serving/blob/master/serving/src/main/java/ai/djl/serving/workflow/function/AdapterWorkflowFunction.java#L104-L105

If WorkerPoolConfig close first, the dependent adapters can't be closed properly.