### PR TITLE
Fix lmi image build by adding --no-build-isolation to pip deps which require it

### DIFF
--- a/serving/docker/lmi-container-requirements-no-iso.txt
+++ b/serving/docker/lmi-container-requirements-no-iso.txt
@@ -1,0 +1,2 @@
+autoawq
+flashinfer-python==0.2.5

--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -23,7 +23,6 @@ scipy==1.16.0
 onnx==1.19.0
 sentence_transformers
 onnxruntime-gpu==1.20.0
-autoawq
 tokenizers
 pydantic==2.11.7
 optimum==1.23.2
@@ -33,4 +32,3 @@ peft
 llmcompressor
 vllm==0.10.2
 xgrammar
-flashinfer-python==0.2.5

--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -89,8 +89,10 @@ RUN scripts/patch_oss_dlc.sh python \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 COPY lmi-container-requirements.txt ./requirements.txt
+COPY lmi-container-requirements-no-iso.txt ./requirements-no-build-isolation.txt
 RUN pip3 install torch==2.8.0 torchvision \
     && pip3 install -r requirements.txt \
+    && pip3 install --no-build-isolation -r requirements-no-build-isolation.txt \
     && pip3 install ${djl_converter_wheel} --no-deps
 
 COPY distribution[s]/ ./


### PR DESCRIPTION
## Description ##

LMI image build has started failing because some ML dependencies, `autoawq` and `flashinfer-python`, require the `--no-build-isolation` flag during pip installation. This is because they require `torch` to be separately pre-installed in their build environment. 

This PR separates these dependencies into their own requirements file and then installs it with `--no-build-isolation` to fix this issue. Now, during installation those deps will use the `torch` which is pre-installed to site-packages in the Dockerfile.
