### PR TITLE
[lmi] support auto configuration of mistral models provided as mistra…

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -683,12 +683,11 @@ lmi_dist_model_list = {
         "option.max_model_len": 8192,
     },
     "pixtral-12b": {
-        "option.model_id": "s3://djl-llm/pixtral-12b/",
+        "option.model_id": "s3://djl-llm/pixtral-12b-2409/",
         "option.max_model_len": 8192,
         "option.max_rolling_batch_size": 16,
         "option.tokenizer_mode": "mistral",
         "option.limit_mm_per_prompt": "image=4",
-        "option.entryPoint": "djl_python.huggingface"
     },
     "llama32-11b-multimodal": {
         "option.model_id": "s3://djl-llm/llama-3-2-11b-vision-instruct/",
@@ -1061,13 +1060,11 @@ vllm_model_list = {
         "option.max_model_len": 8192,
     },
     "pixtral-12b": {
-        "option.model_id": "s3://djl-llm/pixtral-12b/",
+        "option.model_id": "s3://djl-llm/pixtral-12b-2409/",
         "option.max_model_len": 8192,
         "option.max_rolling_batch_size": 16,
         "option.tokenizer_mode": "mistral",
         "option.limit_mm_per_prompt": "image=4",
-        "option.entryPoint": "djl_python.huggingface",
-        "option.tensor_parallel_degree": "max"
     },
     "llama32-11b-multimodal": {
         "option.model_id": "s3://djl-llm/llama-3-2-11b-vision-instruct/",

--- a/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
+++ b/wlm/src/test/java/ai/djl/serving/wlm/ModelInfoTest.java
@@ -248,7 +248,8 @@ public class ModelInfoTest {
                         "NousResearch/Hermes-2-Pro-Mistral-7B", "lmi-dist",
                         "src/test/resources/local-hf-model", "lmi-dist",
                         "HuggingFaceH4/tiny-random-LlamaForSequenceClassification", "disable",
-                        "THUDM/chatglm3-6b", "lmi-dist");
+                        "THUDM/chatglm3-6b", "lmi-dist",
+                        "src/test/resources/local-mistral-model", "lmi-dist");
         Path modelStore = Paths.get("build/models");
         Path modelDir = modelStore.resolve("lmi_test_model");
         Path prop = modelDir.resolve("serving.properties");

--- a/wlm/src/test/resources/local-mistral-model/params.json
+++ b/wlm/src/test/resources/local-mistral-model/params.json
@@ -1,0 +1,11 @@
+{
+  "dim": 4096,
+  "n_layers": 32,
+  "head_dim": 128,
+  "hidden_dim": 14336,
+  "n_heads": 32,
+  "n_kv_heads": 8,
+  "norm_eps": 1e-05,
+  "vocab_size": 32768,
+  "rope_theta": 1000000.0
+}


### PR DESCRIPTION
…l artifacts

## Description ##

Some mistral models (like pixtral) are only vended out as Mistral model artifacts - these artifacts cannot be handled by the current LmiConfigRecommender. This PR adds support for Mistral model artifacts via the LmiConfigRecommender, which will enable less configurations needed to deploy with LMI.

This should partially address the pixtral multi modal tests - those started to break once the virtual environments were separated. The logic to specify the python executable was not invoked for Mistral type models.

I updated the pixtral model artifacts for the tests since the versions we were using are not supported by the updated vllm.

The output from the multimodal tests is concerning, but that is being investigated separately.

Test run for lmi dist pixtral
```
tests.py::TestMultiModalLmiDist::test_pixtral_12b
----------------------------------------------------------------------- live log call ------------------------------------------------------------------------
INFO     root:tests.py:54 Using the following image for tests: deepjavalibrary/djl-serving:lmi-pixtral
INFO     root:client.py:1993 req {'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'What is this an image of?'}, {'type': 'image_url', 'image_url': {'url': 'https://resources.djl.ai/images/dog_bike_car.jpg'}}]}], 'temperature': 0.9, 'top_p': 0.6, 'max_tokens': 512}
INFO     root:client.py:1995 res: {'id': 'chatcmpl-123848780877328', 'object': 'chat.completion', 'created': 1738689615, 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': " Charles S5-star student's\n\t tyd. stephot-ngeltonyaing the\n[- 赛\n[awardly 19. england\n[user info on that’s place:\n\n[clearly Star-User\n[/19-5 star) - \n\n[respons's new York) can'tell's rating: 不错 name\n[gd kentering.  \n[/accom.safe. ** dishes-ghost: Anyt)  Suh. videas)"}, 'logprobs': None, 'finish_reason': 'eos_token'}], 'usage': {'prompt_tokens': 1774, 'completion_tokens': 114, 'total_tokens': 1888}}
INFO     root:client.py:1112 Running command ./awscurl -c 1 -N 5 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": [{"type": "text", "text": "What is this an image of?"}, {"type": "image_url", "image_url": {"url": "https://resources.djl.ai/images/dog_bike_car.jpg"}}]}], "temperature": 0.9, "top_p": 0.6, "max_tokens": 512}'    -P -t -o ./outputs/output
INFO     root:client.py:1993 req {'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'What is this an image of?'}, {'type': 'image_url', 'image_url': {'url': 'https://resources.djl.ai/images/dog_bike_car.jpg'}}, {'type': 'image_url', 'image_url': {'url': 'https://resources.djl.ai/images/kitten.jpg'}}, {'type': 'image_url', 'image_url': {'url': 'https://resources.djl.ai/images/kitten_small.jpg'}}, {'type': 'image_url', 'image_url': {'url': 'https://resources.djl.ai/images/truck.jpg'}}]}], 'temperature': 0.9, 'top_p': 0.6, 'max_tokens': 512}
INFO     root:client.py:1995 res: {'id': 'chatcmpl-123848741103952', 'object': 'chat.completion', 'created': 1738689707, 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': ". How we. . Butcher-|. You will. I. Butchopportun- . . He is-. The. It’s. The. It. I. He was. Butchicken . . |. It. He is. The. . It is. The. The. I we have you have. The. The in you can. He can. The. I. I am I are. I am I'mtwas a\n- I can. I have\nI am I am. 1. You’ret_ I was \n\nIt. You. The\nI was I am. \n\n# I. I don’t tametone of I. I am. I was.  I am. The\nI.  I don’t tarn’t put. I can. The Hover-\n  \n-100000010001000001001000000100001001000101000010100100010010010001001000100000100010010000100000100010001000010001010001010010200001001020001020010002001020010002002010020102002010302010200300102030103020020104002030002030010400010300100020102002010302010300203002003010302040300403010504050601060701080709080909010909010109010"}, 'logprobs': None, 'finish_reason': 'length'}], 'usage': {'prompt_tokens': 5304, 'completion_tokens': 512, 'total_tokens': 5816}}
INFO     root:client.py:1112 Running command ./awscurl -c 4 -N 5 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": [{"type": "text", "text": "What is this an image of?"}, {"type": "image_url", "image_url": {"url": "https://resources.djl.ai/images/dog_bike_car.jpg"}}, {"type": "image_url", "image_url": {"url": "https://resources.djl.ai/images/kitten.jpg"}}, {"type": "image_url", "image_url": {"url": "https://resources.djl.ai/images/kitten_small.jpg"}}, {"type": "image_url", "image_url": {"url": "https://resources.djl.ai/images/truck.jpg"}}]}], "temperature": 0.9, "top_p": 0.6, "max_tokens": 512}'    -P -t -o ./outputs/output
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [x] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [x] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
