### PR TITLE
[LMI v27] Point vLLM wheel at gemma4-26B LoRA reconstructed build

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -9,7 +9,7 @@ sentence-transformers==5.4.1
 optimum==2.1.0
 mpi4py==4.1.1
 compressed-tensors==0.17.0
-https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883-cp312-cp312-linux_x86_64.whl
+https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883.gemma426blora-cp312-cp312-linux_x86_64.whl
 autoawq==0.2.9
 lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1


### PR DESCRIPTION
## What

Bump the custom vLLM wheel referenced by the LMI container from
`vllm-0.23.1.dev4+gcd87ce883` to `vllm-0.23.1.dev4+gcd87ce883.gemma426blora`
in `serving/docker/lmi-container-requirements.txt`.

## Why

The new wheel is the **same content** as the shipped LMI v27 wheel (OSS vLLM
v0.23.0 + the three v27 patches [described in 2ab1ff0]) **plus** vLLM PR #43254, which adds gemma-4-26B
MoE LoRA support (`get_expert_mapping` + `is_3d_moe_weight` on
`Gemma4ForCausalLM`). This unblocks LoRA adapters on gemma-4-26B under LMI.

## Provenance / verification

- Wheel rebuilt from source and verified **byte-identical** to the shipped v27
  wheel across all 1919 `.py` files **except** the two the fix touches
  (`gemma4.py` = the PR #43254 hunks, `_version.py` = the version string).
- All four custom sm100 CUDA ops register and are callable; build is
  production-faithful (CUDA 13 / torch cu130, matching the shipped wheel).
- gemma-4-26B LoRA inference validated on H200 (base + adapter load, MoE-LoRA
  path engaged, no `get_expert_mapping` error) with a passing negative control.