### PR TITLE
[fix] Add vllm_async_handler as entrypoint to VLLM async integration tests

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1497,24 +1497,17 @@ text_embedding_model_list = {
 }
 
 handler_performance_model_list = {
-    "tiny-llama-lmi": {
-        "engine": "MPI",
-        "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.rolling_batch": "lmi-dist",
-        "option.max_rolling_batch_size": 512,
-    },
     "tiny-llama-vllm": {
         "engine": "Python",
+        "option.rolling_batch": "disable",
+        "option.async_mode": True,
         "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.task": "text-generation",
-        "option.rolling_batch": "vllm",
         "option.gpu_memory_utilization": "0.9",
         "option.max_rolling_batch_size": 512,
     },
     "tiny-llama-trtllm": {
         "engine": "Python",
         "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-        "option.rolling_batch": "trtllm",
         "option.max_rolling_batch_size": 512,
     },
 }

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -1504,6 +1504,7 @@ handler_performance_model_list = {
         "option.model_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
         "option.gpu_memory_utilization": "0.9",
         "option.max_rolling_batch_size": 512,
+        "option.entryPoint": "djl_python.lmi_vllm.vllm_async_service",
     },
     "tiny-llama-trtllm": {
         "engine": "Python",

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -358,6 +358,12 @@ class TestTrtLlmHandler2:
             r.launch("CUDA_VISIBLE_DEVICES=0,1,2,3")
             client.run("trtllm flan-t5-xl".split())
 
+    def test_trtllm_performance(self):
+        with Runner('tensorrt-llm', 'handler-performance-trtllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-trtllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance trtllm".split())
+
 
 @pytest.mark.lmi_dist
 @pytest.mark.gpu_4
@@ -647,6 +653,12 @@ class TestVllm1:
             assert req_time < 20
             client.run(
                 "vllm tinyllama-input-len-exceeded --in_tokens 10".split())
+
+    def test_vllm_performance(self):
+        with Runner('lmi', 'handler-performance-vllm') as r:
+            prepare.build_handler_performance_model("tiny-llama-vllm")
+            r.launch("CUDA_VISIBLE_DEVICES=0")
+            client.run("handler_performance vllm".split())
 
 
 @pytest.mark.vllm
@@ -1177,20 +1189,3 @@ class TestTextEmbedding:
             prepare.build_text_embedding_model("bge-base-onnx")
             r.launch()
             client.run("text_embedding bge-base-onnx".split())
-
-
-@pytest.mark.gpu
-@pytest.mark.handler_performance
-class TestGPUHandlerPerformance:
-
-    def test_vllm(self):
-        with Runner('lmi', 'handler-performance-vllm') as r:
-            prepare.build_handler_performance_model("tiny-llama-vllm")
-            r.launch("CUDA_VISIBLE_DEVICES=0")
-            client.run("handler_performance vllm".split())
-
-    def test_trtllm(self):
-        with Runner('tensorrt-llm', 'handler-performance-trtllm') as r:
-            prepare.build_handler_performance_model("tiny-llama-trtllm")
-            r.launch("CUDA_VISIBLE_DEVICES=0")
-            client.run("handler_performance trtllm".split())


### PR DESCRIPTION
## Description ##

Add vllm_async_handler as entrypoint to VLLM async integration tests

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
