### PR TITLE
Remove Ubuntu pip packages

### DIFF
--- a/serving/docker/scripts/install_python.sh
+++ b/serving/docker/scripts/install_python.sh
@@ -19,6 +19,7 @@ else
   else
     DEBIAN_FRONTEND=noninteractive apt-get install -y "python${PYTHON_VERSION}-dev" "python${PYTHON_VERSION}-distutils" "python${PYTHON_VERSION}-venv"
   fi
+  apt-get purge -y python3-pip python3-pip-whl
   ln -sf /usr/bin/"python${PYTHON_VERSION}" /usr/bin/python3
   ln -sf /usr/bin/"python${PYTHON_VERSION}" /usr/bin/python
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Remove Ubuntu's `python3-pip`, `python3-pip-whl` packages.

1) Ubuntu's `python3-pip`, `python3-pip-whl` packages has CVEs.
2) LMI container install its own pip package, so Ubuntu's `python3-pip`, `python3-pip-whl` packages are not needed.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [ ] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
