### PR TITLE
[fix] Add handling for abrupt process termination

### DIFF
--- a/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyPredictor.java
@@ -27,6 +27,9 @@ import ai.djl.translate.TranslatorContext;
 import ai.djl.util.Pair;
 import ai.djl.util.PairList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +39,7 @@ import java.util.regex.Pattern;
 
 class PyPredictor<I, O> extends Predictor<I, O> {
 
+    private static final Logger logger = LoggerFactory.getLogger(PyPredictor.class);
     private static final Pattern BATCH_PATTERN = Pattern.compile("batch_(\\d+)\\.(.*)");
 
     private PyProcess process;
@@ -60,8 +64,17 @@ class PyPredictor<I, O> extends Predictor<I, O> {
             throw new EngineException(
                     "Backend Python process is unrecoverable. Initiating worker termination");
         }
+        if (process.hasProcessExitedAbruptly()) {
+            logger.warn("Detected abrupt termination of Python worker process, attempting restart");
+            process.stopPythonProcess(true);
+            process.resetProcessExitedAbruptlyFlag();
+            try {
+                process.startPythonProcess();
+            } catch (Exception ex) {
+                logger.error("Failed to restart Python process after abrupt exit", ex);
+            }
+        }
         if (!process.isReady()) {
-            // TODO: wait for restart
             throw new TranslateException("Backend Python process is stopped.");
         }
         Object first = inputs.get(0);


### PR DESCRIPTION
## Description ##

- Add additional flag for server to detect if worker has gone down unexpectedly, e.g. segmentation fault from the underlying engine, and trigger process restart accordingly
- Tested behavior by sending SIGSEGV to `mpirun` process to simulate crash, verifying successful restart upon subsequent requests

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
