### PR TITLE
[python] enable rolling batch auto as default

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -107,7 +107,8 @@ class Properties(BaseModel):
             if rolling_batch is None:
                 properties['rolling_batch'] = RollingBatchEnum.disable.value
             elif rolling_batch != RollingBatchEnum.disable.value:
-                raise ValueError("You cannot enable rolling batch with dynamic batching. "
-                                 "Disable dynamic batch by setting batch_size to 1 or "
-                                 "remove/disable option.rolling_batch")
+                raise ValueError(
+                    "You cannot enable rolling batch with dynamic batching. "
+                    "Disable dynamic batch by setting batch_size to 1 or "
+                    "remove/disable option.rolling_batch")
         return properties

--- a/engines/python/setup/djl_python/tests/test_properties_manager.py
+++ b/engines/python/setup/djl_python/tests/test_properties_manager.py
@@ -328,6 +328,7 @@ class TestConfigManager(unittest.TestCase):
             "low_cpu_mem_usage": "true",
             "disable_flash_attn": "false",
             "mpi_mode": "true",
+            "batch_size": 2
         }
 
         hf_configs = HuggingFaceProperties(**properties)
@@ -395,7 +396,7 @@ class TestConfigManager(unittest.TestCase):
         hf_configs = HuggingFaceProperties(**properties, rolling_batch="auto")
         self.assertEqual(hf_configs.kwargs.get("device_map"), "auto")
 
-        hf_configs = HuggingFaceProperties(**properties)
+        hf_configs = HuggingFaceProperties(**properties, batch_size=4)
         self.assertIsNone(hf_configs.kwargs.get("device_map"))
 
     def test_hf_quantize(self):
@@ -414,6 +415,10 @@ class TestConfigManager(unittest.TestCase):
     }, {
         "model_id": "model_id",
         "load_in_8bit": "true"
+    }, {
+        "model_id": "model_id",
+        "batch_size": 4,
+        "rolling_batch": "auto"
     }])
     def test_hf_error_case(self, params):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Description ##

LMIConfigRecommender already takes care of enabling rolling batch in all cases, except, when users themselves disable it, or for non-text generation cases. Java front end sends back rolling batch values in most of the cases. 

- Added validation user cannot enable rolling batch and dynamic batch. 
- If user specifies batch size, then we disable the rolling batch. 