### PR TITLE
[ci] use self-hosted cpu instances in integ tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -119,6 +119,15 @@ jobs:
           --fail \
           | jq '.token' | tr -d '"' )
           ./start_instance.sh action_inf2 $token djl-serving
+      - name: Create new CPU instance
+        id: create_cpu
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-serving/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_cpu $token djl-serving
     outputs:
       gpu_instance_id_1: ${{ steps.create_gpu.outputs.action_g6_instance_id }}
       gpu_instance_id_2: ${{ steps.create_gpu2.outputs.action_g6_instance_id }}
@@ -127,15 +136,15 @@ jobs:
       aarch64_instance_id: ${{ steps.create_aarch64.outputs.action_graviton_instance_id }}
       inf2_instance_id_1: ${{ steps.create_inf2.outputs.action_inf2_instance_id }}
       inf2_instance_id_2: ${{ steps.create_inf2_2.outputs.action_inf2_instance_id }}
-
+      cpu_instance_id: ${{ steps.create_cpu.outputs.action_cpu_instance_id }}
 
   test:
     runs-on:
-      - ${{ matrix.test.gh-runner && matrix.test.instance || 'self-hosted' }}
-      - ${{ matrix.test.gh-runner && matrix.test.instance || format('RUN_ID-{0}', github.run_id) }}
-      - ${{ matrix.test.gh-runner && matrix.test.instance || format('RUN_NUMBER-{0}', github.run_number) }}
-      - ${{ matrix.test.gh-runner && matrix.test.instance || format('SHA-{0}', github.sha) }}
-      - ${{ matrix.test.gh-runner && matrix.test.instance || format('JOB-{0}', 'create-runners') }}
+      - 'self-hosted'
+      - ${{ format('RUN_ID-{0}', github.run_id) }}
+      - ${{ format('RUN_NUMBER-{0}', github.run_number) }}
+      - ${{ format('SHA-{0}', github.sha) }}
+      - ${{ format('JOB-{0}', 'create-runners') }}
       - ${{ matrix.test.instance }}
     timeout-minutes: 120
     needs: create-runners
@@ -144,12 +153,10 @@ jobs:
       matrix:
         test:
           - test: TestCpuFull
-            instance: ubuntu-latest
-            gh-runner: true
+            instance: cpu
             failure-prefix: cpu
           - test: TestCpuBoth
-            instance: ubuntu-latest
-            gh-runner: true
+            instance: cpu
             failure-prefix: cpu
           - test: TestGpu
             instance: g6
@@ -391,4 +398,6 @@ jobs:
           instance_id=${{ needs.create-runners.outputs.inf2_instance_id_1 }}
           ./stop_instance.sh $instance_id
           instance_id=${{ needs.create-runners.outputs.inf2_instance_id_2 }}
+          ./stop_instance.sh $instance_id
+          instance_id=${{ needs.create-runners.outputs.cpu_instance_id }}
           ./stop_instance.sh $instance_id


### PR DESCRIPTION
## Description ##

Integration tests have been failing for the CPU test suites - github is not able to select the proper instance for ubuntu-latest. We have made any changes to the workflows that could cause these failures, so I believe something has changed on the github side that is due to specifying the same label same times in the runs-on criteria.

For now, the easiest option is to move to self-hosted cpu runners. The syntax to implement conditional, variable length criteria for runs-on is tough to get right and parse, and is quite error prone.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
