### PR TITLE
Use VLLM python venv for quantization + make llm compressor version explicit in vllm venv

### DIFF
--- a/serving/docker/partition/sm_neo_dispatcher.py
+++ b/serving/docker/partition/sm_neo_dispatcher.py
@@ -136,10 +136,10 @@ class NeoDispatcher:
                         python_exec = VLLM_VENV_EXEC
                     else:
                         python_exec = LMI_DIST_VENV_EXEC
-                    print(f"Sharding Model...")
+                    print("Sharding Model...")
                     self.run_task(NeoTask.SHARDING, python_exec)
                 else:
-                    self.run_task(NeoTask.QUANTIZATION, LMI_DIST_VENV_EXEC)
+                    self.run_task(NeoTask.QUANTIZATION, VLLM_VENV_EXEC)
             case "trtllm":
                 self.run_task(NeoTask.TENSORRT_LLM, SYSTEM_PY_EXEC)
             case "vllm,lmi-dist,tnx":

--- a/serving/docker/requirements-vllm.txt
+++ b/serving/docker/requirements-vllm.txt
@@ -1,3 +1,3 @@
 peft==0.14.0
-llmcompressor
+llmcompressor==0.4.0
 vllm==0.7.1


### PR DESCRIPTION
## Description ##

Use the vllm python venv for llm-compressor quantization. The vllm venv is compatible with llm-compressor 0.4.0 because it has transformers==4.48.2. 0.4.0 was auto installed in vllm venv. I made this version explicit to avoid confusion.

The lmi-dist venv does not work because it has llm-compressor==0.3.0 installed, and quantization fails with this version. Attempting to upgrade to 0.3.1 fails due to a dependency conflict between llm-compressor==0.3.1 and vllm==0.6.3.post1 (lmi-dist).

## Feature/Issue validation/testing

I also performed further local validation of the container with **llama-3.1-8b**. Quantized and served with the following serving.properties:
Case 1:
```
option.rolling_batch=lmi-dist
option.quantize=fp8
```
- Note that we still input `option.quantize=fp8`, but the output serving.properties will be `option.quantize=compressed-tensors`

Case 2:
```
option.rolling_batch=vllm
option.quantize=fp8
```
Please let me know if there additional models we'd like to validate.
