### PR TITLE
[fix] fix bug with adapter config jobs not being run outside rolling …

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -142,7 +142,10 @@ class PyProcess {
     }
 
     Output predict(Input inputs, int timeout, boolean initialLoad) throws TranslateException {
-        if (initialLoad) {
+        // In RollingBatch, we queue adapter loading jobs to occur after the initial load.
+        // Executing those in RollingBatch context doesn't work, so we need to handle them in the
+        // 'standard' way.
+        if (initialLoad || inputs.getProperty("handler", null) != null) {
             return predictStandard(inputs, timeout, initialLoad);
         }
         if (rollingBatch != null) {


### PR DESCRIPTION
…batch context

## Description ##

Fixes a bug that was introduced in my refactor PR here https://github.com/deepjavalibrary/djl-serving/pull/2758/files.

LoRA requests are not compatible with RollingBatch, so we need to make sure they are processed in the "standard" request pattern. This PR restores the logic from https://github.com/deepjavalibrary/djl-serving/blob/0.32.0-dlc/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java#L81.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
