### PR TITLE
[ci] Remove --runtime=nvidia from launch_container.sh

### DIFF
--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -85,9 +85,9 @@ fi
 
 is_llm=false
 if [[ "$platform" == *"-gpu"* ]]; then # if the platform has cuda capabilities
-  runtime="nvidia"
+  gpus="all"
 elif [[ "$platform" == *"lmi"* || "$platform" == *"trtllm"* || "$platform" == *"tensorrt-llm"* ]]; then # Runs multi-gpu
-  runtime="nvidia"
+  gpus="all"
   is_llm=true
   if [[ "$(is_p4d_or_p5)" == *"true"* || $is_multi_node ]]; then
     shm="20gb"
@@ -157,7 +157,6 @@ if $is_multi_node; then
     -e DJL_LEADER_ADDR=${leader_hostname} \
     -e DJL_WORKER_ADDR_FORMAT="${LWS_NAME}-${GROUP_INDEX}-%d.${LWS_NAME}.${NAMESPACE}" \
     ${env_file} \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
     "${docker_image}" "service ssh start; djl-serving"
@@ -179,7 +178,6 @@ if $is_multi_node; then
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     ${env_file} \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
     "${docker_image}" "service ssh start; /usr/bin/python3 /opt/djl/partition/run_multi_node_setup.py 2>&1 | tee /opt/djl/logs/lmi-worker.log; tail -f"
@@ -187,6 +185,7 @@ elif $is_sm_neo_context; then
   docker run \
     -t \
     --rm \
+    ${gpus:+--gpus ${gpus}} \
     --network="host" \
     ${model_path:+-v ${model_path}/uncompiled:/opt/ml/model/input} \
     ${model_path:+-v ${model_path}/compiled:/opt/ml/model/compiled} \
@@ -207,7 +206,6 @@ elif $is_sm_neo_context; then
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     ${env_file} \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
     "${docker_image}"
@@ -217,6 +215,7 @@ elif $is_partition; then
   docker run \
     -t \
     --rm \
+    ${gpus:+--gpus ${gpus}} \
     --network="host" \
     ${model_path:+-v ${model_path}/test:/opt/ml/input/data/training} \
     -v ${PWD}/logs:/opt/djl/logs \
@@ -228,7 +227,6 @@ elif $is_partition; then
     -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
     "${docker_image}" \
@@ -239,6 +237,7 @@ elif [[ "$docker_image" == *"text-generation-inference"* ]]; then
   container_id=$(docker run \
     -itd \
     --rm \
+    ${gpus:+--gpus ${gpus}} \
     -p 8080:80 \
     ${model_path:+-v ${model_path}:/opt/ml/model:ro} \
     -v ~/sagemaker_infra/:/opt/ml/.sagemaker_infra/:ro \
@@ -247,7 +246,6 @@ elif [[ "$docker_image" == *"text-generation-inference"* ]]; then
     -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     "${docker_image}" \
     ${args})
@@ -259,6 +257,7 @@ else
   container_id=$(docker run \
     -itd \
     --rm \
+    ${gpus:+--gpus ${gpus}} \
     --network="host" \
     ${model_path:+-v ${model_path}:/opt/ml/model:ro} \
     -v ${PWD}/logs:/opt/djl/logs \
@@ -272,7 +271,6 @@ else
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     $uid_mapping \
-    ${runtime:+--runtime="${runtime}"} \
     ${shm:+--shm-size="${shm}"} \
     ${host_device:+ ${host_device}} \
     "${docker_image}" \


### PR DESCRIPTION
## Description ##

The `--runtime=nvidia` docker run flag is being deprecated and doesn't work in all environments. It is not needed as long as the `--gpus` flag is set

