### PR TITLE
[python] move the default compile path to /tmp/.djl.ai

### DIFF
--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -142,10 +142,11 @@ class TransformersNeuronXService(object):
         if self.config.model_loader == "nxdi":
             os.environ[
                 'VLLM_NEURON_FRAMEWORK'] = "neuronx-distributed-inference"
-            djl_neuron_compiled_artifacts_path = os.path.join(os.getenv("DJL_CACHE_DIR", "/tmp/.djl.ai"),
-                                                              "neuron-compiled-artifacts")
+            djl_neuron_compiled_artifacts_path = os.path.join(
+                os.getenv("DJL_CACHE_DIR", "/tmp/.djl.ai"),
+                "neuron-compiled-artifacts")
             nxdi_compiled_model_path = os.path.join(
-                djl_neuron_compiled_artifacts_path, NXDI_COMPILED_MODEL_FILE_NAME)
+                self.config.model_id_or_path, NXDI_COMPILED_MODEL_FILE_NAME)
             if self.config.save_mp_checkpoint_path:
                 # If the compilation path is given by the user
                 os.environ[
@@ -155,7 +156,8 @@ class TransformersNeuronXService(object):
                 os.environ[
                     "NEURON_COMPILED_ARTIFACTS"] = self.config.model_id_or_path
             else:
-                os.environ["NEURON_COMPILED_ARTIFACTS"] = djl_neuron_compiled_artifacts_path
+                os.environ[
+                    "NEURON_COMPILED_ARTIFACTS"] = djl_neuron_compiled_artifacts_path
             return
 
         if self.config.model_loader == "vllm":

--- a/engines/python/setup/djl_python/transformers_neuronx.py
+++ b/engines/python/setup/djl_python/transformers_neuronx.py
@@ -142,14 +142,20 @@ class TransformersNeuronXService(object):
         if self.config.model_loader == "nxdi":
             os.environ[
                 'VLLM_NEURON_FRAMEWORK'] = "neuronx-distributed-inference"
+            djl_neuron_compiled_artifacts_path = os.path.join(os.getenv("DJL_CACHE_DIR", "/tmp/.djl.ai"),
+                                                              "neuron-compiled-artifacts")
+            nxdi_compiled_model_path = os.path.join(
+                djl_neuron_compiled_artifacts_path, NXDI_COMPILED_MODEL_FILE_NAME)
             if self.config.save_mp_checkpoint_path:
+                # If the compilation path is given by the user
                 os.environ[
                     "NEURON_COMPILED_ARTIFACTS"] = self.config.save_mp_checkpoint_path
-            nxdi_compiled_model_path = os.path.join(
-                self.config.model_id_or_path, NXDI_COMPILED_MODEL_FILE_NAME)
-            if os.path.isfile(nxdi_compiled_model_path):
+            elif os.path.isfile(nxdi_compiled_model_path):
+                # if the compilation path already exists
                 os.environ[
                     "NEURON_COMPILED_ARTIFACTS"] = self.config.model_id_or_path
+            else:
+                os.environ["NEURON_COMPILED_ARTIFACTS"] = djl_neuron_compiled_artifacts_path
             return
 
         if self.config.model_loader == "vllm":


### PR DESCRIPTION
## Description ##

In vllm, for JIT, they store the compiled artifacts in the model directory. Sometimes user's model directory could be readonly. So, this PR changes the user's model directory to /tmp/.djl.ai/neuron-compiled-artifacts

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
