### PR TITLE
neo shard script: remove  `del engine` as engine doesn't exist any more

### DIFF
--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -179,7 +179,6 @@ class NeoShardingService():
                 configs=configs,
             )
 
-        del engine
         torch.cuda.empty_cache()
 
     def run_sharding(self):


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
