### PR TITLE
[0.33.0-dlc][docker] Pin cuda-compat-12-8 to 570.148.08-0ubuntu1

### DIFF
--- a/serving/docker/cuda-compat
+++ b/serving/docker/cuda-compat
@@ -1,0 +1,3 @@
+Package: cuda-compat-12-8
+Pin: version 570.148.08-0ubuntu1
+Pin-Priority: 1001

--- a/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
+++ b/serving/docker/dockerd-entrypoint-with-cuda-compat.sh
@@ -30,6 +30,10 @@ if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
   fi
 else
   echo "Skip CUDA compat libs setup as package not found"
+  if [ -n "$TEST_DJL_VERSION" ]; then
+    echo "Error: CUDA compat libs not found"
+    exit 1
+  fi
 fi
 
 if [[ -n "$SM_NEO_EXECUTION_CONTEXT" ]]; then

--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -61,6 +61,7 @@ ENV PATH="/opt/djl/bin:${PATH}"
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]
 
+COPY cuda-compat /etc/apt/preferences.d/cuda-compat
 COPY scripts scripts/
 RUN chmod -R +x scripts
 RUN mkdir -p /opt/djl/conf \


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

* Pin cuda-compat-12-8 to 570.148.08-0ubuntu1
* Update dockerd-entrypoint-with-cuda-compat.sh so that in integration tests, if cuda-compat not installed, we fail the job.

Customer reported an error: `undefined symbol: cuTensorMapEncodeTiled`

The root cause for this is cuda-compat lib not installed correctly. See the log:

```
Skip CUDA compat libs setup as package not found
```

We install it by the command:

```
apt-get install cuda-compat-12-8
```

However, the latest cuda-compat-12-8 package (https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-compat-12-8_575.57.08-0ubuntu1_amd64.deb) is only 12KB. It has no binaries in it and will create empty installation.

See screenshot from the nvidia download page https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/

<img width="980" alt="Screenshot 2025-06-09 at 11 23 21 PM" src="https://github.com/user-attachments/assets/4668296b-0dfb-4cec-b814-a0debd7b121a" />

To fix this, we need to pin the cuda-compat-12-8 package to the latest good version 570.148.08-0ubuntu1.

One thing to note is that, the reason that the error didn't happen in the github actions is because our github action runner has relatively new cuda driver version, like 570.133.20. While sagemaker instances has very old driver version, like 535.247.01.

So I also updated dockerd-entrypoint-with-cuda-compat.sh to make sure in integration tests we can always catch cuda-compat lib not installed, despite github action runner cuda driver version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
