### PR TITLE
Support different Python executables in Neo dispatcher

### DIFF
--- a/serving/docker/partition/sm_neo_dispatcher.py
+++ b/serving/docker/partition/sm_neo_dispatcher.py
@@ -25,6 +25,7 @@ LMI_DIST_VENV_EXEC = "/opt/djl/lmi_dist_venv/bin/python"
 VLLM_VENV_EXEC = "/opt/djl/vllm_venv/bin/python"
 SYSTEM_PY_EXEC = "/usr/bin/python3"
 
+
 class NeoTask(Enum):
     """
     Enum representing available Neo optimization tasks, including their names and script paths
@@ -79,7 +80,8 @@ class NeoDispatcher:
             return True
         return False
 
-    def _get_mpirun_command(self, task: NeoTask, num_processes: int, python_exec: str):
+    def _get_mpirun_command(self, task: NeoTask, num_processes: int,
+                            python_exec: str):
         return [
             "mpirun", "--allow-run-as-root", "--bind-to", "none", "--mca",
             "btl_vader_single_copy_mechanism", "none", "--tag-output", "-x",
@@ -129,7 +131,8 @@ class NeoDispatcher:
         match self.serving_features:
             case "vllm,lmi-dist":
                 if self.is_valid_sharding_config():
-                    if self.properties.get("option.rolling_batch", "lmi-dist").lower() == "vllm":
+                    if self.properties.get("option.rolling_batch",
+                                           "lmi-dist").lower() == "vllm":
                         python_exec = VLLM_VENV_EXEC
                     else:
                         python_exec = LMI_DIST_VENV_EXEC

--- a/serving/docker/partition/sm_neo_shard.py
+++ b/serving/docker/partition/sm_neo_shard.py
@@ -23,7 +23,6 @@ from sm_neo_utils import (OptimizationFatalError, write_error_to_file,
 from utils import (update_kwargs_with_env_vars, load_properties)
 
 import torch
-import sagemaker_fast_model_loader_rust as sm_fml
 from mpi4py import MPI
 
 from lmi_dist.init_engine import engine_from_args
@@ -50,6 +49,7 @@ class NeoShardingService():
 
     def save_configs(self, pp_degree: int, tp_degree: int, input_dir: str,
                      output_dir: str, configs: list) -> None:
+        import sagemaker_fast_model_loader_rust as sm_fml
         py_version = "{}.{}.{}".format(*sys.version_info[:3])
         conf = sm_fml.ModelConfig(
             pipeline_parallel_size=pp_degree,
@@ -160,6 +160,8 @@ class NeoShardingService():
         engine_configs = engine_args.create_engine_configs()
         engine_worker = load_model_for_sharding(engine_configs)
 
+        # Lazy import to avoid MPI not-inited errors
+        import sagemaker_fast_model_loader_rust as sm_fml
         model_dir = os.path.join(output_dir, sm_fml.MODEL_DIR_NAME)
         os.makedirs(model_dir, exist_ok=True)
 


### PR DESCRIPTION
## Description ##

Update the Neo dispatcher to account for different Python executables / venvs required by subprocesses, in accordance with #2690

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
