### PR TITLE
[0.36.0-lmi24-dlc] Fix UID mapping in launch container script

### DIFF
--- a/tests/integration/launch_container.sh
+++ b/tests/integration/launch_container.sh
@@ -108,8 +108,7 @@ if [[ -f ${PWD}/docker_env ]]; then
 fi
 
 rm -rf logs
-mkdir -p logs
-touch logs/serving.log
+mkdir logs
 
 set -ex
 
@@ -260,7 +259,7 @@ elif [[ "$docker_image" == *"text-generation-inference"* ]]; then
 else
   echo "$(whoami), UID: $UID"
   if [[ "$UID" == "1000" ]]; then
-    uid_mapping="-u djl"
+    uid_mapping="-u 1000"
   fi
   container_id=$(docker run \
     -itd \


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

This PR is to fix UID mapping in launch container script. User djl doesn't have permission to write to logs folder, causing the serving.log to be empty. Changing to `-u 1000` will fix the permission issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
