### PR TITLE
Neo Quantization Fixes

### DIFF
--- a/serving/docker/partition/sm_neo_dispatcher.py
+++ b/serving/docker/partition/sm_neo_dispatcher.py
@@ -139,7 +139,14 @@ class NeoDispatcher:
                     print("Sharding Model...")
                     self.run_task(NeoTask.SHARDING, python_exec)
                 else:
-                    self.run_task(NeoTask.QUANTIZATION, VLLM_VENV_EXEC)
+                    if self.properties.get("option.quantize",
+                                           "").lower() == "fp8":
+                        python_exec = VLLM_VENV_EXEC
+                    else:
+                        # run awq quantization with lmi-dist venv b/c AutoAWQ
+                        # is incompatible with newer transformers
+                        python_exec = LMI_DIST_VENV_EXEC
+                    self.run_task(NeoTask.QUANTIZATION, python_exec)
             case "trtllm":
                 self.run_task(NeoTask.TENSORRT_LLM, SYSTEM_PY_EXEC)
             case "vllm,lmi-dist,tnx":

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1117,7 +1117,7 @@ vllm_neo_model_list = {
         "option.model_id": "s3://djl-llm/llama-3.1-8b-hf/",
         "option.quantize": "fp8",
         "option.tensor_parallel_degree": "4",
-        "option.fp8_activation_scheme": "dynamic"
+        "option.fp8_scheme": "FP8_DYNAMIC"
     }
 }
 


### PR DESCRIPTION
## Description ##
Various fixes for neo fp8 CI:
- Update llm/prepare.py to properly pass in option for FP8 quantization.
- Do tokenization from FP8 on our side, like we were doing before with AutoFP8. Delegating this to llmcompressor leads to unneeded tokenization that **leads to timeout in CI**.
- Use lmi-dist-venv to run awq quantization, due to hf transformers version incompatibility.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

- Repeated local tests with Llama-3.1-8b as in #2701 