### PR TITLE
fix docker build error by freezing setuptools version

### DIFF
--- a/serving/docker/scripts/install_python.sh
+++ b/serving/docker/scripts/install_python.sh
@@ -25,6 +25,9 @@ else
   python3 get-pip.py
   rm -rf get-pip.py
 fi
-python3 -m pip --no-cache-dir install -U pip setuptools wheel
+
+# fix fetuptools version for this else you get following error
+#  ModuleNotFoundError: No module named 'pkg_resources'
+python3 -m pip --no-cache-dir install -U pip wheel setuptools==80.9.0
 python3 -m pip --no-cache-dir install -U "numpy<2" awscli
 ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Description ##

Latest version of setuptools 82.0.0 causes problems with the oss_compliance check script. Fixing it to ==80.9.0 
pkg_resources has been removed from setuptools== 82.0.0 onwards
https://github.com/pypa/setuptools/issues/3085
https://setuptools.pypa.io/en/stable/history.html#v82-0-0

