### PR TITLE
Refactor LMI dockerfile

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -14,33 +14,9 @@ FROM nvidia/cuda:$version
 ARG cuda_version=cu124
 ARG djl_version
 ARG djl_serving_version
-# Base Deps
 ARG python_version=3.11
-ARG torch_version=2.5.1
-ARG torch_vision_version=0.20.1
 ARG djl_torch_version=2.5.1
-ARG onnx_version=1.19.0
-ARG pydantic_version=2.9.2
-ARG djl_converter_wheel="https://publish.djl.ai/djl_converter/djl_converter-0.31.0-py3-none-any.whl"
-# HF Deps
-ARG protobuf_version=3.20.3
-ARG transformers_version=4.45.2
-ARG accelerate_version=1.0.1
-ARG bitsandbytes_version=0.44.1
-ARG optimum_version=1.23.2
-ARG auto_gptq_version=0.7.1
-ARG datasets_version=3.0.1
-ARG autoawq_version=0.2.5
-ARG tokenizers_version=0.20.1
-# LMI-Dist Deps
-ARG vllm_wheel="https://publish.djl.ai/vllm/cu124-pt251/vllm-0.6.3.post1%2Bcu124-cp311-cp311-linux_x86_64.whl"
-ARG flash_infer_wheel="https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu124torch2.4-cp311-cp311-linux_x86_64.whl"
-# %2B is the url escape for the '+' character
-ARG lmi_dist_wheel="https://publish.djl.ai/lmi_dist/lmi_dist-13.0.0%2Bnightly-py3-none-any.whl"
-ARG seq_scheduler_wheel="https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl"
-ARG peft_version=0.13.2
-
-ARG sagemaker_fast_model_loader_wheel="https://publish.djl.ai/fast-model-loader/sagemaker_fast_model_loader-0.1.0-cp311-cp311-linux_x86_64.whl"
+ARG djl_onnx_version=1.19.0
 
 EXPOSE 8080
 
@@ -65,8 +41,6 @@ ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 # 0.6.2 is the last version that contains legacy support for beam search
 # TODO: update beam search logic and implementation in handlers
 ENV VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1
-
-
 ENV HF_HOME=/tmp/.cache/huggingface
 ENV PYTORCH_KERNEL_CACHE_PATH=/tmp/.cache
 ENV BITSANDBYTES_NOWELCOME=1
@@ -77,6 +51,7 @@ ENV TORCH_NCCL_BLOCKING_WAIT=0
 ENV TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 ENV TORCH_NCCL_AVOID_RECORD_STREAMS=1
 ENV SERVING_FEATURES=vllm,lmi-dist
+ENV DEBIAN_FRONTEND=noninteractive
 
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
@@ -85,77 +60,45 @@ COPY scripts scripts/
 RUN mkdir -p /opt/djl/conf \
     && mkdir -p /opt/djl/deps \
     && mkdir -p /opt/djl/partition \
-    && mkdir -p /opt/ml/model
+    && mkdir -p /opt/ml/model \
+    && mkdir -p /opt/djl/bin
 COPY config.properties /opt/djl/conf/config.properties
 COPY partition /opt/djl/partition
