### PR TITLE
[ci] enforce execution of awscurl executable file

### DIFF
--- a/awscurl/build.gradle.kts
+++ b/awscurl/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
                         "-c",
                         "cat src/main/scripts/stub.sh build/libs/awscurl*.jar > build/awscurl && chmod +x build/awscurl"
                     )
-                }
+                }.result.get()
             }
         }
     }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- This fixes the `serving.publish` CI failures. https://github.com/deepjavalibrary/djl-serving/actions/workflows/serving-publish.yml. 
- We recently changed awscurl executable build to be async. i.e we changed from exec to providers.exec. Here `result.get()`, we are forcing the execution and retrieving the result of the shell command.

CI after this PR: https://github.com/deepjavalibrary/djl-serving/actions/workflows/serving-publish.yml

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
