### PR TITLE
[fix][ci] install awscli via pip due to issues with using apt

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -83,10 +83,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: install awscli
+      - name: Set up Python3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.x'
+      - name: Install pip dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install awscli -y
+          python -m pip install --upgrade pip
+          pip install awscli
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,28 +224,14 @@ jobs:
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/Java_Corretto_jdk/
           echo "wait dpkg lock..."
           while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 5; done
-      - name: install awscli
-        run: |
-          sudo apt-get update
-          sudo apt-get install awscli -y
       - name: Set up Python3
-        if: ${{ matrix.test.instance != 'aarch64' }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.10.x'
-      - name: Set up Python3 (aarch64)
-        if: ${{ matrix.test.instance == 'aarch64' }}
-        run: |
-          # Using an alternate installation because of an incompatible combination
-          # of aarch64 with ubuntu-20.04 not supported by the actions/setup-python
-          sudo apt-get install python3 python-is-python3 python3-pip -y
       - name: Install pip dependencies
-        run: pip3 install pytest requests "numpy<2" pillow huggingface_hub
-      - name: Install torch
-        # Use torch to get cuda capability of current device to selectively run tests
-        # Torch version doesn't really matter that much
         run: |
-          pip3 install torch==2.3.0
+          python -m pip install --upgrade pip
+          pip install pytest requests "numpy<2" pillow huggingface_hub awscli torch
       - name: Install awscurl
         working-directory: tests/integration
         run: |


### PR DESCRIPTION
## Description ##

This fixes an issue with the nightly pipeline. Two workflows are currently failing due to not finding awscli in apt. This changes the installation of awscli from apt to python via pip.

I'll scan the other workflows and make the same change as necessary - getting this one out now to restore failures in container CI.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
