### PR TITLE
fix ecr push script to tag image after pull and before push

### DIFF
--- a/serving/docker/scripts/push_image_from_ECR.sh
+++ b/serving/docker/scripts/push_image_from_ECR.sh
@@ -36,5 +36,5 @@ if [[ "$mode" == "nightly" ]]; then
   tag="$image-nightly"
 fi
 docker pull $from_repo:$image-$mode-$commit_sha
-echo docker tag $from_repo:$image-$mode-$commit_sha $to_repo:$tag
+docker tag $from_repo:$image-$mode-$commit_sha $to_repo:$tag
 docker push $to_repo:$tag


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

The image retagging doesn't occur because of an echo. Removing it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
