### PR TITLE
updating LMIv21 container requirements to use updated wheel

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -7,6 +7,6 @@ sentence-transformers==3.3.1
 optimum==1.23.2
 llmcompressor==0.9.0.1
 mpi4py==4.0.1
-https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.15.1.dev2%2Bgb225806e5.cu128-cp312-cp312-linux_x86_64.whl
+https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.15.2.dev2%2Bgdbf910fd4-cp312-cp312-linux_x86_64.whl
 lmcache
 autoawq


### PR DESCRIPTION
## Description ##

Same as mentioned in the title 

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
