### PR TITLE
[neo] Generate serving.properties file during sharding jobs

### DIFF
--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -92,6 +92,13 @@ class NeoShardingService():
                 elif os.path.isdir(item_path):
                     shutil.copytree(item_path, os.path.join(output_dir, item))
 
+    def generate_properties_file(self):
+        with open(
+                os.path.join(self.OUTPUT_MODEL_DIRECTORY,
+                             "serving.properties"), "w") as f:
+            for key, value in self.properties.items():
+                f.write(f"{key}={value}\n")
+
     def shard_lmi_dist_model(self, input_dir: str, output_dir: str,
                              pp_degree: int, tp_degree: int,
                              chunk_mb: int) -> None:
@@ -153,6 +160,7 @@ def main():
     try:
         neo_sharding_service = NeoShardingService()
         neo_sharding_service.run_sharding()
+        neo_sharding_service.generate_properties_file()
 
     except Exception as exc:
         MPI.COMM_WORLD.Barrier()

--- a/serving/docker/partition/sm_neo_trt_llm_partition.py
+++ b/serving/docker/partition/sm_neo_trt_llm_partition.py
@@ -63,7 +63,7 @@ class NeoTRTLLMPartitionService():
                              "serving.properties"), "w") as f:
             f.write("engine=MPI\n")
             for key, value in self.properties.items():
-                if key != "option.model_id" and key != "option.model_dir":
+                if key != "option.model_id":
                     f.write(f"{key}={value}\n")
 
     def neo_partition(self):


### PR DESCRIPTION
This PR adds the generation of a `serving.properties` file to the output artifacts of AOT sharding jobs, so the `option.load_format` and `option.tensor_parallel_degree` values can be propagated when loading the artifacts for runtime