### PR TITLE
[lmi][python] remove quantization enum and rely on engine validation/…

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py
@@ -12,24 +12,11 @@
 # the specific language governing permissions and limitations under the License.
 import ast
 from enum import Enum
-from typing import Optional, Mapping, Tuple
+from typing import Optional, Mapping, Tuple, Dict
 
 from pydantic import model_validator, field_validator
 
 from djl_python.properties_manager.properties import Properties
-
-
-class LmiDistQuantizeMethods(str, Enum):
-    awq = 'awq'
-    deepspeedfp = 'deepspeedfp'
-    fp8 = 'fp8'
-    fbgemm_fp8 = 'fbgemm_fp8'
-    gptq = 'gptq'
-    gptq_marlin = 'gptq_marlin'
-    gptq_marlin_24 = 'gptq_marlin_24'
-    awq_marlin = 'awq_marlin'
-    marlin = 'marlin'
-    squeezellm = 'squeezellm'
 
 
 class LmiDistLoadFormats(str, Enum):
@@ -40,7 +27,7 @@ class LmiDistRbProperties(Properties):
     engine: Optional[str] = None
     dtype: Optional[str] = "auto"
     load_format: Optional[str] = "auto"
-    quantize: Optional[LmiDistQuantizeMethods] = None
+    quantize: Optional[str] = None
     tensor_parallel_degree: int = 1
     pipeline_parallel_degree: int = 1
     max_rolling_batch_prefill_tokens: Optional[int] = None

--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -12,31 +12,18 @@
 # the specific language governing permissions and limitations under the License.
 import ast
 from enum import Enum
-from typing import Optional, Any, Mapping, Tuple
+from typing import Optional, Any, Mapping, Tuple, Dict
 
 from pydantic import field_validator, model_validator
 
 from djl_python.properties_manager.properties import Properties
 
 
-class VllmQuantizeMethods(str, Enum):
-    awq = 'awq'
-    deepspeedfp = 'deepspeedfp'
-    fp8 = 'fp8'
-    fbgemm_fp8 = 'fbgemm_fp8'
-    gptq = 'gptq'
-    gptq_marlin = 'gptq_marlin'
-    gptq_marlin_24 = 'gptq_marlin_24'
-    awq_marlin = 'awq_marlin'
-    marlin = 'marlin'
-    squeezellm = 'squeezellm'
-
-
 class VllmRbProperties(Properties):
     engine: Optional[str] = None
     dtype: Optional[str] = "auto"
     load_format: Optional[str] = "auto"
-    quantize: Optional[VllmQuantizeMethods] = None
+    quantize: Optional[str] = None
     tensor_parallel_degree: int = 1
     pipeline_parallel_degree: int = 1
     max_rolling_batch_prefill_tokens: Optional[int] = None


### PR DESCRIPTION
…support

## Description ##

This removes the quantization enum, which we currently rely on for validating the quantization option. We don't really need to be doing this since we can rely directly on the engine for this validation. Furthermore, this enum/validation means we always have to keep the enums up to date. It's more effort than necessary in my opinion.
