### PR TITLE
[async][python] refactor stream response handling to avoid user code …

### DIFF
--- a/engines/python/setup/djl_python/service_loader.py
+++ b/engines/python/setup/djl_python/service_loader.py
@@ -29,12 +29,9 @@ class ModelService(object):
         inputs.properties["model_dir"] = self.model_dir
         return getattr(self.module, function_name)(inputs)
 
-    # TODO: this method currently requires the socket directly for supporting streaming.
-    # This is a temporary solution for the initial implementation, but will be reworked after
-    # some more testing and experiments.
-    async def invoke_handler_async(self, function_name, inputs, cl_socket):
+    async def invoke_handler_async(self, function_name, inputs):
         inputs.properties["model_dir"] = self.model_dir
-        return await getattr(self.module, function_name)(inputs, cl_socket)
+        return await getattr(self.module, function_name)(inputs)
 
 
 def load_model_service(model_dir, entry_point, device_id):


### PR DESCRIPTION
…interacting directly with socket

## Description ##

This PR updates the support for streaming responses in the async handler. The main motivation is to remove the need for interacting with the socket directly in handler code.

Ran tests for vllm in async mode to validate the change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
