### PR TITLE
[secure-mode] Allowlist option.pythonExecutable, but only for recognized paths

### DIFF
--- a/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeAllowList.java
+++ b/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeAllowList.java
@@ -107,5 +107,12 @@ interface SecureModeAllowList {
                     "option.enable_prefix_caching",
                     "option.disable_sliding_window",
                     "option.enable_streaming",
-                    "option.tgi_compat");
+                    "option.tgi_compat",
+                    "option.pythonExecutable");
+
+    public static final Set<String> PYTHON_EXECUTABLE_ALLOWLIST =
+            Set.of(
+                    "/opt/djl/lmi_dist_venv/bin/python",
+                    "/opt/djl/vllm_venv/bin/python",
+                    "/usr/bin/python3");
 }

--- a/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeUtils.java
+++ b/plugins/secure-mode/src/main/java/ai/djl/serving/plugins/securemode/SecureModeUtils.java
@@ -150,6 +150,14 @@ final class SecureModeUtils {
                         "Installing additional dependencies is prohibited in Secure Mode.");
             }
         }
+        String pythonExecutable = prop.getProperty("option.pythonExecutable");
+        if (pythonExecutable != null
+                && !SecureModeAllowList.PYTHON_EXECUTABLE_ALLOWLIST.contains(pythonExecutable)) {
+            throw new IllegalConfigurationException(
+                    "Custom Python executable path is prohibited in Secure Mode. "
+                            + "Only the following paths are allowed: "
+                            + SecureModeAllowList.PYTHON_EXECUTABLE_ALLOWLIST);
+        }
     }
 
     /**

--- a/plugins/secure-mode/src/test/java/ai/djl/serving/plugins/securemode/SecureModePluginTest.java
+++ b/plugins/secure-mode/src/test/java/ai/djl/serving/plugins/securemode/SecureModePluginTest.java
@@ -272,6 +272,22 @@ public class SecureModePluginTest {
                 "foo", TEST_MODEL_DIR.resolve("serving.properties"), "option.not_allowlisted=foo");
     }
 
+    @Test(expectedExceptions = IllegalConfigurationException.class)
+    void testInvalidPythonExecutablePath() throws IOException, ModelException {
+        mockSecurityEnv(
+                "foo",
+                TEST_MODEL_DIR.resolve("serving.properties"),
+                "option.pythonExecutable=/foo/bar/python3");
+    }
+
+    @Test
+    void testAllowedPythonExecutablePath() throws IOException, ModelException {
+        mockSecurityEnv(
+                "foo",
+                TEST_MODEL_DIR.resolve("serving.properties"),
+                "option.pythonExecutable=/opt/djl/lmi_dist_venv/bin/python");
+    }
+
     private void createFileWithContent(Path file, String content) throws IOException {
         if (Files.exists(file)) {
             return;


### PR DESCRIPTION
Allowlist `option.pythonExecutable` in Secure Mode, but only allow it to be explicitly set to trusted executables (LMI venvs and system)

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
