### PR TITLE
[tests][lmi] use async mode for performance tests

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1497,24 +1497,17 @@ text_embedding_model_list = {
 }
 
 handler_performance_model_list = {
-    "tiny-llama-lmi": {
-        "engine": "MPI",
-        "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.rolling_batch": "lmi-dist",
-        "option.max_rolling_batch_size": 512,
-    },
     "tiny-llama-vllm": {
         "engine": "Python",
+        "option.rolling_batch": "disable",
+        "option.async_mode": True,
         "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.task": "text-generation",
-        "option.rolling_batch": "vllm",
         "option.gpu_memory_utilization": "0.9",
         "option.max_rolling_batch_size": 512,
     },
     "tiny-llama-trtllm": {
         "engine": "Python",
         "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.rolling_batch": "trtllm",
         "option.max_rolling_batch_size": 512,
     },
 }

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -358,6 +358,12 @@ class TestTrtLlmHandler2:
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("trtllm flan-t5-xl".split())
 
+    def test_trtllm_performance(self):
+        with Runner('tensorrt-llm', 'handler-performance-trtllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-trtllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance trtllm".split())
+
 
 @pytest.mark.lmi_dist
 @pytest.mark.gpu_4
@@ -647,6 +653,12 @@ class TestVllm1:
             assert req_time < 20
             client.run(
                 "vllm tinyllama-input-len-exceeded --in_tokens 10".split())
+
+    def test_vllm_performance(self):
+        with Runner('lmi', 'handler-performance-vllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-vllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance vllm".split())
 
 
 @pytest.mark.vllm
@@ -1177,20 +1189,3 @@ class TestTextEmbedding:
             prepare.build_text_embedding_model("bge-base-onnx")
             r.launch()
             client.run("text_embedding bge-base-onnx".split())
-
-
-@pytest.mark.gpu
-@pytest.mark.handler_performance
-class TestGPUHandlerPerformance:
-
-    def test_vllm(self):
-        with Runner('lmi', 'handler-performance-vllm') as r:
-            prepare.build_handler_performance_model("tiny-llama-vllm")
-            r.launch("CUDA_VISIBLE_DEVICES=0")
-            client.run("handler_performance vllm".split())
-
-    def test_trtllm(self):
-        with Runner('tensorrt-llm', 'handler-performance-trtllm') as r:
-            prepare.build_handler_performance_model("tiny-llama-trtllm")
-            r.launch("CUDA_VISIBLE_DEVICES=0")
-            client.run("handler_performance trtllm".split())


### PR DESCRIPTION
## Description ##

This fixes some issues in the TestGPU test suite. Couple of issues:
- TestGPU matches with TestGPUHandlerPerformance suite, which incorrectly gets included as the release criteria for the GPU base container. I removed that test suite and moved the actual tests to more relevant suites (vllm and trtllm)
- The handler performance tests were still running with the rolling batch mode, and due to some changes in https://github.com/deepjavalibrary/djl-serving/commit/f4ce3b6a05a7aec22767237645248b21c2336457 that results in both async and rolling batch mode being enabled. For now, I updated the tests here to use async mode (based on the defaults set in the previously mentioned PR). There still needs to be some work to fix the RB/Async flows, and the ideal state should be completely removing Rolling Batch (depends on what this project will do with Neuron mostly)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ x]Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ x] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ x] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Tests for GPU handler performance:

trtllm
```
(base_venv) ubuntu@ip-172-31-9-251:~/workplace/djl-serving/tests/integration$ OVERRIDE_TEST_CONTAINER=deepjavalibrary/djl-serving:tensorrt-llm python -m pytest tests.py::TestGPUHandlerPerformance::test_trtllm
==================================================================== test session starts =====================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/ubuntu/workplace/djl-serving/tests/integration
configfile: pytest.ini
plugins: anyio-4.9.0
collected 1 item

tests.py::TestGPUHandlerPerformance::test_trtllm
----------------------------------------------------------------------- live log call ------------------------------------------------------------------------
WARNING  root:tests.py:36 An override container has been specified - this container may not work for all tests, ensure you are only running tests compatible with the container
INFO     root:tests.py:54 Using the following image for tests: deepjavalibrary/djl-serving:tensorrt-llm
INFO     root:client.py:1882 trtllm req {'inputs': 'DeepSpeed is a machine learning framework', 'max_new_tokens': 256}
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 1 -N 100 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"inputs": "DeepSpeed is a machine learning framework", "max_new_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json  -P -t
INFO     root:client.py:1849 trtllm-handler-batch-001
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 36819.62, 'totalRequests': 100, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 1, 'tps': 2.73, 'tokenThroughput': 81.35, 'totalTokens': 2975, 'tokenPerRequest': 29, 'averageLatency': 365.72, 'averageTokenLatency': 12.29, 'p50Latency': 349.24, 'p90Latency': 350.72, 'p99Latency': 2283.51, 'timeToFirstByte': 360.36, 'p50TimeToFirstByte': 348.862083, 'p90TimeToFirstByte': 350.294694, 'p99TimeToFirstByte': 1782.759246}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "trtllm-handler-batch-001_p50Latency", "Unit": "Milliseconds", "Value": 349.24}, {"MetricName": "trtllm-handler-batch-001_p90Latency", "Unit": "Milliseconds", "Value": 350.72}, {"MetricName": "trtllm-handler-batch-001_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 348.862083}, {"MetricName": "trtllm-handler-batch-001_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 350.294694}, {"MetricName": "trtllm-handler-batch-001_tokenThroughput", "Unit": "Count/Second", "Value": 81.35}, {"MetricName": "trtllm-handler-batch-001_tps", "Unit": "Count/Second", "Value": 2.73}, {"MetricName": "trtllm-handler-batch-001_tokenPerRequest", "Unit": "Count", "Value": 29}]'
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 512 -N 10 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"inputs": "DeepSpeed is a machine learning framework", "max_new_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json  -P -t
INFO     root:client.py:1849 trtllm-handler-batch-512
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 13421.25, 'totalRequests': 5120, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 512, 'tps': 408.04, 'tokenThroughput': 12184.86, 'totalTokens': 152893, 'tokenPerRequest': 29, 'averageLatency': 1254.78, 'averageTokenLatency': 21513.91, 'p50Latency': 1200.13, 'p90Latency': 1507.63, 'p99Latency': 2223.73, 'timeToFirstByte': 1251.71, 'p50TimeToFirstByte': 1199.387987, 'p90TimeToFirstByte': 1498.722747, 'p99TimeToFirstByte': 2223.349121}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "trtllm-handler-batch-512_p50Latency", "Unit": "Milliseconds", "Value": 1200.13}, {"MetricName": "trtllm-handler-batch-512_p90Latency", "Unit": "Milliseconds", "Value": 1507.63}, {"MetricName": "trtllm-handler-batch-512_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 1199.387987}, {"MetricName": "trtllm-handler-batch-512_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 1498.722747}, {"MetricName": "trtllm-handler-batch-512_tokenThroughput", "Unit": "Count/Second", "Value": 12184.86}, {"MetricName": "trtllm-handler-batch-512_tps", "Unit": "Count/Second", "Value": 408.04}, {"MetricName": "trtllm-handler-batch-512_tokenPerRequest", "Unit": "Count", "Value": 29}]'
INFO     root:client.py:1889 trtllm-chat req {'messages': [{'role': 'user', 'content': 'hello, can you help me?'}, {'role': 'assistant', 'content': 'Hi, what can i help you with today?'}, {'role': 'user', 'content': 'What is deep learning?'}], 'max_tokens': 256}
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 1 -N 100 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": "hello, can you help me?"}, {"role": "assistant", "content": "Hi, what can i help you with today?"}, {"role": "user", "content": "What is deep learning?"}], "max_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json -j "choices/message/content" -P -t
INFO     root:client.py:1849 trtllm-handler-chat-batch-001
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 144517.98, 'totalRequests': 100, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 1, 'tps': 0.7, 'tokenThroughput': 82.13, 'totalTokens': 11817, 'tokenPerRequest': 118, 'averageLatency': 1438.74, 'averageTokenLatency': 12.18, 'p50Latency': 1306.47, 'p90Latency': 2149.08, 'p99Latency': 3108.59, 'timeToFirstByte': 1435.66, 'p50TimeToFirstByte': 1305.587011, 'p90TimeToFirstByte': 2110.026352, 'p99TimeToFirstByte': 3107.275666}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "trtllm-handler-chat-batch-001_p50Latency", "Unit": "Milliseconds", "Value": 1306.47}, {"MetricName": "trtllm-handler-chat-batch-001_p90Latency", "Unit": "Milliseconds", "Value": 2149.08}, {"MetricName": "trtllm-handler-chat-batch-001_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 1305.587011}, {"MetricName": "trtllm-handler-chat-batch-001_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 2110.026352}, {"MetricName": "trtllm-handler-chat-batch-001_tokenThroughput", "Unit": "Count/Second", "Value": 82.13}, {"MetricName": "trtllm-handler-chat-batch-001_tps", "Unit": "Count/Second", "Value": 0.7}, {"MetricName": "trtllm-handler-chat-batch-001_tokenPerRequest", "Unit": "Count", "Value": 118}]'
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 512 -N 10 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": "hello, can you help me?"}, {"role": "assistant", "content": "Hi, what can i help you with today?"}, {"role": "user", "content": "What is deep learning?"}], "max_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json -j "choices/message/content" -P -t
INFO     root:client.py:1849 trtllm-handler-chat-batch-512
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 49404.04, 'totalRequests': 5120, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 512, 'tps': 110.79, 'tokenThroughput': 13146.14, 'totalTokens': 607546, 'tokenPerRequest': 118, 'averageLatency': 4621.48, 'averageTokenLatency': 19940.76, 'p50Latency': 4298.97, 'p90Latency': 6020.96, 'p99Latency': 8550.16, 'timeToFirstByte': 4620.51, 'p50TimeToFirstByte': 4298.459442, 'p90TimeToFirstByte': 6020.227562, 'p99TimeToFirstByte': 8548.994669}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "trtllm-handler-chat-batch-512_p50Latency", "Unit": "Milliseconds", "Value": 4298.97}, {"MetricName": "trtllm-handler-chat-batch-512_p90Latency", "Unit": "Milliseconds", "Value": 6020.96}, {"MetricName": "trtllm-handler-chat-batch-512_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 4298.459442}, {"MetricName": "trtllm-handler-chat-batch-512_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 6020.227562}, {"MetricName": "trtllm-handler-chat-batch-512_tokenThroughput", "Unit": "Count/Second", "Value": 13146.14}, {"MetricName": "trtllm-handler-chat-batch-512_tps", "Unit": "Count/Second", "Value": 110.79}, {"MetricName": "trtllm-handler-chat-batch-512_tokenPerRequest", "Unit": "Count", "Value": 118}]'
PASSED
```

vllm

```
(base_venv) ubuntu@ip-172-31-9-251:~/workplace/djl-serving/tests/integration$ OVERRIDE_TEST_CONTAINER=deepjavalibrary/djl-serving:lmi python -m pytest tests.py::TestGPUHandlerPerformance::test_vllm
==================================================================== test session starts =====================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/ubuntu/workplace/djl-serving/tests/integration
configfile: pytest.ini
plugins: anyio-4.9.0
collected 1 item

tests.py::TestGPUHandlerPerformance::test_vllm
----------------------------------------------------------------------- live log call ------------------------------------------------------------------------
WARNING  root:tests.py:36 An override container has been specified - this container may not work for all tests, ensure you are only running tests compatible with the container
INFO     root:tests.py:54 Using the following image for tests: deepjavalibrary/djl-serving:lmi
INFO     root:client.py:1882 vllm req {'inputs': 'DeepSpeed is a machine learning framework', 'max_new_tokens': 256}
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 1 -N 100 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"inputs": "DeepSpeed is a machine learning framework", "max_new_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json  -P -t
INFO     root:client.py:1849 vllm-handler-batch-001
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 30505.39, 'totalRequests': 100, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 1, 'tps': 3.34, 'tokenThroughput': 102.82, 'totalTokens': 3074, 'tokenPerRequest': 30, 'averageLatency': 298.97, 'averageTokenLatency': 9.73, 'p50Latency': 295.51, 'p90Latency': 297.99, 'p99Latency': 790.47, 'timeToFirstByte': 296.36, 'p50TimeToFirstByte': 295.187172, 'p90TimeToFirstByte': 297.592119, 'p99TimeToFirstByte': 562.751385}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "vllm-handler-batch-001_p50Latency", "Unit": "Milliseconds", "Value": 295.51}, {"MetricName": "vllm-handler-batch-001_p90Latency", "Unit": "Milliseconds", "Value": 297.99}, {"MetricName": "vllm-handler-batch-001_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 295.187172}, {"MetricName": "vllm-handler-batch-001_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 297.592119}, {"MetricName": "vllm-handler-batch-001_tokenThroughput", "Unit": "Count/Second", "Value": 102.82}, {"MetricName": "vllm-handler-batch-001_tps", "Unit": "Count/Second", "Value": 3.34}, {"MetricName": "vllm-handler-batch-001_tokenPerRequest", "Unit": "Count", "Value": 30}]'
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 512 -N 10 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"inputs": "DeepSpeed is a machine learning framework", "max_new_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json  -P -t
INFO     root:client.py:1849 vllm-handler-batch-512
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 18755.21, 'totalRequests': 5120, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 512, 'tps': 285.22, 'tokenThroughput': 8795.87, 'totalTokens': 157894, 'tokenPerRequest': 30, 'averageLatency': 1795.09, 'averageTokenLatency': 29803.07, 'p50Latency': 1765.59, 'p90Latency': 2257.11, 'p99Latency': 2325.06, 'timeToFirstByte': 1786.16, 'p50TimeToFirstByte': 1764.303749, 'p90TimeToFirstByte': 2195.528825, 'p99TimeToFirstByte': 2323.524478}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "vllm-handler-batch-512_p50Latency", "Unit": "Milliseconds", "Value": 1765.59}, {"MetricName": "vllm-handler-batch-512_p90Latency", "Unit": "Milliseconds", "Value": 2257.11}, {"MetricName": "vllm-handler-batch-512_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 1764.303749}, {"MetricName": "vllm-handler-batch-512_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 2195.528825}, {"MetricName": "vllm-handler-batch-512_tokenThroughput", "Unit": "Count/Second", "Value": 8795.87}, {"MetricName": "vllm-handler-batch-512_tps", "Unit": "Count/Second", "Value": 285.22}, {"MetricName": "vllm-handler-batch-512_tokenPerRequest", "Unit": "Count", "Value": 30}]'
INFO     root:client.py:1889 vllm-chat req {'messages': [{'role': 'user', 'content': 'hello, can you help me?'}, {'role': 'assistant', 'content': 'Hi, what can i help you with today?'}, {'role': 'user', 'content': 'What is deep learning?'}], 'max_tokens': 256}
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 1 -N 100 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": "hello, can you help me?"}, {"role": "assistant", "content": "Hi, what can i help you with today?"}, {"role": "user", "content": "What is deep learning?"}], "max_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json -j "choices/message/content" -P -t
INFO     root:client.py:1849 vllm-handler-chat-batch-001
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 141682.67, 'totalRequests': 100, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 1, 'tps': 0.71, 'tokenThroughput': 99.88, 'totalTokens': 14049, 'tokenPerRequest': 140, 'averageLatency': 1406.59, 'averageTokenLatency': 10.01, 'p50Latency': 1283.43, 'p90Latency': 2309.76, 'p99Latency': 2776.12, 'timeToFirstByte': 1403.39, 'p50TimeToFirstByte': 1282.592218, 'p90TimeToFirstByte': 2308.400543, 'p99TimeToFirstByte': 2548.162532}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "vllm-handler-chat-batch-001_p50Latency", "Unit": "Milliseconds", "Value": 1283.43}, {"MetricName": "vllm-handler-chat-batch-001_p90Latency", "Unit": "Milliseconds", "Value": 2309.76}, {"MetricName": "vllm-handler-chat-batch-001_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 1282.592218}, {"MetricName": "vllm-handler-chat-batch-001_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 2308.400543}, {"MetricName": "vllm-handler-chat-batch-001_tokenThroughput", "Unit": "Count/Second", "Value": 99.88}, {"MetricName": "vllm-handler-chat-batch-001_tps", "Unit": "Count/Second", "Value": 0.71}, {"MetricName": "vllm-handler-chat-batch-001_tokenPerRequest", "Unit": "Count", "Value": 140}]'
INFO     root:client.py:1139 Running command TOKENIZER=TinyLlama/TinyLlama-1.1B-Chat-v1.0 ./awscurl -c 512 -N 10 -X POST http://127.0.0.1:8080/invocations --connect-timeout 300 -H 'Content-type: application/json' -d '{"messages": [{"role": "user", "content": "hello, can you help me?"}, {"role": "assistant", "content": "Hi, what can i help you with today?"}, {"role": "user", "content": "What is deep learning?"}], "max_tokens": 256}' --delay "rand(0,1000)" --json-path benchmark.json -j "choices/message/content" -P -t
INFO     root:client.py:1849 vllm-handler-chat-batch-512
INFO     root:client.py:1850 raw metrics: {'tokenizer': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'totalTimeMills': 99705.63, 'totalRequests': 5120, 'failedRequests': 0, 'errorRate': 0.0, 'concurrentClients': 512, 'tps': 52.92, 'tokenThroughput': 7572.5, 'totalTokens': 732635, 'tokenPerRequest': 143, 'averageLatency': 9674.94, 'averageTokenLatency': 34617.88, 'p50Latency': 9399.38, 'p90Latency': 12833.87, 'p99Latency': 15054.91, 'timeToFirstByte': 9674.06, 'p50TimeToFirstByte': 9398.831707, 'p90TimeToFirstByte': 12832.674533, 'p99TimeToFirstByte': 15053.854631}
INFO     root:client.py:1853 aws cloudwatch put-metric-data --namespace "serving_handler" --region "us-east-1" --metric-data '[{"MetricName": "vllm-handler-chat-batch-512_p50Latency", "Unit": "Milliseconds", "Value": 9399.38}, {"MetricName": "vllm-handler-chat-batch-512_p90Latency", "Unit": "Milliseconds", "Value": 12833.87}, {"MetricName": "vllm-handler-chat-batch-512_p50TimeToFirstByte", "Unit": "Milliseconds", "Value": 9398.831707}, {"MetricName": "vllm-handler-chat-batch-512_p90TimeToFirstByte", "Unit": "Milliseconds", "Value": 12832.674533}, {"MetricName": "vllm-handler-chat-batch-512_tokenThroughput", "Unit": "Count/Second", "Value": 7572.5}, {"MetricName": "vllm-handler-chat-batch-512_tps", "Unit": "Count/Second", "Value": 52.92}, {"MetricName": "vllm-handler-chat-batch-512_tokenPerRequest", "Unit": "Count", "Value": 143}]'
PASSED
```