### PR TITLE
updated vllm toolparser imports that changed in 0.14.0 + fixed LMCache integration tests

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Union, Any, Callable, Annotated, Tuple,
 from pydantic import Field
 from vllm import TokensPrompt
 from vllm.entrypoints.openai.serving_engine import RequestPrompt, TextTokensPrompt
-from vllm.entrypoints.openai.tool_parsers import ToolParser
+from vllm.tool_parsers import ToolParser
 from vllm.tokenizers.mistral import maybe_serialize_tool_calls
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.entrypoints.openai.protocol import ChatCompletionRequest

--- a/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
+++ b/engines/python/setup/djl_python/properties_manager/vllm_rb_properties.py
@@ -121,7 +121,7 @@ class VllmRbProperties(Properties):
     @model_validator(mode='after')
     def validate_tool_call_parser(self):
         if self.enable_auto_tool_choice:
-            from vllm.entrypoints.openai.tool_parsers import ToolParserManager
+            from vllm.tool_parsers import ToolParserManager
             valid_tool_parses = ToolParserManager.list_registered()
             if self.tool_call_parser not in valid_tool_parses:
                 raise ValueError(

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -55,7 +55,7 @@ class VLLMRollingBatch(RollingBatch):
         self.tool_parser = None
         self.reasoning_parser = None
         if self.vllm_configs.enable_auto_tool_choice:
-            from vllm.entrypoints.openai.tool_parsers import ToolParserManager
+            from vllm.tool_parsers import ToolParserManager
             try:
                 self.tool_parser = ToolParserManager.get_tool_parser(
                     self.vllm_configs.tool_call_parser)

--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -284,10 +284,10 @@ vllm_model_spec = {
         "seq_length": [256],
         "tokenizer": "Qwen/Qwen3-8B"
     },
-    "qwen2.5-72b-lmcache-auto": {
+    "qwen2.5-32b-lmcache-auto": {
         "batch_size": [1, 4],
         "seq_length": [256],
-        "tokenizer": "Qwen/Qwen2.5-72B"
+        "tokenizer": "Qwen/Qwen2.5-32B"
     },
 }
 

--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -529,7 +529,7 @@ vllm_model_list = {
     },
     "qwen3-8b-no-cache": {
         "option.model_id": "Qwen/Qwen3-8B",
-        "option.tensor_parallel_degree": 1,
+        "option.tensor_parallel_degree": 2,
         "option.load_format": "dummy",
         "option.max_new_tokens": 100,
         "option.enable_prefix_caching": False,
@@ -671,6 +671,15 @@ vllm_model_list = {
         "lmcache_redis.yaml",
         "option.kv_transfer_config":
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}',
+    },
+    "qwen2.5-32b": {
+        "option.model_id": "Qwen/Qwen2.5-32B",
+        "option.tensor_parallel_degree": 4,
+        "option.load_format": "dummy",
+        "option.max_new_tokens": 100,
+        "option.max_model_len": 16384,
+        "option.enable_prefix_caching": False,
+        "load_on_devices": 0,
     },
 }
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -715,12 +715,12 @@ class TestVllmLmcache_g6:
             client.run("vllm_lmcache qwen3-8b-lmcache-auto".split())
 
     def test_lmcache_auto_config_larger_model(self):
-        with Runner("lmi", "qwen2.5-72b-no-cache") as r:
-            prepare.build_vllm_async_model("qwen2.5-72b")
+        with Runner("lmi", "qwen2.5-32b") as r:
+            prepare.build_vllm_async_model("qwen2.5-32b")
             r.launch(env_vars=[
                 "PYTHONHASHSEED=0", "OPTION_LMCACHE_AUTO_CONFIG=True"
             ])
-            client.run("vllm_lmcache qwen2.5-72b-lmcache-auto".split())
+            client.run("vllm_lmcache qwen2.5-32b-lmcache-auto".split())
 
 
 @pytest.mark.vllm


### PR DESCRIPTION
## Description ##

Per https://github.com/vllm-project/vllm/pull/30675: `vllm.entrypoints.openai.tool_parsers.ToolParser` has been moved to `vllm.tool_parsers.ToolParser`. The old name will be removed in v0.14.`

Updated imports and fixed LMCache integration tests to work on g6.12x instance (used by runner)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
