### PR TITLE
[ci] don't shor-circuit continuous pr check if 1 job in the matrix fails

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:


### PR DESCRIPTION
## Description ##

Currently, if one of the windows/mac/linux checks fails, we short circuit and cancel all of them. 

this change allows each one to run to completion so that we can understand where an issue lies.

See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
