### PR TITLE
[vllm] fix handling of token ids for TGI style responses

### DIFF
--- a/engines/python/setup/djl_python/lmi_vllm/vllm_async_service.py
+++ b/engines/python/setup/djl_python/lmi_vllm/vllm_async_service.py
@@ -70,7 +70,7 @@ class VLLMHandler:
         self.tokenizer = await self.vllm_engine.get_tokenizer()
         model_config = await self.vllm_engine.get_model_config()
 
-        model_names = self.vllm_engine_args.served_model_name or self.vllm_engine_args.model
+        model_names = self.vllm_engine_args.served_model_name or "lmi"
         if not isinstance(model_names, list):
             model_names = [model_names]
         # Users can provide multiple names that refer to the same model
@@ -174,16 +174,17 @@ class VLLMHandler:
             return handle_streaming_response(
                 response,
                 processed_request.stream_output_formatter,
-                tokenizer=self.tokenizer,
                 request=processed_request.vllm_request,
                 accumulate_chunks=processed_request.accumulate_chunks,
                 include_prompt=processed_request.include_prompt,
+                tokenizer=self.tokenizer,
             )
 
         return processed_request.non_stream_output_formatter(
             response,
             request=processed_request.vllm_request,
-            tokenizer=self.tokenizer)
+            tokenizer=self.tokenizer,
+        )
 
 
 service = VLLMHandler()


### PR DESCRIPTION
## Description ##

The previous logic for converting token text to ids was incorrect for the tgi style schema. This changes fixes those issues by forcing the completion request to return token ids. For non-streaming requests, we do have to convert each token id to the token text because that information is not provided in the response. For streaming, no tokenization is required.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
