### PR TITLE
[python] move nxdi logic to model loader

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -903,22 +903,6 @@ class TestNeuronxRollingBatch:
                 "transformers_neuronx_rolling_batch llama-speculative-compiled-rb"
                 .split())
 
-    def test_llama_8b_vllm_nxdi(self):
-        # For neuron, handler is names as transformers_neuronx, but this handler supports, TNX, NXDI and optimum.
-        with Runner('pytorch-inf2', 'llama-3-1-8b-instruct-vllm-nxdi') as r:
-            prepare.build_transformers_neuronx_handler_model(
-                "llama-3-1-8b-instruct-vllm-nxdi")
-            r.launch(
-                container="pytorch-inf2-4",
-                cmd=
-                "partition --model-dir /opt/ml/input/data/training --save-mp-checkpoint-path /opt/ml/input/data/training/aot --skip-copy"
-            )
-            r.launch(container="pytorch-inf2-4",
-                     cmd="serve -m test=file:/opt/ml/model/test/aot")
-            client.run(
-                "transformers_neuronx_rolling_batch llama-3-1-8b-instruct-vllm-nxdi"
-                .split())
-
     def test_llama_vllm_nxdi_aot(self):
         with Runner('pytorch-inf2',
                     'llama-3-2-1b-instruct-vllm-nxdi-aot') as r:
@@ -927,7 +911,7 @@ class TestNeuronxRollingBatch:
             r.launch(
                 container="pytorch-inf2-1",
                 cmd=
-                "partition --model-dir /opt/ml/input/data/training --save-mp-checkpoint-path /opt/ml/input/data/training/aot --skip-copy"
+                "partition --model-dir /opt/ml/input/data/training --save-mp-checkpoint-path /opt/ml/input/data/training/aot"
             )
             r.launch(container="pytorch-inf2-1",
                      cmd="serve -m test=file:/opt/ml/model/test/aot")


### PR DESCRIPTION
## Description ##

- Moving nxdi logic to a separate model loader. Initially I wanted to avoid introducing another model loader, but the default model loader is TNX Model loader. It does not cause any errors now, but there are some code and initialization done, that are not necessary. Keeping the execution clean would be better for the long run. 

- Removed vllm 8B test. Running AOT with 8B is stuck for some reason, but JIT compilation works. Still figuring out. Will add it back once I am able to figure it out. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
