### PR TITLE
[LMI] Fix llama3-8b-chunked-prefill OOM on L4 under vLLM 0.23 (max_rolling_batch_size=128)

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -140,6 +140,13 @@ vllm_model_list = {
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 4,
         "option.enable_chunked_prefill": "true",
+        # vLLM 0.23 reserves ~0.78 GiB more KV than 0.22 (15.41->16.19 GiB on this 8B/TP4 config),
+        # which starves the post-profiling FULL CUDA-graph capture on tight 22 GiB L4 (g6) cards:
+        # at the default max_rolling_batch_size=256 the capture needs 35 graphs / 0.64 GiB and the
+        # card OOMs by ~60-130 MiB. Pinning batch=128 halves the capture sizes (35->19 graphs,
+        # 0.64->0.44 GiB) and the test fits. Reproduced + fix validated on a g6/L4 ballasted to
+        # CI's 22.04 GiB. (base vLLM 0.23 behavior, not a regression in the v27 wheel.)
+        "option.max_rolling_batch_size": 128,
     },
     "falcon-11b-chunked-prefill": {
         "option.model_id": "s3://djl-llm/falcon-11B/",


### PR DESCRIPTION
## Problem
`TestVllm1_g6 / test_llama3_8b_chunked_prefill` OOMs at `_initialize_kv_caches` on the g6 (L4, ~22 GiB) nightly, first red after the LMI v27 vLLM-0.23 wheel landed (#3054).

## Root cause (reproduced + isolated)
Not a regression in the v27 wheel or the cherry-picked kernels. It is **base vLLM 0.23 behavior**: vLLM 0.23 reserves ~0.78 GiB more KV cache than 0.22 (15.41 → 16.19 GiB on this llama-3-8b / TP=4 config). That extra KV is allocated *before* the FULL CUDA-graph capture, so on a tight ~22 GiB L4 at the default `max_rolling_batch_size=256` (→ 35 FULL graphs / 0.64 GiB capture) the card OOMs by ~60–130 MiB.

Verified on a g6/L4 ballasted to CI’s exact 22.04 GiB, vLLM default `gpu_memory_utilization=0.92`:
| config | FULL graphs | capture | outcome |
|---|---|---|---|
| raw vLLM 0.22.0, batch 256 | 35 | 0.60 GiB | PASS |
| raw vLLM 0.23.0, batch 256 | 35 | 0.64 GiB | **OOM** |
| LMI v27 (0.23.1), batch 256 | 35 | 0.64 GiB | **OOM** (matches CI) |
| LMI v27 (0.23.1), **batch 128** | 19 | 0.44 GiB | **PASS** |

(LMI v27 == stock 0.23.0 on KV/capture to the MiB → the cherry-picks add zero memory.)

## Fix
Pin `option.max_rolling_batch_size=128` on the `llama3-8b-chunked-prefill` test entry. Halves the cudagraph capture sizes (35→19 FULL graphs, 0.64→0.44 GiB) so the test fits on the L4. `max_rolling_batch_size` is the customer-facing throughput knob (preferred over a `gpu_memory_utilization` override); the test asserts chunked-prefill correctness, not batch=256 specifically.

## Test
Reproduced the OOM and validated the fix locally on a g6/L4 ballasted to 22.04 GiB using the exact `prepare.py`-generated serving.properties.
