### PR TITLE
Added new tag for CPU-full container to match new naming convention

### DIFF
--- a/serving/docker/scripts/push_image_from_ECR.sh
+++ b/serving/docker/scripts/push_image_from_ECR.sh
@@ -41,4 +41,17 @@ if [[ "$image" == "cpu" ]]; then
     docker tag "$from_repo:$base_tag-$commit_sha" "$to_repo:$version-nightly"
     docker push "$to_repo:$version-nightly"
   fi
+elif [[ "$image" == "cpu-full" ]]; then
+  # Extract library versions from Dockerfile for new CPU container naming convention
+  PYTHON_VER=$(grep '^ARG python_version=' ../Dockerfile | cut -d'=' -f2 | tr -d '.')
+  TORCH_VER=$(grep '^ARG torch_version=' ../Dockerfile | cut -d'=' -f2)
+  SKLEARN_VER=$(grep '^ARG sklearn_version=' ../Dockerfile | cut -d'=' -f2)
+  XGBOOST_VER=$(grep '^ARG xgboost_version=' ../Dockerfile | cut -d'=' -f2)
+  
+  version_tag="$version-xgb$XGBOOST_VER-skl$SKLEARN_VER-torch$TORCH_VER-py$PYTHON_VER-cpu"
+  if [[ "$mode" == "nightly" ]]; then
+    version_tag="$version_tag-nightly"
+  fi
+  docker tag "$from_repo:$base_tag-$commit_sha" "$to_repo:$version_tag"
+  docker push "$to_repo:$version_tag"
 fi


### PR DESCRIPTION
## Description ##

We plan on renaming the DJL cpu container to follow a new naming convention that better describes the library versions in the container:

`0.36.0-xgb3.0-skl1.7-torch1.2-py313-cpu`

This PR adds an additional tag to the djl cpu container when pushing to ECR for this purpose. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
