### PR TITLE
Fixed sagemaker_llm_benchmark workflow configuration

### DIFF
--- a/.github/workflows/sagemaker_llm_benchmark.yml
+++ b/.github/workflows/sagemaker_llm_benchmark.yml
@@ -1,6 +1,7 @@
 name: SageMaker LLM Benchmark
 
 on:
+   workflow_dispatch:
    schedule:
      - cron: '0 17 * * 5' # Run every Friday at 5pm
 
@@ -21,12 +22,22 @@ jobs:
           --fail \
           | jq '.token' | tr -d '"' )
           ./start_instance.sh action_cpu $token djl-serving
+      - name: Create new CPU instance
+        id: create_cpu2
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_cpu $token djl-serving
     outputs:
       cpu_instance_id1: ${{ steps.create_cpu1.outputs.action_cpu_instance_id }}
+      cpu_instance_id2: ${{ steps.create_cpu2.outputs.action_cpu_instance_id }}
       
   endpoint-tests:
     runs-on: [ self-hosted, cpu ]
-    timeout-minutes: 120
+    timeout-minutes: 720  
     needs: create-runners
     strategy:
       fail-fast: false
@@ -39,37 +50,39 @@ jobs:
         with:
           python-version: '3.10.x'
       - name: Install pip dependencies
-        run: pip3 install -U boto3 awscli
+        run: pip3 install -U boto3 awscli IPython
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
           aws-region: us-west-2
+          role-duration-seconds: 43200 
       - name: Install IR-LLM
         working-directory: tests/integration/benchmark/ir-llm
         run: |
-          aws s3 cp s3://sagemaker-python-sdk-ir-llm/sagemaker-latest.dev0-py3-none-any.whl .
-          aws s3 cp s3://sagemaker-python-sdk-ir-llm/sagemaker.normal.json .
-          aws s3 cp s3://djl-accounts/hf_token .
+          aws s3 cp s3://sagemaker-python-sdk-ir-llm/sagemaker-2.227.1.dev0-py3-none-any.whl . --source-region us-east-1
+          aws s3 cp s3://sagemaker-python-sdk-ir-llm/sagemaker-2017-07-24.normal.json . --source-region us-east-1
+          aws s3 cp s3://djl-accounts/hf_token . --source-region us-east-1
           export HF_TOKEN=$(head -n1 hf_token|cut -d '=' -f2)
-          pip3 install --quiet sagemaker-latest.dev0-py3-none-any.whl
-          aws configure add-model --service-model file://sagemaker.normal.json  --service-name sagemaker
+          pip3 install --quiet sagemaker-2.227.1.dev0-py3-none-any.whl
+          aws configure add-model --service-model file://sagemaker-2017-07-24.normal.json --service-name sagemaker
       - name: Prepare dir to store metrics
         working-directory: tests/integration/benchmark/ir-llm
         run: |
-          METRICS_DIR = "metrics_${{ matrix.engine}}"
-          if [ ! -d "${METRICS_DIR}" ]; then
-            mkdir -p "${METRICS_DIR}"
-            echo "Directory ${METRICS_DIR} created."
+          METRICS_DIR="metrics_${{ matrix.engine }}"
+          if [ ! -d "$METRICS_DIR" ]; then
+            mkdir -p "$METRICS_DIR"
+            echo "Directory '$METRICS_DIR' created."
           else
-            echo "Directory ${METRICS_DIR} already exists."
+            echo "Directory '$METRICS_DIR' already exists."
           fi
       - name: Run IR-LLM
+        working-directory: tests/integration/benchmark/ir-llm
         run: |
-          METRICS_DIR = "metrics_${{ matrix.engine}}"
-          CONFIG_DIR = "config/${{ matrix.engine}}"
+          METRICS_DIR="metrics_${{ matrix.engine }}"
+          CONFIG_DIR="config/${{ matrix.engine }}"
 
-          python3 scripts/cw_metrics.py -j $CONFIG_DIR}/config.yml -c ${CONFIG_DIR}/config_ir_job -m  ${METRICS_DIR}
+          python3 scripts/cw_metrics.py -j ${CONFIG_DIR}/config.yml -c ${CONFIG_DIR}/config_ir_job -m ${METRICS_DIR}
           echo "sleep 30 seconds to allow endpoint deletion"
           sleep 30
 

--- a/tests/integration/benchmark/ir-llm/config/lmi-dist/config.yml
+++ b/tests/integration/benchmark/ir-llm/config/lmi-dist/config.yml
@@ -123,11 +123,11 @@ benchmarks:
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-405b-fp8.json"
         dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
-        action: no 
+        action: yes 
   - model: "Llama-3.1-405b-instruct-fp8"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-405b-instruct-fp8.json"
         dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
-        action: no 
+        action: yes 

