### PR TITLE
Kfhfar/vllm async OOM Integ Tests Failure Issue

### DIFF
--- a/engines/python/setup/djl_python/custom_handler_service.py
+++ b/engines/python/setup/djl_python/custom_handler_service.py
@@ -12,6 +12,7 @@
 # the specific language governing permissions and limitations under the License.
 
 import logging
+import os
 from djl_python.inputs import Input
 from djl_python.service_loader import load_model_service, has_function_in_module
 from djl_python.async_utils import create_non_stream_output
@@ -37,14 +38,25 @@ class CustomHandlerService:
 
     def _initialize(self, properties: dict):
         model_dir = properties.get("model_dir", ".")
+        model_file = os.path.join(model_dir, "model.py")
+        if not os.path.exists(model_file):
+            logger.debug("No model.py found, skipping custom handler")
+            return
         try:
             service = load_model_service(model_dir, "model.py", -1)
             if has_function_in_module(service.module, "handle"):
                 self.custom_handler = service
                 logger.info("Loaded custom handler from model.py")
                 self.initialized = True
+            else:
+                logger.info(
+                    "model.py found but has no handle() function, skipping custom handler"
+                )
+        except (SyntaxError, ImportError) as e:
+            raise CustomHandlerError(
+                f"Failed to load custom handler model.py: {e}", e)
         except Exception as e:
-            logger.debug(f"No custom handler found in model.py: {e}")
+            logger.debug(f"Could not load custom handler from model.py: {e}")
 
     async def handle(self, inputs: Input):
         if self.custom_handler:

--- a/engines/python/setup/djl_python/lmi_vllm/vllm_async_service.py
+++ b/engines/python/setup/djl_python/lmi_vllm/vllm_async_service.py
@@ -442,6 +442,13 @@ async def handle(
     if custom_service is None:
         custom_service = CustomHandlerService(inputs.get_properties())
 
+    # Skip custom handler for init/empty requests (no inference content)
+    if inputs.is_empty():
+        if not service.initialized and not custom_service.initialized:
+            await service.initialize(inputs.get_properties())
+            logger.info("vllm service initialized")
+        return None
+
     # Try custom handler first
     if custom_service.initialized:
         logger.info("Using custom handler for request")
@@ -453,8 +460,6 @@ async def handle(
     if not service.initialized:
         await service.initialize(inputs.get_properties())
         logger.info("vllm service initialized")
-    if inputs.is_empty():
-        return None
 
     outputs = await service.inference(inputs)
     return outputs


### PR DESCRIPTION
## Description ##
The fix eliminates the OOM that poisoned GPU state, which was the root cause of the abnormally slow CUDA graph profiling that pushed the inference response past the timeout.
 
 Example : https://github.com/deepjavalibrary/djl-serving/actions/runs/27238677290/job/80442990367
 
 