### PR TITLE
[fix][ci] specify guaranteed_no_evict batch_scheduler_policy to get t…

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -991,6 +991,8 @@ trtllm_handler_list = {
         "option.model_id": "s3://djl-llm/flan-t5-xl/",
         "option.dtype": "bf16",
         "option.max_rolling_batch_size": 128,
+        # This is needed in v12, but we don't know exactly why the default max_utilization does not work
+        "option.batch_scheduler_policy": "guaranteed_no_evict",
     },
     "llama-3-1-8b": {
         "option.model_id": "s3://djl-llm/llama-3.1-8b-hf/",


### PR DESCRIPTION
…5 working with in flight batching

## Description ##

The default batch_scheduler_policy of max_utilization does not work with enc_dec models that use in flight batching + streaming. However, the guaranteed_no_evict policy does work. We update the policy here for CI, but need to document this as well in release notes.

We still don't know exactly why this difference is only for enc_dec models. We should probably look into that more, as well as explore how this impacts performance for other model types. We're using max_utilization as the default since that maximizes throughput, but it seems like guaranteed no_evict is better for latency
