### PR TITLE
[0.31.0-dlc] Parse adapters iff enable_lora is true

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -198,9 +198,8 @@ def add_server_maintained_params(request_input: RequestInput,
 
 def parse_adapters(request_input: TextInput, input_item: Input,
                    input_map: Dict, **kwargs):
-    adapter_registry = kwargs.get("adapter_registry")
-    # if adapter registry exists and not empty, then we assume, peft is supported for the incoming
-    if adapter_registry:
+    if kwargs.get("configs").enable_lora:
+        adapter_registry = kwargs.get("adapter_registry")
         input_len = len(request_input.input_text) if isinstance(
             request_input.input_text, list) else 1
         adapters_data = _fetch_adapters_from_input(input_map, input_item,

--- a/engines/python/setup/djl_python/properties_manager/properties.py
+++ b/engines/python/setup/djl_python/properties_manager/properties.py
@@ -63,6 +63,7 @@ class Properties(BaseModel):
     mpi_mode: bool = False
     tgi_compat: Optional[bool] = False
     bedrock_compat: Optional[bool] = False
+    enable_lora: Optional[bool] = False
 
     # Spec_dec
     draft_model_id: Optional[str] = None


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Parse adapters from input based on enable_lora config, not based on checking adapter_registry is empty or not. Because adapter_registry might be empty if user has not registered any adapters.