### PR TITLE
[serving] update default chunked read timeout to 120 seconds for sage…

### DIFF
--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -451,7 +451,8 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                 }
                 ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             } catch (InterruptedException | IllegalStateException e) {
-                logger.warn("Chunk reading interrupted", e);
+                String requestId = NettyUtils.getRequestId(ctx.channel());
+                logger.warn("RequestId=[{}] Chunk reading interrupted", requestId, e);
                 ctx.disconnect();
                 ctx.newFailedFuture(e);
             }

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -462,7 +462,7 @@ public final class ConfigManager {
      * @return the ChunkedBytesSupplier read time in seconds
      */
     public int getChunkedReadTimeout() {
-        return getIntProperty(CHUNKED_READ_TIMEOUT, 60);
+        return getIntProperty(CHUNKED_READ_TIMEOUT, 120);
     }
 
     /**


### PR DESCRIPTION
…maker, add requestId to log for timeout

## Description ##

Many customers currently leverage higher than 60 second timeouts on SageMaker endpoints. For non-streaming requests that take longer than 60 seconds, we currently time-out and throw an error.

This PR increases the timeout to 120 seconds by default to stay in line with what most customers are deploying on Sagemaker. It also logs the requestId on timeouts to make debugging easier.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
