### PR TITLE
[sm][docker] use the correct verified cuda version in docker file

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -167,4 +167,4 @@ LABEL djl-version=$djl_version
 LABEL djl-serving-version=$djl_serving_version
 LABEL cuda-version=$cuda_version
 # To use the 535 CUDA driver, CUDA 12.4 can work on this one too
-LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.4
+LABEL com.amazonaws.sagemaker.inference.cuda.verified_versions=12.2


### PR DESCRIPTION
## Description ##

hosting has a strict cuda version check on the label, it needs to 12.2 to use the proper driver. this was fixed in 0.30.0, but seems like we missed it on the main branch
