### PR TITLE
[ci] convert lcnc test to use tp 2, till the issue is fixed in neuron…

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -239,6 +239,8 @@ transformers_neuronx_handler_list = {
         "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
         "option.rolling_batch": "auto",
         "option.model_loading_timeout": 3600,
+        # TODO: Remove this once neuron 2.21 issue if fixed.
+        "option.tensor_parallel_degree": 2,
     },
     "tiny-llama-rb-aot": {
         "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",


### PR DESCRIPTION
… sdk

## Description ##
https://github.com/aws-neuron/aws-neuron-sdk/issues/1100

This use case worked in 2.20 SDK, but it does not in 2.21. Looks like, this kind of issue had occurred in previous versions. https://github.com/aws-neuron/aws-neuron-sdk/issues/1023. I have raised an issue in aws neuron sdk regarding this. And tp_degree 1 is a valid use case. Till they fix it, we could add tp_degree = 2 in our test cases. 

And also, will update this in our release notes in the known issues section. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
