### PR TITLE
[docker] Use lmi-dist 13.0.0 nightly wheel

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -36,8 +36,7 @@ ARG vllm_wheel="https://publish.djl.ai/vllm/cu124-pt240/vllm-0.6.2%2Bcu124-cp310
 ARG flash_attn_2_wheel="https://github.com/vllm-project/flash-attention/releases/download/v2.6.1/vllm_flash_attn-2.6.1-cp310-cp310-manylinux1_x86_64.whl"
 ARG flash_infer_wheel="https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu124torch2.4-cp310-cp310-linux_x86_64.whl"
 # %2B is the url escape for the '+' character
-# TODO: update this back to nightly wheel once required deps have been updated
-ARG lmi_dist_wheel="https://publish.djl.ai/lmi_dist/lmi_dist-12.0.0-py3-none-any.whl"
+ARG lmi_dist_wheel="https://publish.djl.ai/lmi_dist/lmi_dist-13.0.0%2Bnightly-py3-none-any.whl"
 ARG seq_scheduler_wheel="https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl"
 ARG peft_version=0.13.2
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
