### PR TITLE
Fix broken vllm.entrypoints.openai.protocol import in chat completions

### DIFF
--- a/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Optional, Union, Any, Callable, Annotated, Tuple,
 
 from pydantic import Field
 from vllm import TokensPrompt
-from vllm.entrypoints.openai.protocol import RequestPrompt, TextTokensPrompt
 from vllm.tool_parsers import ToolParser
 from vllm.tokenizers.mistral import maybe_serialize_tool_calls
 from vllm.transformers_utils.tokenizer import AnyTokenizer
@@ -112,7 +111,7 @@ def _preprocess_chat(
     tool_parser: Optional[Callable[[AnyTokenizer], ToolParser]] = None,
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None,
     add_special_tokens: bool = False,
-) -> Tuple[List[ConversationMessage], RequestPrompt, TokensPrompt, str]:
+) -> Tuple[List[ConversationMessage], Union[str, List[int]], TokensPrompt, str]:
     resolved_content_format = resolve_chat_template_content_format(
         chat_template,
         tool_dicts,
@@ -161,7 +160,7 @@ def _preprocess_chat(
         )
     else:
         # MistralTokenizer case
-        prompt_inputs = TextTokensPrompt(
+        prompt_inputs = TokensPrompt(
             prompt=tokenizer.decode(request_prompt),
             prompt_token_ids=request_prompt)
 
@@ -180,7 +179,7 @@ def tokenize_prompt_input(request: ChatCompletionRequest,
                           max_model_len: int,
                           truncate_prompt_tokens: Optional[Annotated[
                               int, Field(ge=1)]] = None,
-                          add_special_tokens: bool = True) -> TextTokensPrompt:
+                          add_special_tokens: bool = True) -> TokensPrompt:
     if isinstance(prompt_input, str):
         return normalize_prompt_text_to_input(
             request,
@@ -207,7 +206,7 @@ def normalize_prompt_text_to_input(
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]],
     add_special_tokens: bool,
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     if truncate_prompt_tokens is None:
         encoded = tokenizer(prompt, add_special_tokens=add_special_tokens)
     else:
@@ -225,7 +224,7 @@ def normalize_prompt_tokens_to_input(
     prompt_ids: List[int],
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]],
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     if truncate_prompt_tokens is None:
         input_ids = prompt_ids
     else:
@@ -239,7 +238,7 @@ def validate_input(
     input_ids: List[int],
     input_text: str,
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     token_num = len(input_ids)
 
     # chat completion endpoint supports max_completion_tokens
@@ -259,4 +258,4 @@ def validate_input(
             f"{max_tokens} in the completion). "
             f"Please reduce the length of the messages or completion.")
 
-    return TextTokensPrompt(prompt=input_text, prompt_token_ids=input_ids)
+    return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)


### PR DESCRIPTION
## Summary

- Fixes the `/v1/chat/completions` endpoint failing with `No module named 'vllm.entrypoints.openai.protocol'` when using vLLM rolling batch backend
- The `TextTokensPrompt` and `RequestPrompt` types were removed from vLLM in v0.13.0 (the entire `vllm/entrypoints/openai/protocol.py` module no longer exists). This import was introduced in #2995 when upgrading to vLLM 0.15.0
- Replaces `TextTokensPrompt` with `TokensPrompt` (already imported from `vllm`) which has the same `prompt` and `prompt_token_ids` fields
- Inlines the `RequestPrompt` union type (`Union[str, List[int]]`) in the single type annotation where it was used

Fixes #3000

## Context

In vLLM <= v0.12.0, `TextTokensPrompt` and `RequestPrompt` lived in `vllm.entrypoints.openai.serving_engine`. Starting in v0.13.0, these types were removed entirely and their functionality was consolidated into `vllm.TokensPrompt` (from `vllm.inputs.data`). The DJL code already imports `TokensPrompt` from `vllm` and uses it throughout the file, so this is a minimal and safe replacement.

## Test plan

- [ ] Deploy a model with `OPTION_ROLLING_BATCH=vllm` using a DJL LMI container
- [ ] Send a chat-formatted request to `/v1/chat/completions` and verify it no longer returns a 424 error
- [ ] Verify both HF tokenizer and Mistral tokenizer code paths work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)