### PR TITLE
[neo] Correct enforce_eager default for LMI sharding

### DIFF
--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -108,7 +108,7 @@ class NeoShardingService():
         gpu_memory_utilization = float(
             self.properties.get("option.gpu_memory_utilization", 0.9))
         enforce_eager: bool = self.properties.get("option.enforce_eager",
-                                                  "true").lower() == "true"
+                                                  "false").lower() == "true"
         max_rolling_batch_size = int(
             self.properties.get("option.max_rolling_batch_size", 256))
         max_model_len = self.properties.get("option.max_model_len", None)


### PR DESCRIPTION
Change the default value of `enforce_eager` to false during Fast Model Loader AOT sharding, to [match LMI-Dist's runtime default](https://github.com/deepjavalibrary/djl-serving/blob/6a29680b1267939cdcb05049293a161967c213ce/engines/python/setup/djl_python/properties_manager/lmi_dist_rb_properties.py#L37). This will help GPU memory usage parity between AOT and runtime.