### PR TITLE
[vllm] add flashinfer wheel for 0.2.0.post2

### DIFF
--- a/serving/docker/requirements-vllm.txt
+++ b/serving/docker/requirements-vllm.txt
@@ -1,3 +1,4 @@
 peft==0.14.0
 llmcompressor==0.4.0
 vllm==0.7.1
+https://github.com/flashinfer-ai/flashinfer/releases/download/v0.2.0.post2/flashinfer_python-0.2.0.post2+cu124torch2.5-cp311-cp311-linux_x86_64.whl


### PR DESCRIPTION
## Description ##

Installs the wheel for flashinfer 0.2.0.post2 - vllm 0.7.1 uses post1, but there is not official torch 2.5 wheel for that version. I have tested 0.2.0.post2 locally with Llama and it functions well.

Before this, my test with Llama and FlashInfer backend failed completely. 

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
