### PR TITLE
[python][fix] check whether config has enable_lora attribute

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -198,7 +198,8 @@ def add_server_maintained_params(request_input: RequestInput,
 
 def parse_adapters(request_input: TextInput, input_item: Input,
                    input_map: Dict, **kwargs):
-    if kwargs.get("configs").enable_lora:
+    configs = kwargs.get("configs")
+    if hasattr(configs, "enable_lora") and configs.enable_lora:
         adapter_registry = kwargs.get("adapter_registry")
         input_len = len(request_input.input_text) if isinstance(
             request_input.input_text, list) else 1


### PR DESCRIPTION
## Description ##

Neuronx unit tests cases are failing because of this. `enable_lora` is only available in lmi_dist and vllm as of now. Lora is not supported in neuron yet. 
