### PR TITLE
Fix s5cmd CVE by using custom build with Go 1.24.2

### DIFF
--- a/serving/docker/scripts/install_s5cmd.sh
+++ b/serving/docker/scripts/install_s5cmd.sh
@@ -4,17 +4,18 @@ set -ex
 
 ARCH=$1
 
+# Download custom s5cmd binary built with Go 1.24.2
 if [[ $ARCH == "aarch64" ]]; then
-  curl https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-arm64.tar.gz -L -o s5cmd.tar.gz
+  curl -f https://publish.djl.ai/s5cmd/go1.24.2/s5cmd-linux-arm64 -L -o s5cmd
 else
-  curl https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-64bit.tar.gz -L -o s5cmd.tar.gz
+  curl -f https://publish.djl.ai/s5cmd/go1.24.2/s5cmd-linux-amd64 -L -o s5cmd
 fi
 
 INSTALL_DIR="/opt/djl/bin"
 
 mkdir -p "${INSTALL_DIR}"
-tar -xvf s5cmd.tar.gz -C "${INSTALL_DIR}"
-rm -rf s5cmd.tar.gz
+mv s5cmd "${INSTALL_DIR}/"
+chmod +x "${INSTALL_DIR}/s5cmd"
 
 export PATH="${INSTALL_DIR}:${PATH}"
 echo "export PATH=${INSTALL_DIR}:\$PATH" >>~/.bashrc


### PR DESCRIPTION
- Binaries built with Go 1.24.2 instead of Go 1.22
- Resolves CVE vulnerabilities in s5cmd dependency

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
