### PR TITLE
[python] remove legacy partition for neuron

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/model_loader.py
+++ b/engines/python/setup/djl_python/neuron_utils/model_loader.py
@@ -127,7 +127,6 @@ class TNXModelLoader(ModelLoader):
         super().__init__(*args, **kwargs)
         self.model = None
         self.load_path = None
-        self.split_model_path = None
         self.compiled_graph_path = None
         self.neuron_config = None
         self.generation_config = None
@@ -314,11 +313,6 @@ class TNXModelLoader(ModelLoader):
         return self._neuronx_class.from_pretrained(
             self.load_path, neuron_config=self.neuron_config, **model_kwargs)
 
-    def save_split_model(self):
-        logging.info(
-            f"Saving INF2 model to {self.split_model_path} as split model...")
-        save_pretrained_split(self.model, self.split_model_path)
-
     @staticmethod
     def is_safetensors(path):
         return any(
@@ -449,28 +443,6 @@ class TNXModelLoader(ModelLoader):
         self.update_model_config_to_neuron()
         return self.model
 
-    def legacy_partition(self, save_path: str):
-        """
-        Splits the NeuronX model and additionally saves the compiled model.
-
-        :param save_path: Path to which to save the compiled model.
-        """
-
-        self.split_model_path = os.path.join(save_path, "checkpoint")
-        os.mkdir(self.split_model_path)
-        self.compiled_graph_path = os.path.join(save_path, "compiled")
-        os.mkdir(self.compiled_graph_path)
-
-        self.update_model_config_to_neuron()
-        self.model_config.save_pretrained(self.split_model_path)
-        self.model = self.load_hf_model()
-        self.save_split_model()
-        self.config.load_split_model = True
-        self.load_path = self.split_model_path
-
-        self.model = self.load_inf2_model_from_disk()
-        self.compile_and_save(self.compiled_graph_path)
-
     def safetensors_partition(self, save_path: str):
         """
         Saves the model weights as safetensors, updates config to neuron, and adds compiled artifacts.
@@ -504,12 +476,7 @@ class TNXModelLoader(ModelLoader):
                 shutil.rmtree(save_path)
             os.mkdir(save_path)
 
-        if model_schema == TnXModelSchema.legacy:
-            logging.info(
-                "Partitioning model to split model with compiled artifacts schema..."
-            )
-            self.legacy_partition(save_path)
-        elif model_schema == TnXModelSchema.compile_only:
+        if model_schema == TnXModelSchema.compile_only:
             logging.info("Compiling model artifacts only...")
             self.model = self.load_auto_model(self.config.model_id_or_path)
             self.compile_and_save(save_path)

--- a/engines/python/setup/djl_python/properties_manager/tnx_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/tnx_properties.py
@@ -59,7 +59,6 @@ class TnXModelLoaders(str, Enum):
 
 
 class TnXModelSchema(str, Enum):
-    legacy = "legacy"
     optimum = "optimum"
     safetensors = "safetensors"
     compile_only = "compile_only"

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -141,7 +141,7 @@ class TestConfigManager(unittest.TestCase):
             "enable_saturate_infinity": "true",
             "rolling_batch_strategy": "continuous_batching",
             "collectives_layout": "HSB",
-            "partition_schema": "legacy",
+            "partition_schema": "safetensors",
             "attention_layout": "HSB",
             "cache_layout": "SBH",
             "all_reduce_dtype": "float32",
@@ -196,7 +196,8 @@ class TestConfigManager(unittest.TestCase):
                          TnXGenerationStrategy.continuous_batching)
         self.assertEqual(tnx_configs.collectives_layout,
                          TnXMemoryLayout.LAYOUT_HSB)
-        self.assertEqual(tnx_configs.partition_schema, TnXModelSchema.legacy)
+        self.assertEqual(tnx_configs.partition_schema,
+                         TnXModelSchema.safetensors)
         self.assertEqual(tnx_configs.draft_model_compiled_path,
                          properties['draft_model_compiled_path'])
         self.assertEqual(tnx_configs.attention_layout,
@@ -293,7 +294,6 @@ class TestConfigManager(unittest.TestCase):
         'partition_schema': 'optimum',
         'load_split_model': 'true'
     }, {
-        'partition_schema': 'legacy',
         'model_loader': 'optimum'
     }])
     def test_tnx_configs_error_case(self, params):


### PR DESCRIPTION
## Description ##

Legacy partition is, two fold process. First, is to load the model using HF model and then split and save them. Second step is to load the split model and compile and save them. 

This is not needed anymore, from neuron 2.18. We dont need to support these anymore, as we moved to neuron 2.20.