### PR TITLE
[test] fix transformers neuronx integration test failure

### DIFF
--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_tnx_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_tnx_rolling_batch.py
@@ -105,22 +105,22 @@ class TestNeuronRollingBatch(unittest.TestCase):
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
         # --- Models ---
-        model_names = [
-            "llama",
-            "gpt2",
-            "gptneox",
-            "bloom",
-        ]
+        model_name_vs_artifacts = {
+            "llama": "s3://djl-llm/llama-tiny-4k/",
+            "gpt2": "s3://djl-llm/gpt2-tiny-4k/",
+            "gptneox": "s3://djl-llm/gpt-neox-tiny-4k/",
+            "bloom": "s3://djl-llm/bloom-tiny-4k/",
+        }
 
         # === Test ===
-        for model_id in model_names:
+        for model_id in model_name_vs_artifacts.keys():
             properties = {
                 "tensor_parallel_degree": 2,
                 "n_positions": "128",
                 "rolling_batch": "tnx",
                 "max_rolling_batch_size": 4,
                 "model_loading_timeout": 3600,
-                "model_id": artifacts(model_id)
+                "model_id": model_name_vs_artifacts[model_id]
             }
 
             # ===================== neuron-tnx ============================


### PR DESCRIPTION
## Description ##

EDIT: Even tiny models have higher context length. So, we trained model and tokenizer to have smaller context length 4k on runtime. I trained the model offline and uploaded it to s3. So the previous fix is not needed. 

---

This should fix the tnx unit tests in integration tests failures. This is due to transformers getting upgraded to 4.45.2. This does not affect our handlers. This only affects, `train_new_from_iterator` in transformers. 

Raised PR in transformers to fix it. https://github.com/huggingface/transformers/pull/34661