### PR TITLE
Fix too long requests hang in vLLM & lmi-dist

### DIFF
--- a/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/lmi_dist_rolling_batch.py
@@ -244,6 +244,13 @@ class LmiDistRollingBatch(RollingBatch):
         for request in self.active_requests:
             request_output = request.request_output
             if request_output.finished:
+                prompt_len = len(request_output.prompt_tokens_details)
+                if self.get_model_config():
+                    max_model_len = self.get_model_config().max_model_len
+                    if prompt_len > max_model_len:
+                        raise ValueError(
+                            f"Input prompt ({prompt_len} tokens) is too long and exceeds limit of {max_model_len}"
+                        )
                 request.last_token = True
 
         return self.postprocess_results()

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -53,7 +53,8 @@ def update_request_cache_with_output(request_cache: OrderedDict,
     # Prefill is complete if any of the outputs have token_ids set
     prefill_is_complete = any(
         (output.token_ids for output in vllm_request_output.outputs))
-    if not prefill_is_complete:
+    # If the request is finished, stop waiting for prefill (This happens when the request is ignored)
+    if not prefill_is_complete and not vllm_request_output.finished:
         return request_cache
 
     # sets prompt token details if not set

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -199,6 +199,12 @@ class VLLMRollingBatch(RollingBatch):
         for request in self.active_requests:
             request_output = request.request_output
             if request_output.finished:
+                prompt_len = len(request_output.prompt_tokens_details)
+                max_model_len = self.get_model_config().max_model_len
+                if prompt_len > max_model_len:
+                    raise ValueError(
+                        f"Input prompt ({prompt_len} tokens) is too long and exceeds limit of {max_model_len}"
+                    )
                 request.last_token = True
 
         return self.postprocess_results()

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -1070,7 +1070,9 @@ def send_json(data):
 
     if resp.status_code >= 300:
         LOGGER.exception(f"HTTP error: {resp}")
-        raise ValueError(f"Failed to send request to model server. Status code: {resp.status_code}")
+        raise ValueError(
+            f"Failed to send request to model server. Status code: {resp.status_code}"
+        )
     return resp
 
 

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -1070,7 +1070,7 @@ def send_json(data):
 
     if resp.status_code >= 300:
         LOGGER.exception(f"HTTP error: {resp}")
-        raise ValueError("Failed to send request to model server")
+        raise ValueError(f"Failed to send request to model server. Status code: {resp.status_code}")
     return resp
 
 

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -416,7 +416,12 @@ lmi_dist_model_spec = {
     "flan-t5-xl": {
         "batch_size": [1, 4],
         "seq_length": [256],
-    }
+    },
+    "tinyllama-input-len-exceeded": {
+        "batch_size": [1],
+        "seq_length": [25],
+        "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    },
 }
 
 lmi_dist_chat_model_spec = {
@@ -569,6 +574,11 @@ vllm_model_spec = {
     "gemma-2b": {
         "batch_size": [1, 4],
         "seq_length": [256],
+    },
+    "tinyllama-input-len-exceeded": {
+        "batch_size": [1],
+        "seq_length": [25],
+        "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
     },
 }
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -741,7 +741,13 @@ lmi_dist_model_list = {
     },
     "flan-t5-xl": {
         "option.model_id": "s3://djl-llm/flan-t5-xl/",
-    }
+    },
+    "tinyllama-input-len-exceeded": {
+        "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
+        "option.max_model_len": "50",
+        "option.max_rolling_batch_size": "1",
+        "option.enforce_eager": True,
+    },
 }
 
 vllm_model_list = {
@@ -1092,6 +1098,12 @@ vllm_model_list = {
         "option.max_rolling_batch_size": 4,
         "option.enable_reasoning": True,
         "option.reasoning_parser": "deepseek_r1",
+    },
+    "tinyllama-input-len-exceeded": {
+        "option.model_id": "s3://djl-llm/tinyllama-1.1b-chat/",
+        "option.max_model_len": "50",
+        "option.max_rolling_batch_size": "1",
+        "option.enforce_eager": True,
     },
 }
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -8,6 +8,7 @@ import llm.prepare as prepare
 import llm.client as client
 import rb_client as rb_client
 import test_client
