### PR TITLE
[trt][docker] pin trt version to release version, not nightly

### DIFF
--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -20,7 +20,7 @@ ARG transformers_version=4.44.2
 ARG accelerate_version=0.33.0
 ARG tensorrtlibs_version=10.3.0
 # %2B is the url escape for the '+' character
-ARG trtllm_toolkit_version=0.12.0%2Bnightly
+ARG trtllm_toolkit_version=0.12.0
 ARG trtllm_version=v0.12.0
 ARG cuda_python_version=12.5
 ARG peft_version=0.10.0


### PR DESCRIPTION
## Description ##

release container should be using the release wheel, not nightly
