### PR TITLE
test_lora_llama3_8b_async_with_custom_code - increase output length

### DIFF
--- a/tests/integration/llm/client.py
+++ b/tests/integration/llm/client.py
@@ -821,6 +821,9 @@ def extract_chat_content(response_content):
         line = line.strip()
         if not line:
             continue
+
+        if line.startswith("data: "):
+            line = line[6:]  # Remove "data: " prefix
         try:
             parsed = json.loads(line)
             # Non-streaming chat completion format
@@ -1576,6 +1579,16 @@ def response_checker(res, message):
             for item in message.split('\n'):
                 item = item.strip()
                 if len(item) > 0:
+                    if item.startswith('data: '):
+                        item = item[6:]  # Remove "data: " prefix
+
+                    # Skip [DONE] markers
+                    if item == '[DONE]':
+                        continue
+
+                    # Skip empty items after stripping
+                    if not item:
+                        continue
                     try:
                         json_lines.append(json.loads(item))
                     except json.JSONDecodeError as e:
@@ -1714,6 +1727,18 @@ def check_output_formatter_applied(response_text, expected_identifier):
         line = line.strip()
         if not line:
             continue
+
+        if line.startswith('data: '):
+            line = line[6:]  # Remove "data: " prefix
+
+        # Skip [DONE] markers
+        if line == '[DONE]':
+            continue
+
+        # Skip empty lines after stripping
+        if not line:
+            continue
+
         try:
             parsed_json = json.loads(line)
             # Check for text completion format


### PR DESCRIPTION
## Description ##

Increase output length to see if test_lora_llama3_8b_async_with_custom_code produces more varied outputs with different adapters. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
