### PR TITLE
lmi v27 gemma4 lora patch

### DIFF
--- a/serving/docker/lmi-container-requirements.txt
+++ b/serving/docker/lmi-container-requirements.txt
@@ -9,7 +9,7 @@ sentence-transformers==5.4.1
 optimum==2.1.0
 mpi4py==4.1.1
 compressed-tensors==0.17.0
-https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883-cp312-cp312-linux_x86_64.whl
+https://djl-ai.s3.us-east-1.amazonaws.com/publish/vllm/vllm-0.23.1.dev4%2Bgcd87ce883.gemma426blora-cp312-cp312-linux_x86_64.whl
 autoawq==0.2.9
 lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1


### PR DESCRIPTION
This reinstates PR #3057 (commit 7e13b081), which was reverted by #3061 (b9814150) only to let the initial v27 image ship on time with the known-good original wheel. Re-applying it for the v27 patch re-release (lmi27 v1.0 -> v1.1) that carries gemma-4-26B MoE LoRA support.

Bumps the custom vLLM wheel from 0.23.1.dev4+gcd87ce883 to 0.23.1.dev4+gcd87ce883.gemma426blora = same shipped-v27 wheel content (OSS vLLM 0.23.0 + Rohit's 3 patches) PLUS vLLM PR #43254 (gemma-4-26B MoE LoRA: get_expert_mapping + is_3d_moe_weight on Gemma4ForCausalLM).

Wheel verified byte-identical to the shipped v27 wheel except the gemma4 LoRA fix + version string; uploaded to s3://djl-ai/publish/vllm/ (new object, original wheel untouched); URL returns HTTP 200.

This reverts commit b9814150.