+import time
 
 djl_version = os.environ.get('TEST_DJL_VERSION', '0.33.0').strip()
 override_image_tag_suffix = os.environ.get('IMAGE_TAG_SUFFIX', '').strip()
@@ -544,6 +545,20 @@ class TestLmiDist2:
             r.launch(env_vars=envs)
             client.run("lmi_dist llama-3.1-8b".split())
 
+    def test_tiny_llama_input_length_exceeded(self):
+        with Runner('lmi', 'tinyllama-test-input-length-exceeded') as r:
+            prepare.build_lmi_dist_model("tinyllama-input-len-exceeded")
+            r.launch()
+            start = time.perf_counter()
+            with pytest.raises(ValueError):
+                client.run(
+                    "lmi_dist tinyllama-input-len-exceeded --in_tokens 100".
+                    split())
+            req_time = time.perf_counter() - start
+            assert req_time < 20
+            client.run(
+                "vllm tinyllama-input-len-exceeded --in_tokens 10".split())
+
 
 @pytest.mark.lmi_dist
 @pytest.mark.gpu_4
@@ -654,6 +669,19 @@ class TestVllm1:
             prepare.build_vllm_async_model('llama-3-1-8b-instruct')
             r.launch()
             client.run("vllm_chat llama-3-1-8b-instruct".split())
+
+    def test_tiny_llama_input_length_exceeded(self):
+        with Runner('lmi', 'tinyllama-test-input-length-exceeded') as r:
+            prepare.build_vllm_model("tinyllama-input-len-exceeded")
+            r.launch()
+            start = time.perf_counter()
+            with pytest.raises(ValueError):
+                client.run("vllm tinyllama-input-len-exceeded --in_tokens 100".
+                           split())
+            req_time = time.perf_counter() - start
+            assert req_time < 20
+            client.run(
+                "vllm tinyllama-input-len-exceeded --in_tokens 10".split())
 
 
 @pytest.mark.vllm

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -550,7 +550,7 @@ class TestLmiDist2:
             prepare.build_lmi_dist_model("tinyllama-input-len-exceeded")
             r.launch()
             start = time.perf_counter()
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=r".*424.*"):
                 client.run(
                     "lmi_dist tinyllama-input-len-exceeded --in_tokens 100".
                     split())
@@ -675,7 +675,7 @@ class TestVllm1:
             prepare.build_vllm_model("tinyllama-input-len-exceeded")
             r.launch()
             start = time.perf_counter()
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=r".*424.*"):
                 client.run("vllm tinyllama-input-len-exceeded --in_tokens 100".
                            split())
             req_time = time.perf_counter() - start


### PR DESCRIPTION
## Description ##

Fixes a hang caused by requests that are longer than `max_model_len` in vLLM and lmi-dist handlers. The main fix is here:
https://github.com/a-ys/djl-serving-1/blob/4a8e75869ead48f79c279edc3078d796c0afa163/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py#L57-L58
**Cause**:
vLLM sends a response with the ignored sequence on too long request. Without this check, djl-serving doesn't process the response, waiting for prefill to complete. However, the vLLM engine has already ignored and removed the request from the queue, leaving djl-serving to wait forever for the prefill that won't come.

In addition, we add a check to try throw an error in this case, rather than returning an empty string to the client: https://github.com/a-ys/djl-serving-1/blob/4a8e75869ead48f79c279edc3078d796c0afa163/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py#L204-L207
- Currently, vLLM just ignores the request and adds a warning in container logs like: `Input prompt (24 tokens) is too long and exceeds limit of 10`
- I chose to raise an exception to provide some more clarity to the consumer. However, the response will still be `{"error":"exception occurred during rolling batch inference","code":424}`

This change is accompanied by a change in lmi-dist; lmi-dist is not properly outputting this response token, requires that change to be merged for the lmi-dist tests in this PR to pass.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [X] Have you added tests that prove your fix is effective or that this feature works?

## Feature/Issue validation/testing
Added the same test for vLLM and lmi-dist. The test case is:
1. sending a request that is too long, verifying that an exception is raised.
2. The exception is raised quickly, and we aren't waiting for a timeout
3. the container doesn't die and future requests are still processed


