### PR TITLE
[0.36.0-lmi27-dlc] Fix llama3-8b-chunked-prefill OOM on L4 (max_rolling_batch_size=128)

### DIFF
--- a/tests/integration/llm/prepare.py
+++ b/tests/integration/llm/prepare.py
@@ -140,6 +140,13 @@ vllm_model_list = {
         "option.task": "text-generation",
         "option.tensor_parallel_degree": 4,
         "option.enable_chunked_prefill": "true",
+        # vLLM 0.23 reserves ~0.78 GiB more KV than 0.22 (15.41->16.19 GiB on this 8B/TP4 config),
+        # which starves the post-profiling FULL CUDA-graph capture on tight 22 GiB L4 (g6) cards:
+        # at the default max_rolling_batch_size=256 the capture needs 35 graphs / 0.64 GiB and the
+        # card OOMs by ~60-130 MiB. Pinning batch=128 halves the capture sizes (35->19 graphs,
+        # 0.64->0.44 GiB) and the test fits. Reproduced + fix validated on a g6/L4 ballasted to
+        # CI's 22.04 GiB. (base vLLM 0.23 behavior, not a regression in the v27 wheel.)
+        "option.max_rolling_batch_size": 128,
     },
     "falcon-11b-chunked-prefill": {
         "option.model_id": "s3://djl-llm/falcon-11B/",


### PR DESCRIPTION
Backport of the `llama3-8b-chunked-prefill` L4 OOM fix to the LMI v27 release branch (cherry-pick of the master PR #3055).

**Root cause:** base vLLM 0.23 reserves ~0.78 GiB more KV than 0.22 (15.41→16.19 GiB on llama-3-8b TP=4), starving the post-profiling FULL CUDA-graph capture on the tight ~22 GiB L4 g6 runner. At the default `max_rolling_batch_size=256` (35 FULL graphs / 0.64 GiB capture) the card OOMs by ~60–130 MiB. Not a regression in the v27 wheel — stock vLLM 0.23.0 OOMs identically at batch 256.

**Fix:** pin `option.max_rolling_batch_size=128` (35→19 FULL graphs, 0.64→0.44 GiB capture). Reproduced + validated on a g6/L4 ballasted to CI’s exact 22.04 GiB. Unblocks the v27 nightly (`TestVllm1_g6`).
