### PR TITLE
[fix][ci] fix tag-suffix calculation to ensure correct tag is used fo…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
         secrets: inherit
         with:
             djl-version: ${{ needs.build.outputs.djl_version }}
-            tag-suffix: ${{ inputs.mode == 'nightly' && format('{0}-{1}', 'nightly', github.sha) || github.sha }}
+            tag-suffix: ${{ inputs.mode == 'release' && github.sha || format('{0}-{1}', 'nightly', github.sha) }}
 
     optimization-integration-test:
         needs: [build]
@@ -46,7 +46,7 @@ jobs:
         secrets: inherit
         with:
             djl-version: ${{ needs.build.outputs.djl_version }}
-            tag-suffix: ${{ inputs.mode == 'nightly' && format('{0}-{1}', 'nightly', github.sha) || github.sha }}
+            tag-suffix: ${{ inputs.mode == 'release' && github.sha || format('{0}-{1}', 'nightly', github.sha) }}
 
             
     determine_images_to_publish:


### PR DESCRIPTION
…r cron tigger

## Description ##

When an action is triggered via `cron`, the inputs are not populated with default values. This means for nightly ci runs, the input.mode value is always ''. This causes issues for the tag-suffix specification for dependent workflows.

The fix here is to check if mode is release (a manual action), and if not we assume it's a nightly build and specify the tag correctly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
