### PR TITLE
Updated s5cmd script to build with specified version of go to address related CVEs

### DIFF
--- a/serving/docker/scripts/install_s5cmd.sh
+++ b/serving/docker/scripts/install_s5cmd.sh
@@ -4,18 +4,42 @@ set -ex
 
 ARCH=$1
 
-# Download custom s5cmd binary built with Go 1.25.4
-if [[ $ARCH == "aarch64" ]]; then
-  curl -f https://publish.djl.ai/s5cmd/go1.25.4/s5cmd-linux-arm64 -L -o s5cmd
-else
-  curl -f https://publish.djl.ai/s5cmd/go1.25.4/s5cmd-linux-amd64 -L -o s5cmd
+# Install jq if not available (for lmi container)
+if ! command -v jq &> /dev/null; then
+    apt-get update && apt-get install -y jq
 fi
 
-INSTALL_DIR="/opt/djl/bin"
+# Retrieve latest patched version
+GO_MAJOR_MINOR="1.25"
+GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq -r ".[].version" | grep "^go${GO_MAJOR_MINOR}" | head -1 | sed 's/go//')
+echo "Using Go version: ${GO_VERSION} (latest in ${GO_MAJOR_MINOR}.x series)"
 
+if [[ $ARCH == "aarch64" ]]; then
+  GO_ARCH="arm64"
+else
+  GO_ARCH="amd64"
+fi
+
+curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | tar -xz -C /tmp
+export PATH="/tmp/go/bin:${PATH}"
+export GOPATH="/tmp/gopath"
+export GOCACHE="/tmp/gocache"
+
+# Download s5cmd release source
+S5CMD_VERSION="v2.3.0"
+echo "Building s5cmd ${S5CMD_VERSION}"
+curl -fsSL "https://github.com/peak/s5cmd/archive/refs/tags/${S5CMD_VERSION}.tar.gz" | tar -xz -C /tmp
+mv /tmp/s5cmd-${S5CMD_VERSION#v} /tmp/s5cmd
+cd /tmp/s5cmd
+go build -ldflags "-X github.com/peak/s5cmd/v2/version.Version=${S5CMD_VERSION}" -o s5cmd .
+
+# Install s5cmd
+INSTALL_DIR="/opt/djl/bin"
 mkdir -p "${INSTALL_DIR}"
 mv s5cmd "${INSTALL_DIR}/"
 chmod +x "${INSTALL_DIR}/s5cmd"
+
+rm -rf /tmp/go /tmp/gopath /tmp/gocache /tmp/s5cmd
 
 export PATH="${INSTALL_DIR}:${PATH}"
 echo "export PATH=${INSTALL_DIR}:\$PATH" >>~/.bashrc


### PR DESCRIPTION
## Description ##

The current public release of s5cmd has known vulnerabilities caused by go 1.22. This PR updates the install_s5cmd script to build s5cmd with the latest patched version of the go major release specified in the script

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
