### PR TITLE
[docker] Add CVE patch for libpmix2 in affected images

### DIFF
--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -83,6 +83,7 @@ RUN apt-get update && apt-get install -yq libaio-dev libopenmpi-dev g++ unzip cu
 
 RUN scripts/patch_oss_dlc.sh python \
     && scripts/security_patch.sh lmi \
+    && scripts/patch_libpmix2.sh \
     && useradd -m -d /home/djl djl \
     && chown -R djl:djl /opt/djl \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/serving/docker/scripts/patch_libpmix2.sh
+++ b/serving/docker/scripts/patch_libpmix2.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install -y \
+    build-essential \
+    gfortran \
+    autoconf \
+    automake \
+    libtool \
+    flex \
+    hwloc \
+    libhwloc-dev \
+    libevent-dev \
+    libfabric-dev \
+    libevent-2.1-7 \
+    devscripts \
+    debhelper
+apt remove -y openmpi-bin libopenmpi-dev libpmix-dev libpmix2
+apt autoremove -y
+
+# Build and install libpmix2 as deb
+cd /tmp
+git clone --recursive -b v4.2.6 https://github.com/openpmix/openpmix.git
+cd openpmix
+./autogen.pl
+./configure --prefix=/usr --with-devel-headers
+
+mkdir -p debian/libpmix2/usr
+mkdir -p debian/libpmix2/DEBIAN
+
+make -j$(nproc)
+make DESTDIR=$(pwd)/debian/libpmix2 install
+
+cat > debian/libpmix2/DEBIAN/control << EOL
+Package: libpmix2
+Version: 4.2.6
+Architecture: amd64
+Section: libs
+Depends: libc6, libevent-2.1-7, libhwloc15
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Description: Process Management Interface (Exascale) library
+ This is the OpenMPI implementation of the Process Management Interface (PMI)
+ Exascale API. PMIx aims to retain transparent compatibility with the existing
+ PMI-1 and PMI-2 definitions, and any future PMI releases; Support
+ the Instant On initiative for rapid startup of applications at exascale
+ and beyond.
+EOL
+
+dpkg-deb --build debian/libpmix2
+dpkg -i debian/libpmix2.deb
+
+make install
+ldconfig
+
+# Reinstall OpenMPI
+cd /tmp
+wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
+tar -xvf openmpi-4.1.2.tar.gz
+cd openmpi-4.1.2
+./configure --prefix=/usr --with-pmix=/usr
+make -j$(nproc)
+make install
+ldconfig
+
+# Cleanup
+apt remove -y \
+    build-essential \
+    gfortran \
+    autoconf \
+    automake \
+    libtool \
+    flex \
+    libhwloc-dev \
+    libevent-dev \
+    libfabric-dev \
+    devscripts \
+    debhelper
+
+cd /tmp
+rm -rf openpmix openmpi-4.1.2 openmpi-4.1.2.tar.gz

--- a/serving/docker/scripts/patch_libpmix2.sh
+++ b/serving/docker/scripts/patch_libpmix2.sh
@@ -15,7 +15,8 @@ apt-get install -y \
     libfabric-dev \
     libevent-2.1-7 \
     devscripts \
-    debhelper
+    debhelper \
+    wget
 apt remove -y openmpi-bin libopenmpi-dev libpmix-dev libpmix2
 apt autoremove -y
 

--- a/serving/docker/tensorrt-llm.Dockerfile
+++ b/serving/docker/tensorrt-llm.Dockerfile
@@ -104,6 +104,7 @@ RUN pip install ${triton_toolkit_wheel} ${trtllm_toolkit_wheel} && \
 RUN scripts/install_djl_serving.sh $djl_version $djl_serving_version && \
     scripts/install_s5cmd.sh x64 && \
     scripts/security_patch.sh trtllm && \
+    scripts/patch_libpmix2.sh && \
     scripts/patch_oss_dlc.sh python && \
     mkdir -p /opt/djl/bin && cp scripts/telemetry.sh /opt/djl/bin && \
     echo "${djl_serving_version} tensorrtllm" > /opt/djl/bin/telemetry && \


### PR DESCRIPTION
## Description ##

Addresses https://ubuntu.com/security/CVE-2023-41915 in affected images. Will need to subsequently cherry-pick to release branches.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
