### PR TITLE
[lmi][vllm] do not require do_sample to enable sampling

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -154,28 +154,27 @@ class LmiDistRollingBatch(RollingBatch):
         :return: The same parameters dict, but with lmi-dist style parameter names.
         """
         parameters["max_tokens"] = parameters.pop("max_new_tokens", 30)
-        # If `do_sample` is not provided, force temperature=0.0, i.e. greedy
-        # else set to user-provided value or default to 1.0
-        if not parameters.pop('do_sample', False):
-            parameters['temperature'] = 0.0
-        else:
-            parameters['temperature'] = parameters.get('temperature', 1.0)
+        do_sample = parameters.pop("do_sample", None)
+        if do_sample is not None and do_sample is False:
+            parameters["temperature"] = 0.0
+        if do_sample is None and parameters.get("temperature") is None:
+            parameters["temperature"] = 0.0
         if "seed" in parameters.keys():
             parameters["seed"] = int(parameters["seed"])
-        if "stop_sequences" in parameters.keys():
+        if "stop_sequences" in parameters:
             parameters["stop"] = parameters.pop("stop_sequences")
-        if "ignore_eos_token" in parameters.keys():
+        if "ignore_eos_token" in parameters:
             parameters["ignore_eos"] = parameters.pop("ignore_eos_token")
-        if "num_beams" in parameters.keys():
+        if "num_beams" in parameters:
             parameters["best_of"] = parameters.pop("num_beams")
             parameters["use_beam_search"] = True
         if parameters.pop("decoder_input_details", False):
             parameters["prompt_logprobs"] = 1
-        if "best_of" in parameters.keys():
+        if "best_of" in parameters:
             # if n is not explicitly set, we return `best_of` values sequences.
             if "n" not in "best_of":
                 parameters["n"] = parameters["best_of"]
-        if "top_n_tokens" in parameters.keys():
+        if "top_n_tokens" in parameters:
             parameters["logprobs"] = parameters.pop("top_n_tokens")
         else:
             parameters["logprobs"] = parameters.get("logprobs", 1)

--- a/serving/docs/lmi/user_guides/lmi_input_output_schema.md
+++ b/serving/docs/lmi/user_guides/lmi_input_output_schema.md
@@ -289,6 +289,11 @@ If you are not specifying a specific engine or rolling batch implementation, we 
 
 If you are deploying with a specific backend, additional parameters are available that are unique to the specific backend.
 
+**Note:** 
+To enable sampling in LMI <= 0.31.0, you must specify `do_sample: true` in addition to any sampling parameters you set.
+This behavior will change starting LMI 0.32.0 where you will no longer be required to set `do_sample`,
+it will be inferred from the other sampling parameters.
+
 #### Additional LMI Dist Generation parameters
 
 ```


### PR DESCRIPTION
## Description ##

This change removes the need for `do_sample` to be set explicitly for sampling to occur. Previously, sampling parameters would be ignored unless do_sample was set to true. While that behavior did follow the transformers behavior, it is no longer what users expect.

We will still respect do_sample: false as a greedy sampling indicator.

I also removed the .keys() from this method as it's unnecessary. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
