### PR TITLE
[python] Update output default error message

### DIFF
--- a/engines/python/setup/djl_python/outputs.py
+++ b/engines/python/setup/djl_python/outputs.py
@@ -78,7 +78,7 @@ class Output(object):
         self.message = message
         return self
 
-    def error(self, error: str, code=424, message="prediction failure"):
+    def error(self, error: str, code=424, message="invoke handler failure"):
         self.code = code
         self.message = message
         body = {"code": self.code, "message": self.message, "error": error}

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -251,7 +251,7 @@ When using dynamic batching, errors are returned with HTTP response code 424 and
 ``` 
 {
     "code": 424,
-    "message": "prediction failure",
+    "message": "invoke handler failure",
     "error": "<error details"
 }
 ```


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

The python output default error message is "prediction failure".

But the python handler was also used for register model, I got the following error message when failing to register model in MME case, which could be confusing for customers. So changing to "invoke handler failure". Please also suggest better message if you have one.

```
{
  "code": 500,
  "type": "EngineException",
  "message": "Failed to initialize model: prediction failure"
}
```
