### PR TITLE
[docker] pin huggingface-hub to 0.25.1

### DIFF
--- a/serving/docker/deepspeed.Dockerfile
+++ b/serving/docker/deepspeed.Dockerfile
@@ -28,6 +28,7 @@ ARG bitsandbytes_version=0.41.1
 ARG optimum_version=1.15.0
 ARG auto_gptq_version=0.5.1
 ARG datasets_version=2.17.1
+ARG huggingface_hub_version=0.25.1
 # DeepSpeed Deps
 ARG deepspeed_version=0.12.6
 ARG deepspeed_wheel="https://publish.djl.ai/deepspeed/deepspeed-${deepspeed_version}-cp310-cp310-linux_x86_64.whl"
@@ -90,7 +91,7 @@ RUN pip3 install torch==${torch_version} torchvision==${torch_vision_version} --
     ${deepspeed_wheel} ${seq_scheduler_wheel} ${peft_wheel} ${mmaploader_wheel} ${aiccl_wheel} protobuf==${protobuf_version} \
     transformers==${transformers_version} hf-transfer zstandard datasets==${datasets_version} \
     mpi4py sentencepiece tiktoken blobfile einops accelerate==${accelerate_version} bitsandbytes==${bitsandbytes_version} \
-    optimum==${optimum_version} auto-gptq==${auto_gptq_version} pandas pyarrow jinja2 \
+    optimum==${optimum_version} auto-gptq==${auto_gptq_version} pandas pyarrow jinja2 huggingface-hub==${huggingface_hub_version} \
     diffusers[torch]==${diffusers_version} opencv-contrib-python-headless safetensors scipy && \
     pip3 cache purge
 

--- a/serving/docker/pytorch-inf2.Dockerfile
+++ b/serving/docker/pytorch-inf2.Dockerfile
@@ -26,6 +26,7 @@ ARG diffusers_version=0.26.1
 ARG pydantic_version=2.6.1
 ARG optimum_neuron_version=0.0.20
 ARG numpy_version=1.26.4
+ARG huggingface_hub_version=0.25.1
 EXPOSE 8080
 
 # Sets up Path for Neuron tools
@@ -76,7 +77,7 @@ RUN mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     neuronx_distributed==${neuronx_distributed_version} protobuf==${protobuf_version} sentencepiece jinja2 \
     diffusers==${diffusers_version} opencv-contrib-python-headless  Pillow --extra-index-url=https://pip.repos.neuron.amazonaws.com \
     pydantic==${pydantic_version} optimum optimum-neuron==${optimum_neuron_version} tiktoken blobfile \
-    torchvision==${torchvision_version} && \
+    torchvision==${torchvision_version} huggingface-hub==${huggingface_hub_version} && \
     pip install numpy==${numpy_version} && \
     scripts/install_s5cmd.sh x64 && \
     scripts/patch_oss_dlc.sh python && \

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -31,6 +31,7 @@ ARG janus_version=1.0.0
 ARG pynvml_verison=11.5.0
 ARG numpy_version=1.26.4
 ARG datasets_version=2.17.1
+ARG huggingface_hub_version=0.25.1
 
 EXPOSE 8080
 
@@ -75,7 +76,7 @@ RUN apt-get update && apt-get install -y g++ wget unzip openmpi-bin libopenmpi-d
 # Qwen needs transformers_stream_generator, tiktoken and einops
 RUN pip install torch==${TORCH_VERSION} transformers==${transformers_version} accelerate==${accelerate_version} ${peft_wheel} sentencepiece \
     mpi4py cuda-python==${cuda_python_version} onnx polygraphy pynvml==${pynvml_verison} datasets==${datasets_version} pydantic==${pydantic_version} scipy torchprofile bitsandbytes ninja \
-    transformers_stream_generator einops tiktoken jinja2 graphviz blobfile && \
+    transformers_stream_generator einops tiktoken jinja2 graphviz blobfile huggingface-hub==${huggingface_hub_version} && \
     pip3 cache purge
 
 # Install TensorRT and TRT-LLM Deps


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works? 
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Test failure run is here https://github.com/deepjavalibrary/djl-serving/actions/runs/12247196620/job/34164824528.

I validated stable diffusion works with this change:
```
python llm/prepare.py stable-diffusion stable-diffusion-2-1-base
./launch_container.sh deepjavalibrary/djl-serving:deepspeed ./models/ deepspeed
+ false
+ [[ deepjavalibrary/djl-serving:deepspeed == *\t\e\x\t\-\g\e\n\e\r\a\t\i\o\n\-\i\n\f\e\r\e\n\c\e* ]]
++ whoami
+ echo 'ubuntu, UID: 1000'
ubuntu, UID: 1000
+ [[ 1000 == \1\0\0\0 ]]
+ uid_mapping='-u djl'
++ docker run <args omitted for brevity>
+ container_id=9097b807c7fae646c59cc613614d5ab6565d495d05401c276bc0f2e559cf7e7d
+ set +x
Launching 9097b807c7fae646c59cc613614d5ab6565d495d05401c276bc0f2e559cf7e7d...
extra sleep for 2 min on LLM models
Start pinging to the host... Retry: 0
DJL serving started

python llm/client.py stable-diffusion stable-diffusion-2-1-base
INFO:root:req: {'prompt': 'A bird and cat flying through space', 'parameters': {'height': 256, 'width': 256, 'num_inference_steps': 50}}
INFO:root:Used memory per GPU: [2.9423828125, 2.9384765625, 3.1591796875, 3.1630859375]
INFO:root:req: {'prompt': 'A bird and cat flying through space', 'parameters': {'height': 256, 'width': 256, 'num_inference_steps': 100}}
INFO:root:Used memory per GPU: [3.1708984375, 3.1669921875, 3.1591796875, 3.1630859375]
INFO:root:req: {'prompt': 'A bird and cat flying through space', 'parameters': {'height': 512, 'width': 512, 'num_inference_steps': 50}}
INFO:root:Used memory per GPU: [3.1708984375, 3.1669921875, 3.7861328125, 3.7900390625]
INFO:root:req: {'prompt': 'A bird and cat flying through space', 'parameters': {'height': 512, 'width': 512, 'num_inference_steps': 100}}
INFO:root:Used memory per GPU: [3.7978515625, 3.7939453125, 3.7861328125, 3.7900390625]
```

