### PR TITLE
[vllm][lora] use v0 engine for lora in tests due to issues with v1

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -692,55 +692,55 @@ class TestVllmLora:
     def test_lora_llama2_7b(self):
         with Runner('lmi', 'llama-7b-unmerged-lora') as r:
             prepare.build_vllm_model("llama-7b-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters llama-7b-unmerged-lora".split())
 
     def test_lora_llama2_7b_overflow(self):
         with Runner('lmi', 'llama-7b-unmerged-lora-overflow') as r:
             prepare.build_vllm_model("llama-7b-unmerged-lora-overflow")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters llama-7b-unmerged-lora-overflow".split())
 
     def test_lora_llama2_13b_awq(self):
         with Runner('lmi', 'llama2-13b-awq-unmerged-lora') as r:
             prepare.build_vllm_model("llama2-13b-awq-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters llama2-13b-awq-unmerged-lora".split())
 
     def test_lora_mistral_7b(self):
         with Runner('lmi', 'mistral-7b-unmerged-lora') as r:
             prepare.build_vllm_model("mistral-7b-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters mistral-7b-unmerged-lora".split())
 
     def test_lora_mistral_7b_awq(self):
         with Runner('lmi', 'mistral-7b-awq-unmerged-lora') as r:
             prepare.build_vllm_model("mistral-7b-awq-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters mistral-7b-awq-unmerged-lora".split())
 
     def test_lora_mistral_7b_gptq(self):
         with Runner('lmi', 'mistral-7b-gptq-unmerged-lora') as r:
             prepare.build_lmi_dist_model("mistral-7b-gptq-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters mistral-7b-gptq-unmerged-lora".split())
 
     def test_lora_llama3_8b(self):
         with Runner('lmi', 'llama3-8b-unmerged-lora') as r:
             prepare.build_vllm_model("llama3-8b-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters llama3-8b-unmerged-lora".split())
 
     def test_lora_gemma_7b(self):
         with Runner('lmi', 'gemma-7b-unmerged-lora') as r:
             prepare.build_lmi_dist_model("gemma-7b-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters gemma-7b-unmerged-lora".split())
 
     def test_lora_phi2(self):
         with Runner('lmi', 'phi2-unmerged-lora') as r:
             prepare.build_lmi_dist_model("phi2-unmerged-lora")
-            r.launch()
+            r.launch("VLLM_USE_V1=0")
             client.run("vllm_adapters phi2-unmerged-lora".split())
 
 


### PR DESCRIPTION
## Description ##

LoRA tests are failing after the vLLM update to 0.8.3, which makes the default engine v1. Our existing LoRA tests have started failing with v1.

For now, we opt for v0 engine for LoRA. vLLM also indicates that LoRA performance in v1 is not as good as v0 https://docs.vllm.ai/en/latest/getting_started/v1_user_guide.html. 

For LoRA support moving forward, we should opt for the async vLLM implementation so that we can use the public LoRA management APIs provided by vLLM.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
