### PR TITLE
[ci][fix] apply batch size constraint for t5 trt test to prevent fail…

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1005,7 +1005,8 @@ trtllm_handler_list = {
     },
     "flan-t5-xl": {
         "option.model_id": "s3://djl-llm/flan-t5-xl/",
-        "option.dtype": "bf16"
+        "option.dtype": "bf16",
+        "option.max_rolling_batch_size": 128,
     },
     "llama-3-1-8b": {
         "option.model_id": "s3://djl-llm/llama-3.1-8b-hf/",


### PR DESCRIPTION
…ures

## Description ##

Applying the same constraint we did in 0.30.0-dlc branch. Behavior change for t5 we're still working through with nvidia, this ensures passing ci in the interim
