### PR TITLE
[fix] return prompt from get_prompt_inputs utility method

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -326,3 +326,4 @@ def get_prompt_inputs(request: Request):
 
     if multi_modal_data is not None:
         prompt["multi_modal_data"] = multi_modal_data
+    return prompt


### PR DESCRIPTION
## Description ##

There was a missing return in the utility method that formats the request for vllm/lmi-dist.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [ x] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [x ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works? 
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Before this change, an inference request would result in:
```
INFO  PyProcess W-1674-08a20b291e447c9-stdout: INFO::[RequestId=d43e0d40-5a8f-4bb8-b588-de2f08976c93] parsed and scheduled for inference
INFO  PyProcess W-1674-08a20b291e447c9-stdout: ERROR::Rolling batch inference error. There are 1 requests impacted. Dumping the impacted requestIds
INFO  PyProcess W-1674-08a20b291e447c9-stdout: Traceback (most recent call last):
INFO  PyProcess W-1674-08a20b291e447c9-stdout:   File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/rolling_batch/rolling_batch.py", line 47, in try_catch_handling
INFO  PyProcess W-1674-08a20b291e447c9-stdout:     return func(self, *args, **kwargs)
INFO  PyProcess W-1674-08a20b291e447c9-stdout:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-1674-08a20b291e447c9-stdout:   File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/rolling_batch/vllm_rolling_batch.py", line 137, in inference
INFO  PyProcess W-1674-08a20b291e447c9-stdout:     self.engine.add_request(request_id=request_id,
INFO  PyProcess W-1674-08a20b291e447c9-stdout:   File "/usr/local/lib/python3.11/dist-packages/vllm/utils.py", line 1063, in inner
INFO  PyProcess W-1674-08a20b291e447c9-stdout:     return fn(*args, **kwargs)
INFO  PyProcess W-1674-08a20b291e447c9-stdout:            ^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-1674-08a20b291e447c9-stdout:   File "/usr/local/lib/python3.11/dist-packages/vllm/engine/llm_engine.py", line 792, in add_request
INFO  PyProcess W-1674-08a20b291e447c9-stdout:     assert prompt is not None and params is not None
INFO  PyProcess W-1674-08a20b291e447c9-stdout:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INFO  PyProcess W-1674-08a20b291e447c9-stdout: AssertionError
```

Now we get:
```
INFO  PyProcess W-2153-08a20b291e447c9-stdout: INFO::[RequestId=032b931d-17ee-4758-aa01-0aee01f926ec] parsed and scheduled for inference
```