### PR TITLE
[python] move toolparsermanager to local imports

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -16,7 +16,6 @@ from typing import Optional, Any, Mapping, Tuple, Dict
 from pydantic import field_validator, model_validator
 
 from djl_python.properties_manager.properties import Properties
-from vllm.entrypoints.openai.tool_parsers import ToolParserManager
 
 
 class VllmRbProperties(Properties):
@@ -153,9 +152,10 @@ class VllmRbProperties(Properties):
 
     @model_validator(mode='after')
     def validate_tool_call_parser(self):
-        valid_tool_parses = ToolParserManager.tool_parsers.keys()
-        if self.enable_auto_tool_choice \
-                and self.tool_call_parser not in valid_tool_parses:
-            raise ValueError(
-                f"Invalid tool call parser: {self.tool_call_parser} "
-                f"(chose from {{ {','.join(valid_tool_parses)} }})")
+        if self.enable_auto_tool_choice:
+            from vllm.entrypoints.openai.tool_parsers import ToolParserManager
+            valid_tool_parses = ToolParserManager.tool_parsers.keys()
+            if self.tool_call_parser not in valid_tool_parses:
+                raise ValueError(
+                    f"Invalid tool call parser: {self.tool_call_parser} "
+                    f"(chose from {{ {','.join(valid_tool_parses)} }})")

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -14,8 +14,6 @@ from collections import OrderedDict, defaultdict
 
 from vllm import LLMEngine, SamplingParams
 from vllm.sampling_params import RequestOutputKind
-from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
-from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import random_uuid, AtomicCounter
 
 from djl_python.request import Request
@@ -56,8 +54,9 @@ class VLLMRollingBatch(RollingBatch):
         self.lora_id_counter = AtomicCounter(0)
         self.lora_requests = {}
         self.is_mistral_tokenizer = self.vllm_configs.tokenizer_mode == 'mistral'
-        self.tool_parser: Optional[Callable[[AnyTokenizer], ToolParser]] = None
+        self.tool_parser = None
         if self.vllm_configs.enable_auto_tool_choice:
+            from vllm.entrypoints.openai.tool_parsers import ToolParserManager
             try:
                 self.tool_parser = ToolParserManager.get_tool_parser(
                     self.vllm_configs.tool_call_parser)


### PR DESCRIPTION
## Description ##

Neuron vllm is still using 0.6.2, so ToolParse imports are failing for neuron test cases. So this PR, moves these to local imports to avoid problems for Neuron containers. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
