### PR TITLE
[docker][inf2] pin hf hub python dependency

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     neuronx_distributed==${neuronx_distributed_version} protobuf==${protobuf_version} sentencepiece jinja2 \
     diffusers==${diffusers_version} opencv-contrib-python-headless  Pillow --extra-index-url=https://pip.repos.neuron.amazonaws.com \
     pydantic==${pydantic_version} optimum optimum-neuron==${optimum_neuron_version} tiktoken blobfile && \
-    pip install transformers==${transformers_version} && \
+    pip install transformers==${transformers_version} "huggingface_hub<0.26" && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \
     useradd -m -d /home/djl djl && \


### PR DESCRIPTION
## Description ##

This pins the hf hub dependency to <0.26 to prevent the breaking change that introduced causing regression. I validated that this change works by building the container and running the impacted tests (neuron unit tests) locally