### PR TITLE
AutoFP8 to llmcompressor migration for FP8 quantization

### DIFF
--- a/serving/docker/lmi-container-requirements-common.txt
+++ b/serving/docker/lmi-container-requirements-common.txt
@@ -23,6 +23,7 @@ onnx
 sentence_transformers
 onnxruntime-gpu==1.20.0
 autoawq==0.2.5
+llmcompressor==0.3.1
 tokenizers==0.20.3
 pydantic==2.9.2
 optimum==1.23.2

--- a/serving/docker/partition/sm_neo_quantize.py
+++ b/serving/docker/partition/sm_neo_quantize.py
@@ -99,11 +99,16 @@ class NeoQuantizationService():
         """
         Updates outputted serving.properties.
 
+        ## tensor parallel degree & device_map
         We set option.tensor_parallel_degree & option.device_map for quantization.
         This function passes through these values to the outputted serving.properties if received from the customer.
         Otherwise, nothing is outputted for these values.
+
+        ## quantization
+        For FP8 quantization with llm-compressor, vllm requires quantization_method to be set to 'compressed-tensors'
         """
         passthrough_properties = {}
+        # checking if customer set property through envvar or serving.properties.
         passthrough_properties[
             "option.tensor_parallel_degree"] = os.environ.get(
                 "OPTION_TENSOR_PARALLEL_DEGREE") if os.environ.get(
@@ -126,6 +131,9 @@ class NeoQuantizationService():
                 logging.info(
                     f"User did not pass {k}. Outputted serving.properties "
                     "will not include this field.")
+
+        if output_properties.get("option.quantize") == "fp8":
+            output_properties["option.quantize"] = "compressed-tensors"
 
         self.properties_manager.properties = output_properties
         self.properties_manager.generate_properties_file()


### PR DESCRIPTION
## Description ##

Migrates existing FP8 quantization functionality to llmcompressor from AutoFP8. The existing quantization recipe is fp8 weights and activation quantization, with static activation scales. Uses cnn-dailymail for calibration, defaulting to 512 samples at 2048 seq len.

Installed the previous version of llm-compressor (0.3.1) due to an issue with compatibility between llm-compressor (0.4.0) and transformers 2.5.2, which is the current version in djl-serving.

## TODOs

- Update CI tests in lmi-distro to verify these changes.
- Remove AutoFP8 dependency from container.
- Future feature support (prioritization tbd)
    - MoE model quantization. (May run with exiting code, but will not ignore the correct layers)
    - KV cache quantization with static scales.
    - Calibration dataset selection
    - AWQ migration (not yet supported in llmcompressor)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [x] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

- Tested quantization of tinyllama with llmcompressor and serving with v14 v2 preview container through Neo workflow.

