### PR TITLE
add new github workflow files for the new nightly workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,103 @@
+name: Build and push docker nightly to temp ECR repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+          - nightly
+          - release
+  workflow_call:
+    inputs:
+      mode:
+        description: 'release/nightly, default is nightly'
+        type: string
+        required: true
+        default: 'nightly'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_ECR_REPO: "185921645874.dkr.ecr.us-east-1.amazonaws.com/djl-ci-temp"
+
+jobs:
+  create-aarch64-runner:
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new Graviton instance
+        id: create_aarch64
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_graviton $token djl-serving
+    outputs:
+      aarch64_instance_id: ${{ steps.create_aarch64.outputs.action_graviton_instance_id }}
+
+  nightly-aarch64:
+    runs-on: [ self-hosted, aarch64 ]
+    timeout-minutes: 60
+    needs: create-aarch64-runner
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean docker env
+        working-directory: serving/docker
+        run: |
+          yes | docker system prune -a --volumes
+      - name: Login to Docker
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: install awscli
+        run: |  
+          sudo apt-get update
+          sudo apt-get install awscli -y
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::185921645874:role/github-actions-djl-serving
+          aws-region: us-east-1
+      - name: Pull and sync to docker hub
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          ECR_REGION=$(echo "${{ env.AWS_ECR_REPO }}" | awk -F. '{print $4}')
+          aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${{env.AWS_ECR_REPO}}
+          ./scripts/pull_and_retag.sh $DJL_VERSION deepjavalibrary/djl-serving ${{ inputs.mode }}
+      - name: Pull and sync to ECR
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          repo="125045733377.dkr.ecr.us-east-1.amazonaws.com/djl-serving"
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo
+          ./scripts/pull_and_retag.sh $DJL_VERSION $repo ${{ inputs.mode }}
+      - name: Retag image for release latest
+        if: ${{ inputs.mode == 'release' }}
+        working-directory: serving/docker
+        run: |
+          DJL_VERSION=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' ../../gradle/libs.versions.toml)
+          docker tag deepjavalibrary/djl-serving:${DJL_VERSION} deepjavalibrary/djl-serving:latest
+          docker push deepjavalibrary/djl-serving:latest
+      - name: Clean docker env
+        working-directory: serving/docker
+        run: |
+          yes | docker system prune -a --volumes
+  stop-aarch64-runner:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [nightly-aarch64, create-aarch64-runner]
+    steps:
+      - name: Stop all instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-aarch64-runner.outputs.aarch64_instance_id }}
+          ./stop_instance.sh $instance_id

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+name: Nightly Pipeline
+
+on:
+    workflow_dispatch:
+        inputs:
+            mode:
+                description: 'release/nightly, default is nightly'
+                required: true
+                default: 'nightly'
+                type: choice
+                options:
+                - nightly
+                - release
+    workflow_call:
+        inputs:
+            mode:
+                description: 'release/nightly, default is nightly'
+                type: string
+                required: true
+                default: 'nightly'
+    schedule:
+        - cron: '0 13 * * *'
+
+
+permissions:
+    id-token: write
+    contents: read
+    
+jobs:
+    build:
+        uses: ./.github/workflows/docker-nightly-publish.yml
+        secrets: inherit
+        with:
+            mode: ${{ inputs.mode }}
+    get_image_tag_suffix:
+        outputs:
+            test_image_tag_suffix: ${{ steps.get_image_tag_suffix.test_image_tag_suffix }}
+        needs: [build]
+        runs-on: ubuntu-latest
+        steps:
+            - name: get_image_tag_suffix
+              id: get_image_tag_suffix
+              run: |
+                if ${{ inputs.mode == 'nightly'}}; then
+                    test_image_tag_suffix='nightly'
+                fi
+                if ${{ inputs.mode == 'release'}}; then
+                    test_image_tag_suffix='${{ needs.build.outputs.djl_version}}-${GITHUB_RUN_ID}'
+                fi
+                echo "test_image_tag_suffix=$test_image_tag_suffix" >> $GITHUB_OUTPUT
+    integration-test:
+        needs: [get_image_tag_suffix]
+        uses: ./.github/workflows/integration.yml
+        secrets: inherit
+        with:
+            tag-suffix:: ${{ needs.get_image_tag_suffix.outputs.test_image_tag_suffix }}
+    publish:
+        needs: [integration-test, get_image_tag_suffix]
+        uses: ./.github/workflows/docker_publish.yml
+        secrets: inherit
+        with:
+            mode: ${{ inputs.mode }}


### PR DESCRIPTION
## Description ##

add new github workflow for the new nightly workflow so we can start testing runs .
in order for developer to start a new run, github requires yml files to be in the mainline 

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)




## Checklist:

- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works? 
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
