### PR TITLE
[vllm] Update vllm_rb_properties.py to accommodate vllm-0.8.5 changes

### DIFF
--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -16,7 +16,7 @@ from typing import Optional, Any, Dict, Tuple, Literal, Union
 from pydantic import field_validator, model_validator, ConfigDict, Field
 from vllm import EngineArgs, AsyncEngineArgs
 from vllm.utils import FlexibleArgumentParser
-from vllm.engine.arg_utils import StoreBoolean
+from vllm.utils import StoreBoolean
 
 from djl_python.properties_manager.properties import Properties
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
- Nightly pipeline: https://github.com/deepjavalibrary/djl-serving/actions/runs/14890506033


## Feature/Issue validation/testing

The full set of integration tests are run. The tests passed except for the Neuron ones. 
