### PR TITLE
[docker] fix typo in install_djl_serving script

### DIFF
--- a/serving/docker/scripts/install_djl_serving.sh
+++ b/serving/docker/scripts/install_djl_serving.sh
@@ -32,7 +32,7 @@ dpkg -i djl-serving_all.deb
 rm djl-serving_all.deb
 
 mkdir -p /opt/djl/plugins
-if [ -n "$PYTORCH_JNI"]; then
+if [ -n "$PYTORCH_JNI" ]; then
   djl-serving -i "ai.djl.pytorch:pytorch-jni:${PYTORCH_JNI}-${DJL_VERSION}"
   rm -rf /opt/djl/logs
 fi


### PR DESCRIPTION
## Description ##

forgot a space in the check for pytorch jni value.