+COPY scripts/telemetry.sh /opt/djl/bin
+RUN echo "${djl_serving_version} lmi" > /opt/djl/bin/telemetry
 
 COPY distribution[s]/ ./
 RUN mv *.deb djl-serving_all.deb || true
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq libaio-dev libopenmpi-dev g++ \
-    && scripts/install_openssh.sh \
-    && scripts/install_djl_serving.sh $djl_version $djl_serving_version \
-    && scripts/install_djl_serving.sh $djl_version $djl_serving_version ${djl_torch_version} \
-    && djl-serving -i ai.djl.onnxruntime:onnxruntime-engine:$djl_version \
-    && djl-serving -i com.microsoft.onnxruntime:onnxruntime_gpu:$onnx_version \
-    && scripts/install_python.sh ${python_version} \
-    && scripts/install_s5cmd.sh x64 \
-    && mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin \
-    && echo "${djl_serving_version} lmi" > /opt/djl/bin/telemetry \
-    && pip3 cache purge \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install torch==${torch_version} torchvision==${torch_vision_version} --index-url https://download.pytorch.org/whl/cu124
-RUN pip3 install \
-    ${seq_scheduler_wheel} \
-    peft==${peft_version} \
-    protobuf==${protobuf_version} \
-    transformers==${transformers_version} \
-    hf-transfer \
-    zstandard \
-    datasets==${datasets_version} \
-    mpi4py \
-    sentencepiece \
-    tiktoken \
-    blobfile \
-    einops \
-    accelerate==${accelerate_version} \
-    bitsandbytes==${bitsandbytes_version} \
-    auto-gptq==${auto_gptq_version} \
-    pandas \
-    pyarrow \
-    jinja2 \
-    retrying \
-    opencv-contrib-python-headless \
-    safetensors \
-    scipy \
-    onnx \
-    sentence_transformers \
-    onnxruntime \
-    autoawq==${autoawq_version} \
-    tokenizers==${tokenizers_version} \
-    pydantic==${pydantic_version} \
-    ${djl_converter_wheel} \
-    optimum==${optimum_version} \
-    ${flash_infer_wheel} \
-    ${vllm_wheel} \
-    ${lmi_dist_wheel} \
-    torch==${torch_version} \
-    torchvision==${torch_vision_version} \
-    ${sagemaker_fast_model_loader_wheel} \
-    && git clone https://github.com/neuralmagic/AutoFP8.git && cd AutoFP8 && git reset --hard 4b2092c && pip3 install . && cd .. && rm -rf AutoFP8 \
-    && pip3 cache purge
-
+RUN apt-get update && apt-get install -yq libaio-dev libopenmpi-dev g++ unzip
+RUN scripts/install_openssh.sh
+RUN scripts/install_python.sh ${python_version}
+RUN scripts/install_s5cmd.sh x64
+RUN pip3 cache purge
 # Add CUDA-Compat
 RUN apt-get update && apt-get install -y cuda-compat-12-4 && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+COPY requirements-lmi.txt ./requirements.txt
+RUN pip3 install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu124
+RUN pip3 install -r requirements.txt
+RUN git clone https://github.com/neuralmagic/AutoFP8.git \
+    && cd AutoFP8 \
+    && git reset --hard 4b2092c \
+    && pip3 install . \
+    && cd .. \
+    && rm -rf AutoFP8 \
+RUN pip3 cache purge
 
 RUN scripts/patch_oss_dlc.sh python \
     && scripts/security_patch.sh lmi \
     && useradd -m -d /home/djl djl \
     && chown -R djl:djl /opt/djl \
-    && rm -rf scripts \
-    && pip3 cache purge \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN scripts/install_djl_serving.sh $djl_version $djl_serving_version ${djl_torch_version} && rm -rf scripts
+RUN djl-serving -i ai.djl.onnxruntime:onnxruntime-engine:$djl_version
+RUN djl-serving -i com.microsoft.onnxruntime:onnxruntime_gpu:$djl_onnx_version
 
 LABEL maintainer="djl-dev@amazon.com"
 LABEL dlc_major_version="1"

