### PR TITLE
Use UTC timezone to format session expiration ts

### DIFF
--- a/engines/python/setup/djl_python/session_utils.py
+++ b/engines/python/setup/djl_python/session_utils.py
@@ -10,9 +10,9 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
 # the specific language governing permissions and limitations under the License.
-import datetime
 import logging
 
+from datetime import datetime, timezone
 from djl_python.async_utils import create_non_stream_output
 from djl_python.outputs import Output
 
@@ -26,8 +26,9 @@ async def create_session(request):
     session_manager, inputs = request
     try:
         session = session_manager.create_session()
-        expiration_ts = datetime.datetime.fromtimestamp(
-            session.expiration_ts).strftime("%Y-%m-%dT%H:%M:%SZ")
+        expiration_ts = datetime.fromtimestamp(
+            session.expiration_ts,
+            tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         logger.info(f"Session {session.session_id} created")
         return {
             "data": {

--- a/serving/docs/stateful_sessions.md
+++ b/serving/docs/stateful_sessions.md
@@ -73,7 +73,7 @@ create_session_response = smr_client.invoke_endpoint(
     SessionId="NEW_SESSION")
 ```
 
-The LMI container handles the request by starting a new session. The container provides the session ID and expiration timestamp by setting the following HTTP header in the response:
+The LMI container handles the request by starting a new session. The container provides the session ID and expiration timestamp (UTC timezone) by setting the following HTTP header in the response:
 
 ```
 X-Amzn-SageMaker-Session-Id: session_id; Expires=yyyy-mm-ddThh:mm:ssZ


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Use UTC timezone to format session expiration ts, to avoid confusion when endpoint instances in different timezone with the client.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L72); One example would be `pytest tests.py -k "TestCorrectnessLmiDist"  -m "lmi_dist"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