--- a/tests/integration/benchmark/ir-llm/config/lmi-dist/config.yml
+++ b/tests/integration/benchmark/ir-llm/config/lmi-dist/config.yml
@@ -4,7 +4,7 @@ cloudwatch:
   metrics_namespace: "SageMaker_LLM_Benchmark"
 
 s3:
-  bucket_name: "djl-benchmark"
+  bucket_name: "djl-benchmark-llm"
   folder: "sm-lmi-dist"
 
 metrics:
@@ -66,68 +66,68 @@ benchmarks:
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-8b.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-8b-suzuka"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_LMI_V12_Llama-3-1-8b-suzuka.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_base_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_payload_en_500-1000.tar.gz"
         action: no 
   - model: "Llama-3.1-8b-instruct"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-8b-instruct.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-8b-instruct-suzuka"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_LMI_V12_Llama-3-1-8b-instruct-suzuka.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_instruct_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_payload_en_500-1000.tar.gz"
         action: no 
   - model: "Llama-3.1-70b"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-70b.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-70b-suzuka"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_LMI_V12_Llama-3-1-70b-suzuka.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_base_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_payload_en_500-1000.tar.gz"
         action: no 
   - model: "Llama-3.1-70b-instruct"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-70b-instruct.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-70b-instruct-suzuka"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_LMI_V12_Llama-3-1-70b-instruct-suzuka.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_instruct_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_payload_en_500-1000.tar.gz"
         action: no 
   - model: "Llama-3.1-405b-fp8"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-405b-fp8.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_base_sample_payload_en_500-1000.tar.gz"
         action: no 
   - model: "Llama-3.1-405b-instruct-fp8"
     endpoints: 
       - endpoint: "sagemaker"
         image: "LMI-dist"
         config: "benchmark_config_passive_Llama-3-1-405b-instruct-fp8.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_instruct_sample_payload_en_500-1000.tar.gz"
         action: no 

--- a/tests/integration/benchmark/ir-llm/config/trtllm/config.yml
+++ b/tests/integration/benchmark/ir-llm/config/trtllm/config.yml
@@ -4,7 +4,7 @@ cloudwatch:
   metrics_namespace: "SageMaker_LLM_Benchmark"
 
 s3:
-  bucket_name: "djl-benchmark"
+  bucket_name: "djl-benchmark-llm"
   folder: "sm-trtllm"
 
 metrics:
@@ -67,40 +67,40 @@ benchmarks:
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-8b.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-8b-instruct"
     endpoints: 
       - endpoint: "sagemaker"
         image: "TRTLLM-v12-8192-sample"
         config: "benchmark_config_Llama-3-1-8b-instruct.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
         action: yes 
   - model: "Llama-3.1-70b"
     endpoints: 
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-70b.json"
-        dataset: "s3://ddjl-benchmark-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://ddjl-benchmark-llm-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
         action: yes  
   - model: "Llama-3.1-70b-instruct"
     endpoints:  
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-70b-instruct.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
         action: yes   
   - model: "Llama-3.1-405b-fp8"
     endpoints: 
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-405b-fp8.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
         action: no
   - model: "Llama-3.1-405b-instruct-fp8"
     endpoints: 
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-405b-instruct-fp8.json"
-        dataset: "s3://djl-benchmark-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
         action: no 

--- a/tests/integration/benchmark/ir-llm/config/trtllm/config.yml
+++ b/tests/integration/benchmark/ir-llm/config/trtllm/config.yml
@@ -72,7 +72,7 @@ benchmarks:
   - model: "Llama-3.1-8b-instruct"
     endpoints: 
       - endpoint: "sagemaker"
-        image: "TRTLLM-v12-8192-sample"
+        image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-8b-instruct.json"
         dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_instruct_sample_payload_en_500-1000.tar.gz"
         action: yes 
@@ -81,7 +81,7 @@ benchmarks:
       - endpoint: "sagemaker"
         image: "TRTLLM"
         config: "benchmark_config_Llama-3-1-70b.json"
-        dataset: "s3://ddjl-benchmark-llm-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
+        dataset: "s3://djl-benchmark-llm-datasets/openorca/openorca_trtllm_base_sample_payload_en_500-1000.tar.gz"
         action: yes  
   - model: "Llama-3.1-70b-instruct"
     endpoints:  


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

This PR includes:
- extend workflow and aws client session timeout
- add one runner to parallel lmi-dist and trtllm benchmark
- fix typos

Test:
- https://github.com/deepjavalibrary/djl-serving/actions/runs/12001588530
- Cloudwatch dashboards

1. SM_LLM_benchmark_LMI_Llama-405b-fp8-series 
2. SM_LLM_benchmark_LMI_Llama-70b-series
3. SM_LLM_benchmark_LMI_Llama-8b-series
4. SM_LLM_benchmark_TRTLLM_Llama-405b-fp8-series
5. SM_LLM_benchmark_TRTLLM_Llama-70b-series
6. SM_LLM_benchmark_TRTLLM_Llama-8b-series
