### PR TITLE
[python] return neuron cores instead of neuron devices

### DIFF
--- a/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/neuron_utils/neuron_smart_default_utils.py
@@ -112,7 +112,9 @@ class NeuronSmartDefaultUtils:
         command = "neuron-ls --json-output"
         try:
             output = sp.check_output(command, shell=True).decode("utf-8")
-            return len(json.loads(output))
+            output = json.loads(output)
+            neuron_cores = sum(device.get("nc_count", 0) for device in output)
+            return neuron_cores
         except Exception as e:
             logger.debug(f"Failed to get available cores: {e}")
         return 0

--- a/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_smart_default_utils.py
+++ b/engines/python/setup/djl_python/tests/neuron_test_scripts/test_neuron_smart_default_utils.py
@@ -66,8 +66,10 @@ class TestNeuronSmartDefaultUtils(unittest.TestCase):
 
     def test_get_available_cores(self):
         with patch('subprocess.check_output') as mock_check_output:
-            mock_check_output.return_value = b'[{"core": 0}, {"core": 1}, {"core": 2}, {"core": 3}]'
-            assert NeuronSmartDefaultUtils.get_available_cores() == 4
+            mock_check_output.return_value = (
+                b'[{"core": 0, "nc_count": 2}, {"core": 1, "nc_count": 2}, '
+                b'{"core": 2, "nc_count": 2}, {"core": 3, "nc_count": 2}]')
+            assert NeuronSmartDefaultUtils.get_available_cores() == 8
 
     def test_get_available_cores_exception(self):
         with patch('subprocess.check_output') as mock_check_output:


### PR DESCRIPTION
## Description ##

In Tranium or Inferentia devices, each neuron devices has multiple neuron cores, usualy 2 cores per device. Tensor parallel degree is specified in terms of neuron cores. 

Here this method get_available_cores, is supposed to return the neuron cores, and we use this to set the default tp degree if one is not provided by the user. 

In this PR, we are fixing this method to return neuron cores, previously it was return the neuron devices. 

This PR, also fixes the CI which is failing for LCNC use case for AOT for tinyllama model. tp_degree is supposed to be 2, but we return 1 here, which causes the compilation to fail. This used to work in previous neuron sdk versions, even with tp_degree=1. So this seems to be regression in Neuron SDK 2.21. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
