### PR TITLE
refactor lmi and trt dockerfiles to install python requirements from …

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -13,21 +13,9 @@ FROM ubuntu:22.04
 ARG djl_version
 ARG djl_serving_version
 ARG torch_version=2.1.2
-ARG torchvision_version=0.16.2
-ARG python_version=3.10
+ARG python_version=3.11
 ARG neuronsdk_version=2.20.0
-ARG torch_neuronx_version=2.1.2.2.3.0
-ARG transformers_neuronx_version=0.12.313
-ARG neuronx_distributed_version=0.9.0
-ARG neuronx_cc_version=2.15.128.0
-ARG neuronx_cc_stubs_version=2.15.128.0
-ARG torch_xla_version=2.1.4
 ARG transformers_version=4.45.2
-ARG accelerate_version=0.29.2
-ARG diffusers_version=0.28.2
-ARG pydantic_version=2.6.1
-ARG optimum_neuron_version=0.0.24
-ARG huggingface_hub_version=0.25.2
 # %2B is the url escape for the '+' character
 ARG vllm_wheel="https://publish.djl.ai/neuron_vllm/vllm-0.6.2%2Bnightly-py3-none-any.whl"
 EXPOSE 8080
@@ -47,12 +35,12 @@ ENV TRANSFORMERS_CACHE=/tmp/.cache/huggingface/transformers
 ENV PYTORCH_KERNEL_CACHE_PATH=/tmp/.cache
 ENV MODEL_LOADING_TIMEOUT=1200
 ENV PREDICT_TIMEOUT=240
-ENV NEURON_SDK_PATH=/usr/local/lib/python3.10/dist-packages/torch_neuronx/lib
+ENV NEURON_SDK_PATH=/usr/local/lib/${python_version}/dist-packages/torch_neuronx/lib
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NEURON_SDK_PATH
-ENV PYTORCH_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/torch/lib
+ENV PYTORCH_LIBRARY_PATH=/usr/local/lib/${python_version}/dist-packages/torch/lib
 ENV PYTORCH_EXTRA_LIBRARY_PATH=$NEURON_SDK_PATH/libtorchneuron.so
 ENV PYTORCH_PRECXX11=true
-ENV PYTORCH_VERSION=2.1.2
+ENV PYTORCH_VERSION=${torch_version}
 ENV JAVA_OPTS="-Xmx1g -Xms1g -Xss2m -XX:+ExitOnOutOfMemoryError"
 ENV NEURON_CC_FLAGS="--logfile /tmp/compile.log --temp-dir=/tmp"
 ENV SERVING_FEATURES=vllm,lmi-dist,tnx
@@ -70,18 +58,14 @@ RUN mkdir -p /opt/djl/conf && \
     mkdir -p /opt/ml/model
 COPY config.properties /opt/djl/conf/
 COPY partition /opt/djl/partition
+COPY requirements-neuron.txt ./requirements.txt
 RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     echo "${djl_serving_version} inf2" > /opt/djl/bin/telemetry && \
     scripts/install_python.sh && \
     scripts/install_djl_serving.sh $djl_version $djl_serving_version && \
     scripts/install_djl_serving.sh $djl_version $djl_serving_version ${torch_version} && \
     scripts/install_inferentia2.sh && \
-    pip install accelerate==${accelerate_version} safetensors torchvision==${torchvision_version} \
-    neuronx-cc==${neuronx_cc_version} torch-neuronx==${torch_neuronx_version} transformers-neuronx==${transformers_neuronx_version} \
-    torch_xla==${torch_xla_version} neuronx-cc-stubs==${neuronx_cc_stubs_version} huggingface-hub==${huggingface_hub_version} \
-    neuronx_distributed==${neuronx_distributed_version} protobuf sentencepiece jinja2 \
-    diffusers==${diffusers_version} opencv-contrib-python-headless Pillow --extra-index-url=https://pip.repos.neuron.amazonaws.com \
-    pydantic==${pydantic_version} optimum optimum-neuron==${optimum_neuron_version} tiktoken blobfile && \
+    pip install -r requirements.txt && \
     pip install transformers==${transformers_version} ${vllm_wheel} && \
     echo y | pip uninstall triton && \
     scripts/install_s5cmd.sh x64 && \

