### PR TITLE
Update LMI container to PyTorch 2.9.1, vLLM 0.14.0, and protobuf 6.30+

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -1,8 +1,8 @@
-torch==2.9.0
+torch==2.9.1
 autoawq
 torchvision
 peft==0.15.1
-protobuf==4.25.8
+protobuf>=6.30.0
 transformers==4.57.1
 hf-transfer
 zstandard
@@ -32,7 +32,7 @@ uvloop
 ninja
 peft
 llmcompressor
-vllm==0.12.0
+vllm==0.14.0
 xgrammar
 flashinfer-python==0.5.3
 lmcache

--- a/serving/docker/lmi.Dockerfile
+++ b/serving/docker/lmi.Dockerfile
@@ -90,7 +90,7 @@ RUN scripts/patch_oss_dlc.sh python \
 
 COPY lmi-container-requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip setuptools
-RUN pip3 install torch==2.9.0 torchvision \
+RUN pip3 install torch==2.9.1 torchvision \
     && pip3 install -r requirements.txt \
     && pip3 install ${djl_converter_wheel} --no-deps
 


### PR DESCRIPTION
## Description ##

Update vLLM to latest released version (0.14.0) for LMI v19 release. 0.14.0 requires protobuf>=6.30.0 and torch 2.9.1

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
