### PR TITLE
[neo] Allow setting GPU memory-related LMI options in sharding jobs

### DIFF
--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -98,15 +98,19 @@ class NeoShardingService():
         # Use default LMI value of 0.9 for gpu_memory_utilization, unless set otherwise
         gpu_memory_utilization = float(
             self.properties.get("option.gpu_memory_utilization", 0.9))
+        # Use default LMI value of False for enforce_eager, unless set otherwise
+        enforce_eager: bool = str(
+            self.properties.get("option.enforce_eager",
+                                False)).lower() == "true"
 
         engine_args = VllmEngineArgs(
             model=input_dir,
             pipeline_parallel_size=pp_degree,
             tensor_parallel_size=tp_degree,
-            enforce_eager=True,
             disable_custom_all_reduce=True,
             distributed_executor_backend="mp",
             gpu_memory_utilization=gpu_memory_utilization,
+            enforce_eager=enforce_eager,
         )
         engine = engine_from_args(engine_args)
 

--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -95,13 +95,16 @@ class NeoShardingService():
     def shard_lmi_dist_model(self, input_dir: str, output_dir: str,
                              pp_degree: int, tp_degree: int,
                              chunk_mb: int) -> None:
-        # Use default LMI value of 0.9 for gpu_memory_utilization, unless set otherwise
+        # For engine args which can affect GPU memory utilization, use LMI defaults
+        # unless specified otherwise by the customer
         gpu_memory_utilization = float(
             self.properties.get("option.gpu_memory_utilization", 0.9))
-        # Use default LMI value of False for enforce_eager, unless set otherwise
         enforce_eager: bool = str(
             self.properties.get("option.enforce_eager",
                                 False)).lower() == "true"
+        max_rolling_batch_size = int(
+            self.properties.get("option.max_rolling_batch_size", 256))
+        max_model_len = int(self.properties.get("option.max_model_len", None))
 
         engine_args = VllmEngineArgs(
             model=input_dir,
@@ -111,6 +114,8 @@ class NeoShardingService():
             distributed_executor_backend="mp",
             gpu_memory_utilization=gpu_memory_utilization,
             enforce_eager=enforce_eager,
+            max_num_seqs=max_rolling_batch_size,
+            max_model_len=max_model_len,
         )
         engine = engine_from_args(engine_args)
 

--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -95,6 +95,9 @@ class NeoShardingService():
     def shard_lmi_dist_model(self, input_dir: str, output_dir: str,
                              pp_degree: int, tp_degree: int,
                              chunk_mb: int) -> None:
+        # Use default LMI value of 0.9 for gpu_memory_utilization, unless set otherwise
+        gpu_memory_utilization = float(
+            self.properties.get("option.gpu_memory_utilization", 0.9))
 
         engine_args = VllmEngineArgs(
             model=input_dir,
@@ -103,7 +106,7 @@ class NeoShardingService():
             enforce_eager=True,
             disable_custom_all_reduce=True,
             distributed_executor_backend="mp",
-            gpu_memory_utilization=0.99,
+            gpu_memory_utilization=gpu_memory_utilization,
         )
         engine = engine_from_args(engine_args)
 

--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -103,6 +103,7 @@ class NeoShardingService():
             enforce_eager=True,
             disable_custom_all_reduce=True,
             distributed_executor_backend="mp",
+            gpu_memory_utilization=0.99,
         )
         engine = engine_from_args(engine_args)
 


### PR DESCRIPTION
This PR allows customers to pass in values for the LMI options
- `option.gpu_memory_utilization` 
- `option.enforce_eager` 
- `option.max_rolling_batch_size `
- `option.max_model_len`

during Neo AOT sharding jobs. Changing the values of these options can potentially allow a customer to shard a model on an instance which would result in OOM when using default values. Note that the customized options need to be set to the same values when loading back the artifacts during runtime; the generated `serving.properties` in the output artifacts will ensure this parity.