### PR TITLE
[lora] Add load option to LoRA adapter API

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -283,5 +283,5 @@ class LmiDistRollingBatch(RollingBatch):
         # 2) An adapter is not evicted, call add_lora() is not necessary.
         # But since whether an adapter is evicted is not exposed outside of engine,
         # and add_lora() in this case will take negligible time, we will still call add_lora().
-        return self.engine.add_lora(lora_request) and self.engine.pin_lora(
-            lora_request.lora_int_id)
+        loaded = self.engine.add_lora(lora_request)
+        return loaded and self.engine.pin_lora(lora_request.lora_int_id)

--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -283,5 +283,5 @@ class LmiDistRollingBatch(RollingBatch):
         # 2) An adapter is not evicted, call add_lora() is not necessary.
         # But since whether an adapter is evicted is not exposed outside of engine,
         # and add_lora() in this case will take negligible time, we will still call add_lora().
-        self.engine.add_lora(lora_request)
-        return self.engine.pin_lora(lora_request.lora_int_id)
+        return self.engine.add_lora(lora_request) and self.engine.pin_lora(
+            lora_request.lora_int_id)

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -198,5 +198,5 @@ class VLLMRollingBatch(RollingBatch):
         # 2) An adapter is not evicted, call add_lora() is not necessary.
         # But since whether an adapter is evicted is not exposed outside of engine,
         # and add_lora() in this case will take negligible time, we will still call add_lora().
-        self.engine.add_lora(lora_request)
-        return self.engine.pin_lora(lora_request.lora_int_id)
+        return self.engine.add_lora(lora_request) and self.engine.pin_lora(
+            lora_request.lora_int_id)

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -198,5 +198,5 @@ class VLLMRollingBatch(RollingBatch):
         # 2) An adapter is not evicted, call add_lora() is not necessary.
         # But since whether an adapter is evicted is not exposed outside of engine,
         # and add_lora() in this case will take negligible time, we will still call add_lora().
-        return self.engine.add_lora(lora_request) and self.engine.pin_lora(
-            lora_request.lora_int_id)
+        loaded = self.engine.add_lora(lora_request)
+        return loaded and self.engine.pin_lora(lora_request.lora_int_id)

--- a/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/AdapterManagementRequestHandler.java
@@ -168,7 +168,7 @@ public class AdapterManagementRequestHandler extends HttpRequestHandler {
         for (int i = pagination.getPageToken(); i < pagination.getLast(); ++i) {
             String adapterName = keys.get(i);
             Adapter<Input, Output> adapter = modelInfo.getAdapter(adapterName);
-            list.addAdapter(adapter.getName(), adapter.getSrc(), adapter.isPin());
+            list.addAdapter(adapter.getName(), adapter.getSrc(), adapter.isLoad(), adapter.isPin());
         }
 
         NettyUtils.sendJsonResponse(ctx, list);

--- a/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/DescribeAdapterResponse.java
@@ -20,6 +20,7 @@ import ai.djl.serving.wlm.Adapter;
 public class DescribeAdapterResponse {
     private String name;
     private String src;
+    private boolean load;
     private boolean pin;
 
     /**
@@ -30,6 +31,7 @@ public class DescribeAdapterResponse {
     public DescribeAdapterResponse(Adapter<Input, Output> adapter) {
         this.name = adapter.getName();
         this.src = adapter.getSrc();
+        this.load = adapter.isLoad();
         this.pin = adapter.isPin();
     }
 
@@ -49,6 +51,15 @@ public class DescribeAdapterResponse {
      */
     public String getSrc() {
         return src;
+    }
+
+    /**
+     * Returns whether to load the adapter weights.
+     *
+     * @return whether to load the adapter weights
+     */
+    public boolean isLoad() {
+        return load;
     }
 
     /**

--- a/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
+++ b/serving/src/main/java/ai/djl/serving/http/list/ListAdaptersResponse.java
@@ -58,21 +58,24 @@ public class ListAdaptersResponse {
      *
      * @param name the adapter name
      * @param src the adapter source
+     * @param load whether to load the adapter weights
      * @param pin whether to pin the adapter
      */
-    public void addAdapter(String name, String src, boolean pin) {
-        adapters.add(new AdapterItem(name, src, pin));
+    public void addAdapter(String name, String src, boolean load, boolean pin) {
+        adapters.add(new AdapterItem(name, src, load, pin));
     }
 
     /** A class that holds the adapter response. */
     public static final class AdapterItem {
         private String name;
         private String src;
+        private boolean load;
         private boolean pin;
 
-        private AdapterItem(String name, String src, boolean pin) {
+        private AdapterItem(String name, String src, boolean load, boolean pin) {
             this.name = name;
             this.src = src;
+            this.load = load;
             this.pin = pin;
         }
 

--- a/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
+++ b/wlm/src/main/java/ai/djl/serving/wlm/Adapter.java
@@ -193,6 +193,15 @@ public abstract class Adapter<I, O> {
     }
 
     /**
+     * Returns whether to load the adapter weights.
+     *
+     * @return whether to load the adapter weights
+     */
+    public boolean isLoad() {
+        return Boolean.parseBoolean(options.getOrDefault("load", "true"));
+    }
+
+    /**
      * Returns whether to pin the adapter.
      *
      * @return whether to pin the adapter


### PR DESCRIPTION
## Description ##

Add an additional `load` option to the register adapter API and update adapter API.

The reason is for this change is to keep consistent with other model servers like vllm and lorax. vllm load_lora_adapter API don't load adapter weights, the adapter weights is only loaded when running inference using one particular adapter.

Discussed with Hosting team, making default to `true`.

Example:

```
curl -X POST "http://localhost:8080/models/model/adapters?name=eng_alpaca&load=false&src=/opt/ml/model/adapters/eng_alpaca"
```