### PR TITLE
Transformer dependency pinning and chat completions fix.

### DIFF
--- a/engines/python/setup/djl_python/__init__.py
+++ b/engines/python/setup/djl_python/__init__.py
@@ -15,3 +15,5 @@ from .inputs import Input
 from .outputs import Output
 from .pair_list import PairList
 from .session_manager import SessionManager, Session
+
+__version__ = "0.36.0"

--- a/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
+++ b/engines/python/setup/djl_python/chat_completions/vllm_chat_utils.py
@@ -14,21 +14,25 @@ from typing import Dict, List, Optional, Union, Any, Callable, Annotated, Tuple,
 
 from pydantic import Field
 from vllm import TokensPrompt
-from vllm.entrypoints.openai.protocol import RequestPrompt, TextTokensPrompt
+from vllm.inputs import TextPrompt
 from vllm.tool_parsers import ToolParser
 from vllm.tokenizers.mistral import maybe_serialize_tool_calls
-from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.tokenizers import TokenizerLike
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.chat_utils import (
-    apply_hf_chat_template, apply_mistral_chat_template, parse_chat_messages,
-    resolve_chat_template_content_format, ChatCompletionMessageParam,
+    parse_chat_messages, ChatCompletionMessageParam,
     ChatTemplateContentFormatOption, ConversationMessage)
+from vllm.renderers.hf import (
+    safe_apply_chat_template, resolve_chat_template_content_format)
 
 from djl_python.rolling_batch.vllm_rolling_batch import VLLMRollingBatch
 
-# The logic in this file is heavily inspired by https://github.com/vllm-project/vllm/blob/v0.7.1/vllm/entrypoints/openai/serving_chat.py#L109
-# Many of the utilities and validation logic are modified directly from vLLM's code
+# The logic in this file is heavily inspired by vLLM's chat completion serving code.
+# Many of the utilities and validation logic are modified directly from vLLM's code.
 # TODO: Figure out a way to integrate with vLLM at a higher level than we do now to avoid this code
