### PR TITLE
Use s5cmd built with Go 1.25.4 to address CVE

### DIFF
--- a/serving/docker/scripts/install_s5cmd.sh
+++ b/serving/docker/scripts/install_s5cmd.sh
@@ -4,11 +4,11 @@ set -ex
 
 ARCH=$1
 
-# Download custom s5cmd binary built with Go 1.25.2
+# Download custom s5cmd binary built with Go 1.25.4
 if [[ $ARCH == "aarch64" ]]; then
-  curl -f https://publish.djl.ai/s5cmd/go1.25.2/s5cmd-linux-arm64 -L -o s5cmd
+  curl -f https://publish.djl.ai/s5cmd/go1.25.4/s5cmd-linux-arm64 -L -o s5cmd
 else
-  curl -f https://publish.djl.ai/s5cmd/go1.25.2/s5cmd-linux-amd64 -L -o s5cmd
+  curl -f https://publish.djl.ai/s5cmd/go1.25.4/s5cmd-linux-amd64 -L -o s5cmd
 fi
 
 INSTALL_DIR="/opt/djl/bin"


### PR DESCRIPTION
## Description ##

To address CVE https://www.wiz.io/vulnerability-database/cve/cve-2025-58187