### PR TITLE
[python] use uvloop instead of asyncio for event loop

### DIFF
--- a/engines/python/setup/djl_python/python_async_engine.py
+++ b/engines/python/setup/djl_python/python_async_engine.py
@@ -135,7 +135,14 @@ class PythonAsyncEngine(PythonSyncEngine):
                 await asyncio.get_event_loop().run_in_executor(
                     executor, check_threads)
 
+        try:
+            import uvloop
+            uvloop.install()
+        except ImportError:
+            logging.warning("uvloop not available, using asyncio as default")
+
         asyncio.run(main())
+
         if not self.exception_queue.empty():
             logging.error(
                 f"djl async engine terminated with error {self.exception_queue.get()}"

--- a/serving/docker/lmi-container-requirements-common.txt
+++ b/serving/docker/lmi-container-requirements-common.txt
@@ -28,5 +28,6 @@ pydantic==2.9.2
 optimum==1.23.2
 torch==2.5.1
 torchvision==0.20.1
+uvloop
 # sequence scheduler wheel for hf accelerate rolling batch
 https://publish.djl.ai/seq_scheduler/seq_scheduler-0.1.0-py3-none-any.whl


### PR DESCRIPTION
## Description ##

Use uvloop instead of asyncio for the event loop. I've tested this locally and uvloop can get significantly faster than asyncio when streaming responses for many concurrent requests. In my local testing, it's never slower than asyncio.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
