### PR TITLE
[python] Add more OOM handling

### DIFF
--- a/engines/python/setup/djl_python_engine.py
+++ b/engines/python/setup/djl_python_engine.py
@@ -166,8 +166,10 @@ class PythonEngine(object):
                         f"Invalid output type: {type(outputs)}")
             except Exception as e:
                 logging.exception("Failed invoke service.invoke_handler()")
-                if type(e).__name__ == "OutOfMemoryError" or type(
-                        e).__name__ == "MemoryError":
+                if (type(e).__name__ == "OutOfMemoryError"
+                        or type(e).__name__ == "MemoryError"
+                        or "No available memory for the cache blocks" in str(e)
+                        or "CUDA error: out of memory" in str(e)):
                     outputs = Output(code=507, message=str(e))
                 else:
                     outputs = Output().error(str(e))


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

During testing, I found 2 cases that should be caught as OOM and send 507 status code.

Currently we only catch exceptions thrown as torch.OutOfMemoryError and MemoryError as OOM. See: https://github.com/deepjavalibrary/djl-serving/blob/master/engines/python/setup/djl_python_engine.py#L169-L171

But the below 2 cases are thrown as ValueError and RuntimeError:

1)

```
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:ERROR::Failed invoke service.invoke_handler()
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python_engine.py", line 161, in run_server
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    outputs = self.service.invoke_handler(function_name, inputs)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/service_loader.py", line 30, in invoke_handler
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    return getattr(self.module, function_name)(inputs)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/huggingface.py", line 624, in handle
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    _service.initialize(inputs.get_properties())
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/huggingface.py", line 132, in initialize
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    self.rolling_batch = _rolling_batch_cls(
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/rolling_batch/lmi_dist_rolling_batch.py", line 105, in __init__
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    self.engine = engine_from_args(engine_args, **kwargs)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 20, in engine_from_args
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    def engine_from_args(engine_args:VllmEngineArgs,debug_args:dict={})->Engine:A=engine_args.create_engine_configs();return _engine_from_config(A,debug_args)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 16, in _engine_from_config
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    else:C=None;D=_create_engine_components_from_config(A)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 10, in _create_engine_components_from_config
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    else:from.vllm_engine import create_vllm_engine_components_from_config as G;return G(A)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/vllm_engine.py", line 141, in create_vllm_engine_components_from_config
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    else:init_cache(H,F,E,B)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/vllm_engine.py", line 125, in init_cache
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    def init_cache(worker,cache_config,scheduler_config,lora_config)->None:A=worker;E=_profile_run(A);B=_get_all_world_rank_values(E);C=min(A[0]for A in B);D=min(A[1]for A in B);logger.info(f"# GPU blocks: {C}, # CPU blocks: {D}");A.initialize_cache(C,D)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/worker/worker.py", line 74, in initialize_cache
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    def initialize_cache(self,*A,**B):return super().initialize_cache(*A,**B)
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 258, in initialize_cache
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    raise_if_cache_size_invalid(num_gpu_blocks,
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 478, in raise_if_cache_size_invalid
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:    raise ValueError("No available memory for the cache blocks. "
INFO  PyProcess W-495-model1-stdout: [1,0]<stdout>:ValueError: No available memory for the cache blocks. Try increasing `gpu_memory_utilization` when initializing the engine.

```
2)

```
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:ERROR::Failed invoke service.invoke_handler()
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python_engine.py", line 161, in run_server
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    outputs = self.service.invoke_handler(function_name, inputs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/service_loader.py", line 30, in invoke_handler
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    return getattr(self.module, function_name)(inputs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/huggingface.py", line 624, in handle
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    _service.initialize(inputs.get_properties())
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/huggingface.py", line 132, in initialize
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    self.rolling_batch = _rolling_batch_cls(
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/rolling_batch/lmi_dist_rolling_batch.py", line 105, in __init__
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    self.engine = engine_from_args(engine_args, **kwargs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 20, in engine_from_args
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    def engine_from_args(engine_args:VllmEngineArgs,debug_args:dict={})->Engine:A=engine_args.create_engine_configs();return _engine_from_config(A,debug_args)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 16, in _engine_from_config
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    else:C=None;D=_create_engine_components_from_config(A)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/init_engine.py", line 10, in _create_engine_components_from_config
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    else:from.vllm_engine import create_vllm_engine_components_from_config as G;return G(A)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/vllm_engine.py", line 141, in create_vllm_engine_components_from_config
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    else:init_cache(H,F,E,B)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/vllm_engine.py", line 125, in init_cache
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    def init_cache(worker,cache_config,scheduler_config,lora_config)->None:A=worker;E=_profile_run(A);B=_get_all_world_rank_values(E);C=min(A[0]for A in B);D=min(A[1]for A in B);logger.info(f"# GPU blocks: {C}, # CPU blocks: {D}");A.initialize_cache(C,D)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/worker/worker.py", line 74, in initialize_cache
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    def initialize_cache(self,*A,**B):return super().initialize_cache(*A,**B)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 266, in initialize_cache
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    self._warm_up_model()
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/lmi_dist/worker/worker.py", line 79, in _warm_up_model
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    with temporary_field_overwrite(self.parallel_config,'pipeline_parallel_size',1):return super()._warm_up_model(*A,**B)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 282, in _warm_up_model
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    self.model_runner.capture_model(self.gpu_cache)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    return func(*args, **kwargs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 1448, in capture_model
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    graph_runner.capture(**capture_inputs)
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 1723, in capture
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    with torch.cuda.graph(self._graph, pool=memory_pool, stream=stream):
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/torch/cuda/graphs.py", line 185, in __exit__
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    self.cuda_graph.capture_end()
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.10/dist-packages/torch/cuda/graphs.py", line 83, in capture_end
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:    super().capture_end()
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:RuntimeError: CUDA error: out of memory
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:For debugging consider passing CUDA_LAUNCH_BLOCKING=1
INFO  PyProcess W-299-model1-stdout: [1,0]<stdout>:Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```