--- a/serving/docker/requirements-lmi.txt
+++ b/serving/docker/requirements-lmi.txt
@@ -1,0 +1,42 @@
+torch==2.5.1
+torchvision==0.20.1
+# sequence scheduler for hf accelerate rolling batch
+https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl
+peft==0.13.2
+protobuf==3.20.3
+transformers==4.45.2
+hf-transfer
+zstandard
+datasets==3.0.1
+mpi4py
+sentencepiece
+tiktoken
+blobfile
+einops
+accelerate==1.0.1
+bitsandbytes==0.44.1
+auto-gptq==0.7.1
+pandas
+pyarrow
+jinja2
+retrying
+opencv-contrib-python-headless
+safetensors
+scipy
+onnx
+sentence_transformers
+onnxruntime
+autoawq==0.2.5
+tokenizers==0.20.1
+pydantic==2.9.2
+# djl converter wheel for converting hf models to onnx/rust
+https://publish.djl.ai/djl_converter/djl_converter-0.31.0-py3-none-any.whl
+optimum==1.23.2
+# flashinfer for vllm
+https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu124torch2.4-cp311-cp311-linux_x86_64.whl
+# vllm wheel using PT 2.5.1
+https://publish.djl.ai/vllm/cu124-pt251/vllm-0.6.3.post1%2Bcu124-cp311-cp311-linux_x86_64.whl
+# lmi-dist wheel - need to change this to the one built by ci once ready
+https://publish.djl.ai/lmi_dist/lmi_dist-13.0.0-cp311-cp311-linux_x86_64.whl
+# sagemaker fast model loader wheel
+https://publish.djl.ai/fast-model-loader/sagemaker_fast_model_loader-0.1.0-cp311-cp311-linux_x86_64.whl

--- a/serving/docker/requirements-neuron.txt
+++ b/serving/docker/requirements-neuron.txt
@@ -1,0 +1,23 @@
+--extra-index-url https://pip.repos.neuron.amazonaws.com
+accelerate==0.29.2
+safetensors
+torchvision==0.16.2
+neuronx-cc==2.15.128.0
+torch-neuronx==2.1.2.2.3.0
+transformers-neuronx==0.12.313
+torch_xla==2.1.4
+neuronx-cc-stubs==2.15.128.0
+huggingface-hub==0.25.2
+neuronx_distributed==0.9.0
+protobuf
+sentencepiece
+jinja2
+diffusers==0.28.2
+opencv-contrib-python-headless
+pillow
+pydantic==2.6.1
+optimum
+optimum-neuron==0.0.25
+tiktoken
+blobfile
+transformers

--- a/serving/docker/requirements-trt.txt
+++ b/serving/docker/requirements-trt.txt
@@ -1,0 +1,38 @@
+torch==2.4.0
+transformers==4.42.4
+accelerate==0.32.1
+peft==0.13.2
+sentencepiece
+mpi4py
+cuda-python==12.5
+onnx
+polygraphy
+pynvml==11.5.0
+datasets==2.19.1
+pydantic==2.6.1
+scipy
+torchprofile
+bitsandbytes
+ninja
+transformers_stream_generator
+einops
+tiktoken
+jinja2
+graphviz
+blobfile
+colored
+h5py
+strenum
+pulp
+flax
+easydict
+tensorrt==10.3.0
+janus==1.0.0
+nvidia-modelopt==0.15.0
+numpy==1.26.4
+# TRTLLM toolkit wheel
+https://publish.djl.ai/tensorrt-llm/toolkit/tensorrt_llm_toolkit-0.12.0%2Bnightly-py3-none-any.whl
+# TRTLLM wheel - contains necessary patch fix not available in OSS
+https://publish.djl.ai/tensorrt-llm/v0.12.0/tensorrt_llm-0.12.0-cp310-cp310-linux_x86_64.whl
+# Triton toolkit wheel - pybindings for trtllm
+https://publish.djl.ai/tritonserver/r24.04/tritontoolkit-24.4-py310-none-any.whl


### PR DESCRIPTION
…requirements file

## Description ##

This PR changes our dockerfile to install python dependencies via a requirements file. This is easier to parse than the full set of versions and dependencies in our docker file.

Additionally, it gives us the ability to:
- specify version ranges, or less strict  version requirements per dependency
- ensure we install compatible versions of dependencies by relying on the pip dependency resolver


Few more change I want to make before moving out of the draft stage, but this is more or less what it will look like.
I've tested the integ tests locally to verify the newly built containers are functioning as expected.