### PR TITLE
[python] add rolling batch as auto for neuron smart default

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
@@ -16,6 +16,8 @@ import logging
 from typing import List, Dict, Any
 import subprocess as sp
 
+from djl_python.properties_manager.properties import RollingBatchEnum
+
 logger = logging.getLogger(__name__)
 
 BILLION = 1_000_000_000.0
@@ -69,6 +71,10 @@ class NeuronSmartDefaultUtils:
         :param is_partition: Indicates whether we are saving pre-sharded checkpoints or not.
                              We set some smart defaults for it.
         """
+
+        if "rolling_batch" not in properties:
+            properties["rolling_batch"] = RollingBatchEnum.auto.value
+
         if "n_positions" not in properties:
             if self.get_model_parameters(
                     model_config) <= 0 or self.available_cores == 0:

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -1821,8 +1821,14 @@ def test_transformers_neuronx_handler(model, model_spec):
     if "worker" in spec:
         check_worker_number(spec["worker"])
     for batch_size in spec["batch_size"]:
+        inputs = batch_generation(batch_size)
+        if batch_size == 1:
+            # for rolling batch, inputs should be a str not list.
+            # i.e, client side batching is not enabled when rolling batch is enabled.
+            # if batch_size is just 1, then we assume it is for rolling batch here.
+            inputs = inputs[0]
         for seq_length in spec["seq_length"]:
-            req = {"inputs": batch_generation(batch_size)}
+            req = {"inputs": inputs}
             params = {"max_length": seq_length}
             if "use_sample" in spec:
                 params["use_sample"] = True


### PR DESCRIPTION
## Description ##

This PR aims to fixes the Neo failures for this model configuration. https://github.com/deepjavalibrary/djl-serving/blob/255408edc13d1a01903b6206bcabeca04291312a/tests/integration/llm/prepare.py#L1345 

- During partition, since no rolling_batch option is specified, the default setting of disable is used, and the model is compiled accordingly.
- During inference, Java side, has LMI smart default capability, which assigns the rolling batch option to auto.
Since compiled configuration is different from inference configuration, the hash values of the neff files are different, hence it fails.

### Fix:
- In this PR, we are setting rolling batch as auto in smart defaults, so when partitioning, the default becomes `auto` for `option.rolling_batch`
- We recently added validations that input should be string for rolling batch. In our test client, if the batch size is 1, then sending the input as string. 

### Testing:
- Tested the neo use case manually in my EC2 machine. 

### Next:
- In the next PR, will change the default for rolling_batch to auto in here. https://github.com/deepjavalibrary/djl-serving/blob/83b6fb74b6c50c6a14026e70a6c08f4f5f507add/engines/python/setup/djl_python/properties_manager/properties.py#L51. 
