### PR TITLE
[fix] Add handling for abrupt process termination (#2857)

### DIFF
--- a/buildSrc/src/main/kotlin/ai/djl/javaBase.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai/djl/javaBase.gradle.kts
@@ -14,9 +14,6 @@ val libs = the<LibrariesForLibs>()
 var servingVersion: String? = System.getenv("DJL_VERSION")
 val stagingRepo: String? = System.getenv("DJL_STAGING")
 servingVersion = if (servingVersion == null) libs.versions.serving.get() else servingVersion
-if (!project.hasProperty("staging")) {
-    servingVersion += "-SNAPSHOT"
-}
 
 group = "ai.djl.serving"
 version = servingVersion!!

--- a/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
+++ b/engines/python/src/main/java/ai/djl/python/engine/PyProcess.java
@@ -55,6 +55,7 @@ class PyProcess {
     private AtomicInteger restartCount;
     private CompletableFuture<Void> restartFuture;
     private boolean passiveWorkersMode;
+    private AtomicInteger processExitedAbruptly;
 
     private static AtomicInteger counter = new AtomicInteger(0);
 
@@ -62,6 +63,7 @@ class PyProcess {
         this.model = model;
         this.pyEnv = pyEnv;
         this.workerId = workerId;
+        this.processExitedAbruptly = new AtomicInteger(0);
         int port = counter.getAndIncrement();
         if (pyEnv.isMpiMode()) {
             int tensorParallelDegree = pyEnv.getTensorParallelDegree();
@@ -145,6 +147,7 @@ class PyProcess {
             if (!initialLoad) {
                 logger.info("Restart python process ...");
                 restartFuture = CompletableFuture.runAsync(this::startPythonProcess);
+                CompletableFuture.runAsync(this::monitorRestart);
             } else {
                 modelUnrecoverable = true;
             }
@@ -152,6 +155,35 @@ class PyProcess {
                 throw (EngineException) e;
             }
             throw new EngineException(e);
+        }
+    }
+
+    private void monitorRestart() {
+        try {
+            Thread.sleep(5000);
+            while (!restartFuture.isDone() && process != null) {
+                if (isProcessDead()) {
+                    logger.warn(
+                            "Python process exited unexpectedly with code: {}",
+                            process.exitValue());
+                    processExitedAbruptly.set(1);
+                    restartFuture.cancel(true);
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+        } catch (InterruptedException e) {
+            logger.warn("Process monitoring interrupted", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean isProcessDead() {
+        try {
+            process.exitValue();
+            return true;
+        } catch (IllegalThreadStateException e) {
+            return false;
         }
     }
 
@@ -267,6 +299,14 @@ class PyProcess {
         return modelUnrecoverable;
     }
 
+    boolean hasProcessExitedAbruptly() {
+        return processExitedAbruptly.get() > 0 && modelLoaded;
+    }
+
+    void resetProcessExitedAbruptlyFlag() {
+        processExitedAbruptly.set(0);
+    }
+
     private static String[] getHosts(int clusterSize) {
         String leaderAddr = Utils.getenv("DJL_LEADER_ADDR");
         String workerAddrFormat = Utils.getenv("DJL_WORKER_ADDR_FORMAT");
@@ -329,6 +369,10 @@ class PyProcess {
             } finally {
                 logger.info("ReaderThread({}) stopped - {}", processId, getName());
                 lifeCycle.setStarted(false, processId);
+                if (lifeCycle.pyEnv.isMpiMode() && lifeCycle.modelLoaded) {
+                    lifeCycle.processExitedAbruptly.set(1);
+                    logger.warn("MPI worker may have gone down unexpectedly");
+                }
                 try {
                     is.close();
                 } catch (IOException e) {

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -677,6 +677,7 @@ class TestVllm1:
             client.run(
                 "vllm tinyllama-input-len-exceeded --in_tokens 10".split())
 
+
 @pytest.mark.vllm
 @pytest.mark.lora
 @pytest.mark.gpu_4


### PR DESCRIPTION
## Description ##

- Add additional flag for server to detect if worker has gone down unexpectedly, e.g. segmentation fault from the underlying engine, and trigger process restart accordingly
- Tested behavior by sending SIGSEGV to `mpirun` process to simulate crash, verifying successful restart upon subsequent requests

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
