### PR TITLE
[fix][trtllm] only import vllm chat processing when required

### DIFF
--- a/engines/python/setup/djl_python/input_parser.py
+++ b/engines/python/setup/djl_python/input_parser.py
@@ -16,7 +16,6 @@ from typing import List, Dict, Optional, Callable
 
 from djl_python import Input
 from djl_python.chat_completions.chat_utils import is_chat_completions_request, parse_chat_completions_request
-from djl_python.chat_completions.vllm_chat_utils import parse_chat_completions_request_vllm
 from djl_python.encode_decode import decode
 from djl_python.properties_manager.properties import is_rolling_batch_enabled
 from djl_python.request import Request
@@ -144,6 +143,8 @@ def parse_text_inputs_params(request_input: TextInput, input_item: Input,
         rolling_batch = kwargs.get("rolling_batch")
         if rolling_batch is not None and rolling_batch.use_vllm_chat_completions(
         ):
+            # we only import this here as we know we're in a vllm context - ensures no bad imports for trtllm
+            from djl_python.chat_completions.vllm_chat_utils import parse_chat_completions_request_vllm
             inputs, param = parse_chat_completions_request_vllm(
                 input_map,
                 kwargs.get("is_rolling_batch"),


### PR DESCRIPTION
## Description ##

This change imports the vllm chat processing only when required. This will fix the trtllm integ tests failures.

Sample failure https://github.com/deepjavalibrary/djl-serving/actions/runs/12950279922/job/36124428030

```
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:Traceback (most recent call last):
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python_engine.py", line 204, in main
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    model_service = load_model_service(args.model_dir, entry_point,
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/service_loader.py", line 48, in load_model_service
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    module = importlib.import_module(entry_point)
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    return _bootstrap._gcd_import(name[level:], package, level)
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/tensorrt_llm.py", line 19, in <module>
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    from djl_python.input_parser import parse_input_with_formatter
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/input_parser.py", line 19, in <module>
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    from djl_python.chat_completions.vllm_chat_utils import parse_chat_completions_request_vllm
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/chat_completions/vllm_chat_utils.py", line 15, in <module>
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    from djl_python.chat_completions.vllm_chat_properties import ChatProperties
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:  File "/tmp/.djl.ai/python/0.32.0-SNAPSHOT/djl_python/chat_completions/vllm_chat_properties.py", line 15, in <module>
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:    from vllm.entrypoints.openai.protocol import ChatCompletionRequest
[INFO ] 2025-01-24 15:45:48 PyProcess - W-10627-test-stdout: [1,3]<stdout>:ModuleNotFoundError: No module named 'vllm'
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
