### PR TITLE
[LMI] Update vLLM wheel to 0.23.0 base for LMI v27

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -8,8 +8,8 @@ peft==0.19.1
 sentence-transformers==5.4.1
 optimum==2.1.0
 mpi4py==4.1.1
-compressed-tensors==0.15.0.1
-https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.22.1.dev0%2Bg0b3ba88f1.d20260605-cp312-cp312-linux_x86_64.whl
+compressed-tensors==0.17.0
+https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883-cp312-cp312-linux_x86_64.whl
 autoawq==0.2.9
 lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1


### PR DESCRIPTION
## Description
Update the custom vLLM wheel for the LMI v27 release.

**Changes (serving/docker/lmi-container-requirements.txt):**
1. vLLM wheel `0.22.1.dev0+g0b3ba88f1` → `0.23.1.dev4+gcd87ce883` — base vLLM **v0.23.0** + jinhuang12 PR#3 (gemma-4-31B NVFP4) + PR#2 (Nemotron-3-Super NVFP4) + fardin tuned unified-attention patch. Wheel arches: sm_80/86/89/90/100/120.
2. `compressed-tensors` `0.15.0.1` → `0.17.0` — required to match vLLM 0.23.0 (0.22 pinned 0.15.0.1; 0.23.0 requires 0.17.0). Without this, `pip install -r requirements.txt` fails with ResolutionImpossible.

## Type of change
- Bug fix / dependency update (non-breaking)

## Validation
Local container build (`docker compose build lmi`) pulling the wheel **from S3** (mirrors the nightly pipeline build):
- Image builds clean (19/19 stages).
- `import vllm` inside the container reports: vllm `0.23.1.dev4+gcd87ce883`, compressed-tensors `0.17.0`, torch `2.11.0+cu130`.