--- a/serving/docker/requirements-lmi.txt
+++ b/serving/docker/requirements-lmi.txt
@@ -1,0 +1,42 @@
+peft==0.13.2
+protobuf==3.20.3
+transformers==4.45.2
+hf-transfer
+zstandard
+datasets==3.0.1
+mpi4py
+sentencepiece
+tiktoken
+blobfile
+einops
+accelerate==1.0.1
+bitsandbytes==0.44.1
+auto-gptq==0.7.1
+pandas
+pyarrow
+jinja2
+retrying
+opencv-contrib-python-headless
+safetensors
+scipy
+onnx
+sentence_transformers
+onnxruntime
+autoawq==0.2.5
+tokenizers==0.20.3
+pydantic==2.9.2
+optimum==1.23.2
+torch==2.5.1
+torchvision==0.20.1
+# sequence scheduler wheel for hf accelerate rolling batch
+https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl
+# djl converter wheel for text-embedding use case
+https://publish.djl.ai/djl_converter/djl_converter-0.31.0-py3-none-any.whl
+# flash infer kernels for vllm/lmi-dist
+https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu124torch2.4-cp311-cp311-linux_x86_64.whl
+# vllm wheel built with pt2.5.1
+https://publish.djl.ai/vllm/cu124-pt251/vllm-0.6.3.post1%2Bcu124-cp311-cp311-linux_x86_64.whl
+# lmi dist wheel
+https://publish.djl.ai/lmi_dist/lmi_dist-13.0.0%2Bnightly-py3-none-any.whl
+# fast model loader
+https://publish.djl.ai/fast-model-loader/sagemaker_fast_model_loader-0.1.0-cp311-cp311-linux_x86_64.whl

--- a/serving/docker/scripts/install_djl_serving.sh
+++ b/serving/docker/scripts/install_djl_serving.sh
@@ -6,34 +6,33 @@ DJL_VERSION=$1
 DJL_SERVING_VERSION=$2
 PYTORCH_JNI=$3
 
-if [ -z "$PYTORCH_JNI" ]; then
-  # install Java
-  apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-    fakeroot \
-    wget \
-    gpg \
-    curl \
-    jq \
-    unzip \
-    ca-certificates \
-    fontconfig \
-    vim
+# install Java
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  fakeroot \
+  wget \
+  gpg \
+  curl \
+  jq \
+  unzip \
+  ca-certificates \
+  fontconfig \
+  vim
 # add corretto https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/generic-linux-install.html
-  wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg &&
-    echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-    java-17-amazon-corretto-jdk
+wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg &&
+  echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  java-17-amazon-corretto-jdk
 
-  # install DJLServing package 
-  if [ ! -f djl-serving_all.deb ]; then
-    curl "https://publish.djl.ai/djl-serving/djl-serving_${DJL_SERVING_VERSION//-/\~}-1_all.deb" -f -o djl-serving_all.deb
-  fi
-  dpkg -i djl-serving_all.deb
-  rm djl-serving_all.deb
+# install DJLServing package
+if [ ! -f djl-serving_all.deb ]; then
+  curl "https://publish.djl.ai/djl-serving/djl-serving_${DJL_SERVING_VERSION//-/\~}-1_all.deb" -f -o djl-serving_all.deb
+fi
+dpkg -i djl-serving_all.deb
+rm djl-serving_all.deb
 
-  mkdir -p /opt/djl/plugins
-else
+mkdir -p /opt/djl/plugins
+if [ -n "$PYTORCH_JNI"]; then
   djl-serving -i "ai.djl.pytorch:pytorch-jni:${PYTORCH_JNI}-${DJL_VERSION}"
   rm -rf /opt/djl/logs
 fi


### PR DESCRIPTION
## Description ##

This refactors the the lmi.Dockerfile primarily to order the layers in such a way that the more "static" layers are up towards the beginning, and the more "dynamic" layers are towards the bottom. After a release, the most likely components of the container to change are:
- DJL Serving
- OS patches

previously, these were done before any of the python installs, meaning that if we patched/updated a container with a new djl_serving deb, everything from that point on would need to be rebuilt. Moving the djl and os patching towards the bottom should allow for all of the previous layers to be mostly static (caching/build/pull implications).

Additionally, I have refactored the python dependency installation into a requirements file. The requirements file is easier to parse in my opinion (version and dep are together), and ensure that we don't separately install a dependency that could break things without the pip dependency resolver.

I also changed the install_djl_serving script - it required us to run it twice previously to install pytorch deps. 

## Testing
built the container locally and ran `python -m pytest -k "LmiDist" tests.py` to test the lmi functionality. 
