### PR TITLE
[docker] update neuron artifacts to 2.20.1

### DIFF
--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -15,12 +15,12 @@ ARG djl_serving_version
 ARG torch_version=2.1.2
 ARG torchvision_version=0.16.2
 ARG python_version=3.10
-ARG neuronsdk_version=2.20.0
-ARG torch_neuronx_version=2.1.2.2.3.0
+ARG neuronsdk_version=2.20.1
+ARG torch_neuronx_version=2.1.2.2.3.1
 ARG transformers_neuronx_version=0.12.313
 ARG neuronx_distributed_version=0.9.0
-ARG neuronx_cc_version=2.15.128.0
-ARG neuronx_cc_stubs_version=2.15.128.0
+ARG neuronx_cc_version=2.15.141.0
+ARG neuronx_cc_stubs_version=2.15.141.0
 ARG torch_xla_version=2.1.4
 ARG transformers_version=4.45.2
 ARG accelerate_version=0.29.2


### PR DESCRIPTION
## Description ##

Neuron 2.20.1 release addresses an issue with the Neuron Persistent Cache that was brought forth in 2.20 release.