+
+# Type aliases for backward compatibility
+RequestPrompt = Union[str, list[int]]
 
 
 def parse_chat_completions_request_vllm(
@@ -81,12 +85,11 @@ def parse_chat_completions_request_vllm(
     # Use max_tokens from request if provided, otherwise use default
     max_tokens = chat_params.max_tokens or chat_params.max_completion_tokens or default_max_new_tokens
     sampling_params = chat_params.to_sampling_params(
-        max_tokens, rolling_batch.engine.model_config.logits_processor_pattern,
-        default_sampling_params)
+        max_tokens, default_sampling_params)
     params = {
         "stream": chat_params.stream,
         "output_formatter":
-        "jsonlines_chat" if chat_params.stream else "json_chat",
+        "sse_chat" if chat_params.stream else "json_chat",
         "sampling_params": sampling_params,
         "conversation": conversation,
         "request_prompts": request_prompt,
@@ -100,7 +103,7 @@ def parse_chat_completions_request_vllm(
 
 def _preprocess_chat(
     request: ChatCompletionRequest,
-    tokenizer: AnyTokenizer,
+    tokenizer: TokenizerLike,
     messages: List[ChatCompletionMessageParam],
     chat_template: Optional[str],
     chat_template_content_format: ChatTemplateContentFormatOption,
@@ -109,7 +112,7 @@ def _preprocess_chat(
     continue_final_message: bool = False,
     tool_dicts: Optional[List[Dict[str, Any]]] = None,
     documents: Optional[List[Dict[str, str]]] = None,
-    tool_parser: Optional[Callable[[AnyTokenizer], ToolParser]] = None,
+    tool_parser: Optional[Callable[[TokenizerLike], ToolParser]] = None,
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None,
     add_special_tokens: bool = False,
 ) -> Tuple[List[ConversationMessage], RequestPrompt, TokensPrompt, str]:
@@ -122,7 +125,6 @@ def _preprocess_chat(
     conversation, mm_data, mm_uuids = parse_chat_messages(
         messages,
         rolling_batch.engine.model_config,
-        tokenizer,
         content_format=resolved_content_format,
     )
     chat_template_kwargs: Dict[str, Any] = dict(
@@ -135,14 +137,14 @@ def _preprocess_chat(
 
     request_prompt: Union[str, List[int]]
     if rolling_batch.is_mistral_tokenizer:
-        request_prompt = apply_mistral_chat_template(tokenizer,
-                                                     messages=messages,
-                                                     **chat_template_kwargs)
+        # Mistral tokenizer handles chat template application directly
+        request_prompt = tokenizer.apply_chat_template(
+            messages, **chat_template_kwargs)
     else:
-        request_prompt = apply_hf_chat_template(
+        request_prompt = safe_apply_chat_template(
+            rolling_batch.engine.model_config,
             tokenizer,
-            conversation=conversation,
-            model_config=rolling_batch.engine.model_config,
+            conversation,
             **chat_template_kwargs)
 
     should_parse_tools = tool_parser is not None and request.tool_choice != "none"
@@ -161,7 +163,7 @@ def _preprocess_chat(
         )
     else:
         # MistralTokenizer case
-        prompt_inputs = TextTokensPrompt(
+        prompt_inputs = TokensPrompt(
             prompt=tokenizer.decode(request_prompt),
             prompt_token_ids=request_prompt)
 
@@ -175,12 +177,12 @@ def _preprocess_chat(
 
 
 def tokenize_prompt_input(request: ChatCompletionRequest,
-                          tokenizer: AnyTokenizer,
+                          tokenizer: TokenizerLike,
                           prompt_input: Union[str, List[int]],
                           max_model_len: int,
                           truncate_prompt_tokens: Optional[Annotated[
                               int, Field(ge=1)]] = None,
-                          add_special_tokens: bool = True) -> TextTokensPrompt:
+                          add_special_tokens: bool = True) -> TokensPrompt:
     if isinstance(prompt_input, str):
         return normalize_prompt_text_to_input(
             request,
@@ -202,12 +204,12 @@ def tokenize_prompt_input(request: ChatCompletionRequest,
 
 def normalize_prompt_text_to_input(
     request: ChatCompletionRequest,
-    tokenizer: AnyTokenizer,
+    tokenizer: TokenizerLike,
     prompt: str,
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]],
     add_special_tokens: bool,
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     if truncate_prompt_tokens is None:
         encoded = tokenizer(prompt, add_special_tokens=add_special_tokens)
     else:
@@ -221,11 +223,11 @@ def normalize_prompt_text_to_input(
 
 def normalize_prompt_tokens_to_input(
     request: ChatCompletionRequest,
-    tokenizer: AnyTokenizer,
+    tokenizer: TokenizerLike,
     prompt_ids: List[int],
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]],
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     if truncate_prompt_tokens is None:
         input_ids = prompt_ids
     else:
@@ -239,7 +241,7 @@ def validate_input(
     input_ids: List[int],
     input_text: str,
     max_model_len: int,
-) -> TextTokensPrompt:
+) -> TokensPrompt:
     token_num = len(input_ids)
 
     # chat completion endpoint supports max_completion_tokens
@@ -259,4 +261,4 @@ def validate_input(
             f"{max_tokens} in the completion). "
             f"Please reduce the length of the messages or completion.")
 
-    return TextTokensPrompt(prompt=input_text, prompt_token_ids=input_ids)
+    return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)

--- a/engines/python/setup/djl_python/output_formatter.py
+++ b/engines/python/setup/djl_python/output_formatter.py
@@ -507,6 +507,24 @@ def _jsonlines_chat_output_formatter(request_output: TextGenerationOutput):
     return json_encoded_str
 
 
+def _sse_chat_output_formatter(request_output: TextGenerationOutput):
+    """
+    SSE output formatter for chat completions API (OpenAI-compatible).
+    Wraps each chunk with 'data: ' prefix and adds [DONE] at end.
+    """
+    output_str = _jsonlines_chat_output_formatter(request_output)
+    if not output_str:
+        return ""
+    # Check if this is the last token by looking at finish_reason in the output
+    result = f"data: {output_str}\n"
+    # If the json contains a non-null finish_reason, append [DONE]
+    best_sequence = request_output.sequences[
+        request_output.best_sequence_index]
+    if best_sequence.finish_reason is not None:
+        result += "data: [DONE]\n\n"
+    return result
+
+
 def sse_response_formatter(request_output: TextGenerationOutput):
     """
     Decorator that used to form as SSE
@@ -569,6 +587,8 @@ def get_output_formatter(output_formatter: Union[str, Callable], stream: bool,
         return _json_chat_output_formatter, "application/json"
     if output_formatter == "jsonlines_chat":
         return _jsonlines_chat_output_formatter, "application/jsonlines"
+    if output_formatter == "sse_chat":
+        return _sse_chat_output_formatter, "text/event-stream"
     if output_formatter == "3p":
         return _json_3p_output_formatter, "application/json"
     if output_formatter == "3p_stream":

--- a/engines/python/setup/djl_python/tests/test_rolling_batch.py
+++ b/engines/python/setup/djl_python/tests/test_rolling_batch.py
@@ -3,7 +3,7 @@ import unittest
 
 from djl_python.request import Request
 from djl_python.output_formatter import _json_output_formatter, _jsonlines_output_formatter, \
-    _jsonlines_chat_output_formatter, _json_chat_output_formatter
+    _jsonlines_chat_output_formatter, _json_chat_output_formatter, _sse_chat_output_formatter
 from djl_python.request_io import Token, TextGenerationOutput, TextInput
 
 
@@ -885,6 +885,51 @@ class TestRollingBatch(unittest.TestCase):
             "length"
         }],
                          json.loads(req.get_next_token())["choices"])
+        req.reset_next_token()
+
+    def test_sse_chat(self):
+        req = Request(
+            TextInput(request_id=0,
+                      input_text="This is a wonderful day",
+                      parameters={"max_new_tokens": 256},
+                      output_formatter=_sse_chat_output_formatter))
+
+        # First token - should have data: prefix and role
+        req.set_next_token(Token(244, "He", -0.334532))
+        output = req.get_next_token()
+        self.assertTrue(output.startswith("data: "))
+        self.assertTrue(output.endswith("\n\n"))
+        payload = json.loads(output[len("data: "):].strip())
+        self.assertEqual(payload["object"], "chat.completion.chunk")
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "He")
+        self.assertEqual(payload["choices"][0]["delta"]["role"], "assistant")
+        self.assertIsNone(payload["choices"][0]["finish_reason"])
+        self.assertNotIn("[DONE]", output)
+        req.reset_next_token()
+
+        # Middle token - no role, no [DONE]
+        req.set_next_token(Token(576, "llo", -0.123123))
+        output = req.get_next_token()
+        self.assertTrue(output.startswith("data: "))
+        payload = json.loads(output[len("data: "):].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "llo")
+        self.assertNotIn("role", payload["choices"][0]["delta"])
+        self.assertNotIn("[DONE]", output)
+        req.reset_next_token()
+
+        # Last token - should have finish_reason and [DONE]
+        req.set_next_token(Token(4558, " world", -0.567854), True, 'length')
+        output = req.get_next_token()
+        self.assertTrue(output.startswith("data: "))
+        # Split into SSE events
+        events = output.split("\n\n")
+        # First event is the data chunk
+        data_line = events[0]
+        payload = json.loads(data_line[len("data: "):])
+        self.assertEqual(payload["choices"][0]["delta"]["content"], " world")
+        self.assertEqual(payload["choices"][0]["finish_reason"], "length")
+        # [DONE] should be present
+        self.assertIn("data: [DONE]", output)
         req.reset_next_token()
 
     def test_custom_fmt(self):

--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu130
 torch==2.11.0
 torchvision==0.26.0
-transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0
+transformers >= 4.56.0, <= 5.9.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0
 huggingface-hub
 hf-transfer
 peft==0.19.1


### PR DESCRIPTION
## Description ##
Update DJL chat completions handling for vLLM 0.22 API compatibility and fix OpenAI SSE streaming format.                                                                                                                                            
                                                                                                                                                                                                                                                         
  Changes:                                                                                                                                                                                                                                               
  1. vllm_chat_utils.py — Rewrite imports and API calls for vLLM 0.22 breaking changes:                                                                                                                                                                  
    - AnyTokenizer → TokenizerLike (moved to vllm.tokenizers)                                                                                                                                                                                            
    - apply_hf_chat_template → safe_apply_chat_template (moved to vllm.renderers.hf)                                                                                                                                                                   
    - apply_mistral_chat_template → tokenizer.apply_chat_template() directly                                                                                                                                                                             
    - resolve_chat_template_content_format → imported from vllm.renderers.hf                                                                                                                                                                             
    - parse_chat_messages — removed tokenizer positional arg                                                                                                                                                                                             
    - to_sampling_params — removed logits_processor_pattern arg                                                                                                                                                                                          
  2. output_formatter.py — Add _sse_chat_output_formatter that emits proper OpenAI SSE format (data: {...}\n\n + data: [DONE]\n\n) for streaming chat completions.                                                                                       
  3. lmi-container-requirements.txt — Pin transformers<=5.9.0 to avoid MistralCommonImageProcessor.fetch_images AttributeError introduced in 5.10.                  

## Type of change
  - Bug fix (non-breaking change which fixes an issue)                                                                                                                                                                                                   
  - New feature (non-breaking change which adds functionality)  

## Feature/Issue validation/testing

  - Unit Tests — test_rolling_batch.py (24 passed including new test_sse_chat)                                                                                                                                                                           
  $ python -m pytest djl_python/tests/test_rolling_batch.py -x -q                                                                                                                                                                                      
  24 passed, 6 warnings in 0.13s 

  - Import Verification — All vLLM 0.22 imports validated inside container                                                                                                                                                                               
  $ docker run --rm --entrypoint python3 deepjavalibrary/djl-serving:0.36.0-lmi -c "                                                                                                                                                                     
  from vllm.tokenizers import TokenizerLike                                                                                                                                                                                                              
  from vllm.renderers.hf import safe_apply_chat_template, resolve_chat_template_content_format                                                                                                                                                           
  from vllm.entrypoints.chat_utils import parse_chat_messages, ChatCompletionMessageParam                                                                                                                                                                
  print('All imports OK') 
                                                                                                                                                                                                                                                         
  - AIPerf Benchmark — 20/20 requests successful with streaming chat endpoint                                                                                                                                                                          
  $ aiperf profile --model google/gemma-4-26B-A4B-it --url http://localhost:8080 --endpoint-type chat --streaming --concurrency 2 --request-count 20                                                                                                     
  Output Token Throughput: 373.9 tokens/sec                                                                                                                                                                                                            
  Request Throughput: 1.85 req/sec                                                                                                                                                                                                                       
  Request Count: 20 (0 errors)                                                                                                                                                                                                                           
                                 
