### PR TITLE
[lmi] validate inputs field is of type string for request

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -266,6 +266,16 @@ def parse_lmi_default_request_rolling_batch(payload):
             f"Invalid request payload. Request payload should be a json object specifying the 'inputs' field. Received payload {payload}"
         )
 
+    if not isinstance(inputs, str):
+        raise ValueError(
+            f"Invalid request payload. The 'inputs' field must be a string. Received type {type(inputs)}"
+        )
+
+    if len(inputs) == 0:
+        raise ValueError(
+            f"Invalid request payload. The 'inputs' field does not contain any content. Received payload {payload}"
+        )
+
     parameters = payload.get("parameters", {})
     if not isinstance(parameters, dict):
         raise ValueError(

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -420,7 +420,11 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                     // This allows inference update HTTP code.
                     // If this is the first and last chunk, we're in a non-streaming case and can
                     // use default response without chunked transfer encoding
+                    // Note, we have to read the code and message from output AGAIN here.
+                    // They get changed to different values from when we read them at the start of
+                    // this method
                     if (first && !supplier.hasNext()) {
+                        status = new HttpResponseStatus(output.getCode(), output.getMessage());
                         FullHttpResponse resp =
                                 new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status);
                         for (Map.Entry<String, String> entry : output.getProperties().entrySet()) {
@@ -433,8 +437,7 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                         return;
                     }
                     if (first) {
-                        code = output.getCode();
-                        status = new HttpResponseStatus(code, output.getMessage());
+                        status = new HttpResponseStatus(output.getCode(), output.getMessage());
                         HttpResponse resp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
                         for (Map.Entry<String, String> entry : output.getProperties().entrySet()) {
                             resp.headers().set(entry.getKey(), entry.getValue());


### PR DESCRIPTION
## Description ##

Two changes in this PR:
1. Add stricter validation on the input schema for default payload format (validating that inputs is of type str

If you passed in a list or dict to `inputs` before, you would get something like this in the logs:
```
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:INFO::[RequestId=6b6324e5-588b-469f-a10b-64db2f221273] parsed and scheduled for inference
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:ERROR::Rolling batch inference error. There are 1 requests impacted. Dumping the impacted requestIds
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/rolling_batch/rolling_batch.py", line 47, in try_catch_handling
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    return func(self, *args, **kwargs)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/rolling_batch/lmi_dist_rolling_batch.py", line 212, in inference
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    self.engine.add_requests(new_lmi_dist_requests)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/lmi_dist/engine.py", line 65, in add_requests
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    for C in B:A.preprocessor.preprocess(C)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/nvtx/nvtx.py", line 116, in inner
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    result = func(*args, **kwargs)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:             ^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/lmi_dist/vllm_engine.py", line 38, in preprocess
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    A.prompt_token_ids=self.tokenizer.encode(A.prompt,lora_request=A.lora_request)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/vllm/transformers_utils/tokenizer_group/tokenizer_group.py", line 59, in encode
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    ret = tokenizer.encode(prompt)
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:          ^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/transformers/tokenization_utils_base.py", line 2783, in encode
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    encoded_inputs = self.encode_plus(
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:                     ^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/transformers/tokenization_utils_base.py", line 3202, in encode_plus
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    return self._encode_plus(
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:           ^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/transformers/tokenization_utils_fast.py", line 603, in _encode_plus
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    batched_output = self._batch_encode_plus(
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:                     ^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/usr/local/lib/python3.11/dist-packages/transformers/tokenization_utils_fast.py", line 529, in _batch_encode_plus
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:    encodings = self._tokenizer.encode_batch(
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]
INFO  PyProcess W-161-926d3f85ed178e0-stdout: [1,0]<stdout>:INFO::[RequestId=6b6324e5-588b-469f-a10b-64db2f221273] impacted by rolling batch error
```
And a response like
```
{"error":"exception occurred during rolling batch inference","code":424}
```

Now you will get in the logs
```
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:WARNING::[RequestId=ec4135c1-d787-4bdc-aa9f-49a10f559ce8Input Parsing failed. Ensure that the request payload is valid. Invalid request payload. The 'inputs' field must be a string. Received type <class 'dict'>
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 84, in parse_input_with_formatter
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    request_input = input_formatter_function(input_item, **kwargs)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 127, in format_input
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    parse_text_inputs_params(request_input, input_item, input_map, **kwargs)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 157, in parse_text_inputs_params
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    inputs, param = parse_lmi_default_request_rolling_batch(input_map)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 270, in parse_lmi_default_request_rolling_batch
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    raise ValueError(
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:ValueError: Invalid request payload. The 'inputs' field must be a string. Received type <class 'dict'>
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:WARNING::[RequestId=d20b32b6-a833-4a07-8bf2-240e2772bbbbInput Parsing failed. Ensure that the request payload is valid. Invalid request payload. The 'inputs' field must be a string. Received type <class 'dict'>
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:Traceback (most recent call last):
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 84, in parse_input_with_formatter
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    request_input = input_formatter_function(input_item, **kwargs)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 127, in format_input
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    parse_text_inputs_params(request_input, input_item, input_map, **kwargs)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 157, in parse_text_inputs_params
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    inputs, param = parse_lmi_default_request_rolling_batch(input_map)
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:  File "/tmp/.djl.ai/python/0.31.0-SNAPSHOT/djl_python/input_parser.py", line 270, in parse_lmi_default_request_rolling_batch
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:    raise ValueError(
INFO  PyProcess W-2033-926d3f85ed178e0-stdout: [1,0]<stdout>:ValueError: Invalid request payload. The 'inputs' field must be a string. Received type <class 'dict'>
```

and a response like
```
{"error":"Input Parsing failed. Ensure that the request payload is valid. Invalid request payload. The \u0027inputs\u0027 field must be a string. Received type \u003cclass \u0027dict\u0027\u003e","code":424}
```


2. Fixed a bug with the incorrect HTTP status code returned. The RollingBatch.java interaction with InferenceRequestHandler.sendOutput is not obvious, and needs improvement. The issue is that the attributes of the Output object can change underneath us, and are not reliable to use until we have parsed the next chunk from the byte supplier. In order to return the correct code and message, we have to read them again after we have read the first chunk from the bytes supplier