### PR TITLE
[vllm] leverage passthrough for generation_config engine argument

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -81,7 +81,6 @@ class VllmRbProperties(Properties):
     # Neuron vLLM properties
     device: str = 'auto'
     preloaded_model: Optional[Any] = None
-    generation_config: Optional[Any] = None
     override_neuron_config: Optional[Dict] = None
 
     # Non engine arg properties
@@ -237,7 +236,6 @@ class VllmRbProperties(Properties):
         # These neuron configs are not implemented in the vllm arg parser
         if self.device == 'neuron':
             setattr(engine_args, 'preloaded_model', self.preloaded_model)
-            setattr(engine_args, 'generation_config', self.generation_config)
             setattr(engine_args, 'override_neuron_config',
                     self.override_neuron_config)
         return engine_args


### PR DESCRIPTION
## Description ##

This PR removes the generation_config parameter from vllm properties. This is an engine argument and can be leveraged via pass-through. 

I validated this for GPU - when specifying OPTION_GENERATION_CONFIG=auto , vllm will pick up generation_config.json if present.

I added some logging to test:

Without sampling params in the payload:
```
INFO  PyProcess W-3507-08a20b291e447c9-stdout: INFO::default sampling params are default_sampling_params={'temperature': 0.36, 'top_p': 0.9}
INFO  PyProcess W-3507-08a20b291e447c9-stdout: INFO::using sampling params sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.36, top_p=0.9, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=131012, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
INFO  PyProcess W-3507-08a20b291e447c9-stdout: INFO::[RequestId=92a42946-013e-4b18-99fc-39dd6085ea0c] parsed and scheduled for inference
```

override sampling params in payload
```
INFO  WorkerThread Starting worker thread WT-0001 for model meta_llama_Llama_3_1_8B_Instruct_-1887791483 (M-0001, READY) on device gpu(0)
INFO  ModelServer Initialize BOTH server with: EpollServerSocketChannel.
INFO  ModelServer BOTH API bind to: http://0.0.0.0:8080
INFO  PyProcess W-2859-08a20b291e447c9-stdout: INFO 02-06 22:44:17 chat_utils.py:330] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
INFO  PyProcess W-2859-08a20b291e447c9-stdout: INFO::default sampling params are default_sampling_params={'temperature': 0.36, 'top_p': 0.9}
INFO  PyProcess W-2859-08a20b291e447c9-stdout: INFO::using sampling params sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.6, top_p=0.9, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=512, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
INFO  PyProcess W-2859-08a20b291e447c9-stdout: INFO::[RequestId=ca3db734-fbf8-4e17-83d8-5c50aea81200] parsed and scheduled for inference
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
