### PR TITLE
Fix build for 0.32.0 LMI DLC

### DIFF
--- a/serving/docker/requirements-lmi.txt
+++ b/serving/docker/requirements-lmi.txt
@@ -1,5 +1,7 @@
 peft==0.13.2
 llmcompressor
+# required for vllm 0.6.3, nolonger on pypi
+git+https://github.com/NICTA/pyairports.git@9699eae8c6b03c97239018dea92e01daa8594936
 # flash infer kernels for vllm/lmi-dist
 https://github.com/flashinfer-ai/flashinfer/releases/download/v0.1.6/flashinfer-0.1.6+cu124torch2.4-cp311-cp311-linux_x86_64.whl
 # vllm wheel built with pt2.5.1


### PR DESCRIPTION
## Description ##

PyAirports dependency broken for vLLM 0.6.3 build. See vLLM issue: https://github.com/vllm-project/vllm/issues/23983

This is caused by the package being delisted from PyPi. Previously available here: https://web.archive.org/web/20241114154647/https://pypi.org/project/pyairports/

Manually install the dependency from github, tagging a specific commit.
