### PR TITLE
Revert "[LMI v27] Point vLLM wheel at gemma4-26B LoRA reconstructed build (#3057)"

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -9,7 +9,7 @@ sentence-transformers==5.4.1
 optimum==2.1.0
 mpi4py==4.1.1
 compressed-tensors==0.17.0
-https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883.gemma426blora-cp312-cp312-linux_x86_64.whl
+https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883-cp312-cp312-linux_x86_64.whl
 autoawq==0.2.9
 lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1


### PR DESCRIPTION
## Revert #3057 — restore the standard v27 vLLM wheel

Reverts commit 7e13b081383bd46293d4b49ab214d4757b1effd5 ("[LMI v27] Point vLLM wheel at gemma4-26B LoRA reconstructed build (#3057)") on the **`0.36.0-lmi27-dlc` release branch only** (master/mainline untouched).

### What this changes
Restores the vLLM wheel pointer in `serving/docker/lmi-container-requirements.txt` from the gemma4-26B-LoRA reconstructed build back to the standard LMI v27 build:

```diff
-.../vllm-0.23.1.dev4%2Bgcd87ce883.gemma426blora-cp312-cp312-linux_x86_64.whl
+.../vllm-0.23.1.dev4%2Bgcd87ce883-cp312-cp312-linux_x86_64.whl
```

This is the wheel that was built + benchmarked for the v27 release (`0.23.1.dev4+gcd87ce883`, base = vLLM v0.23.0 + the 4 v27 cherry-picks).

### Why
The LoRA-reconstructed wheel was not the artifact validated for the v27 launch. Reverting to the standard wheel means **no new wheel build and no benchmark re-run** are required.

### Scope / safety
- **Single-line change**, one file.
- **Xin Yang's #3059** ("Remove Ubuntu pip packages") is fully preserved — it sits below this revert and is untouched (it's a Docker build-script change with no wheel impact).
- Restored wheel verified present on S3 and **SHA256-matched** to the benchmarked build (`2421608d…9eb66`).