### PR TITLE
Surface vLLM extract_hidden_states via VLLMRollingBatch

### DIFF
--- a/engines/python/setup/djl_python/request_io.py
+++ b/engines/python/setup/djl_python/request_io.py
@@ -85,6 +85,9 @@ class Sequence:
         cumulative_log_prob: cumulative log probability of the sequence.
         finish_reason: finish reason of the sequence.
         stop_reason: stop reason of the sequence.
+        hidden_states_path: path to a file containing extracted hidden states
+            for this sequence (rolling_batch=vllm with extract_hidden_states),
+            or None if hidden state extraction was not requested/configured.
     """
     tokens: List[Token] = field(default_factory=lambda: [])
     top_tokens: Optional[List[List[Token]]] = field(default_factory=lambda: [])
@@ -92,6 +95,7 @@ class Sequence:
     finish_reason: str = None
     _last_token_index: Optional[int] = None
     stop_reason: Optional[str] = None
+    hidden_states_path: Optional[str] = None
     _tokens_iterator: Optional[Iterator] = field(init=False, default=None)
     _top_tokens_iterator: Optional[Iterator] = field(init=False, default=None)
 

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -92,11 +92,23 @@ def update_request_cache_with_output(request_cache: OrderedDict,
 
 
 def update_multiple_sequences(request_output, vllm_request_output):
+    # kv_transfer_params is set by vLLM's extract_hidden_states mechanism
+    # (rolling_batch=vllm + speculative_config method=extract_hidden_states +
+    # a hidden-states KV connector) - None for all other configurations, so
+    # this is a no-op for the common case.
+    hidden_states_path = None
+    if vllm_request_output.kv_transfer_params:
+        hidden_states_path = vllm_request_output.kv_transfer_params.get(
+            "hidden_states_path")
+
     for completion_output in vllm_request_output.outputs:
         sequence_index = completion_output.index
 
         if sequence_index not in request_output.sequences:
             request_output.sequences[sequence_index] = Sequence()
+        if hidden_states_path is not None:
+            request_output.sequences[
+                sequence_index].hidden_states_path = hidden_states_path
 
         # get the newly generated token_ids
         new_token_ids = completion_output.token_ids

--- a/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
+++ b/engines/python/setup/djl_python/rolling_batch/rolling_batch_vllm_utils.py
@@ -97,9 +97,10 @@ def update_multiple_sequences(request_output, vllm_request_output):
     # a hidden-states KV connector) - None for all other configurations, so
     # this is a no-op for the common case.
     hidden_states_path = None
-    if vllm_request_output.kv_transfer_params:
-        hidden_states_path = vllm_request_output.kv_transfer_params.get(
-            "hidden_states_path")
+    kv_transfer_params = getattr(vllm_request_output, "kv_transfer_params",
+                                 None)
+    if kv_transfer_params:
+        hidden_states_path = kv_transfer_params.get("hidden_states_path")
 
     for completion_output in vllm_request_output.outputs:
         sequence_index = completion_output.index

--- a/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
+++ b/engines/python/setup/djl_python/rolling_batch/vllm_rolling_batch.py
@@ -148,6 +148,17 @@ class VLLMRollingBatch(RollingBatch):
             parameters["logprobs"] = parameters.pop("top_n_tokens")
         else:
             parameters["logprobs"] = parameters.get("logprobs", 1)
+
+        # kv_transfer_params (e.g. for vLLM's extract_hidden_states feature -
+        # see rolling_batch_vllm_utils.update_multiple_sequences) is not a
+        # SamplingParams field itself, so it must go through extra_args or
+        # filter_unused_generation_params below would silently drop it.
+        kv_transfer_params = parameters.pop("kv_transfer_params", None)
+        if kv_transfer_params is not None:
+            extra_args = parameters.get("extra_args") or {}
+            extra_args["kv_transfer_params"] = kv_transfer_params
+            parameters["extra_args"] = extra_args
+
         parameters = filter_unused_generation_params(parameters,
                                                      VLLM_GENERATION_PARAMS,
                                                      "vllm",

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -346,6 +346,25 @@ def _compare_tokens(expected_token, actual_token):
            expected_token.log_prob == actual_token.log_prob
 
 
+def _mock_vllm_module():
+    """A `vllm` module stand-in whose `SamplingParams().__struct_fields__`
+    mirrors the real msgspec.Struct fields translate_vllm_params relies on.
+    Without this, SamplingParams is an unconfigured MagicMock and
+    VLLM_GENERATION_PARAMS (computed from __struct_fields__ at import time)
+    ends up empty, so filter_unused_generation_params silently strips every
+    field - including extra_args - and the routing it's supposed to
+    exercise is never actually tested."""
+    sampling_params = MagicMock()
+    sampling_params.__struct_fields__ = ("max_tokens", "temperature", "top_p",
+                                         "n", "best_of", "stop", "seed",
+                                         "logprobs", "prompt_logprobs",
+                                         "ignore_eos", "use_beam_search",
+                                         "output_kind", "extra_args")
+    vllm_module = MagicMock()
+    vllm_module.SamplingParams.return_value = sampling_params
+    return vllm_module
+
+
 class TestVllmUtils(unittest.TestCase):
 
     @mock.patch(
@@ -722,13 +741,14 @@ class TestVllmUtils(unittest.TestCase):
 
         self.assertIsNone(req.request_output.sequences[0].hidden_states_path)
 
-    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm': _mock_vllm_module()})
     @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.sampling_params': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.utils': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.utils.counter': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils.argparse_utils': MagicMock()})
     def test_translate_vllm_params_routes_kv_transfer_params_to_extra_args(
             self):
         """kv_transfer_params is not itself a SamplingParams field, so it
@@ -748,13 +768,14 @@ class TestVllmUtils(unittest.TestCase):
         self.assertEqual({"include_output_tokens": True},
                          result["extra_args"]["kv_transfer_params"])
 
-    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm': _mock_vllm_module()})
     @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.sampling_params': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.utils': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.utils.counter': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils.argparse_utils': MagicMock()})
     def test_translate_vllm_params_no_kv_transfer_params_is_noop(self):
         """No kv_transfer_params in the request parameters (the common case)
         must not add an extra_args key that wasn't already there."""

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -60,6 +60,7 @@ class MockRequestOutput:
         prompt_logprobs: Optional[MockPromptLogprobs],
         outputs: List[MockCompletionOutput],
         finished: bool,
+        kv_transfer_params: Optional[Dict[str, Union[str, bool]]] = None,
     ) -> None:
         self.request_id = request_id
         self.prompt = prompt
@@ -67,6 +68,7 @@ class MockRequestOutput:
         self.prompt_logprobs = prompt_logprobs
         self.outputs = outputs
         self.finished = finished
+        self.kv_transfer_params = kv_transfer_params
 
 
 example_request_output = [
@@ -294,6 +296,46 @@ example_chunked_prefill_request_output = [
                                                stop_reason=None)
                       ],
                       finished=False),
+]
+
+example_hidden_states_request_output = [
+    MockRequestOutput(
+        request_id="test_hidden_states_request_id",
+        prompt="I am a",
+        prompt_token_ids=[1, 315, 837, 264],
+        prompt_logprobs=None,
+        outputs=[
+            MockCompletionOutput(index=0,
+                                 text=' member',
+                                 token_ids=[4292],
+                                 cumulative_logprob=-4.2740092277526855,
+                                 logprobs=None,
+                                 finish_reason='length',
+                                 stop_reason=None)
+        ],
+        finished=True,
+        kv_transfer_params={
+            "hidden_states_path": "/tmp/hidden_states/test.safetensors"
+        },
+    ),
+]
+
+example_no_hidden_states_request_output = [
+    MockRequestOutput(request_id="test_no_hidden_states_request_id",
+                      prompt="I am a",
+                      prompt_token_ids=[1, 315, 837, 264],
+                      prompt_logprobs=None,
+                      outputs=[
+                          MockCompletionOutput(index=0,
+                                               text=' member',
+                                               token_ids=[4292],
+                                               cumulative_logprob=-4.2740092277526855,
+                                               logprobs=None,
+                                               finish_reason='length',
+                                               stop_reason=None)
+                      ],
+                      finished=True,
+                      kv_transfer_params=None),
 ]
 
 
@@ -618,6 +660,68 @@ class TestVllmUtils(unittest.TestCase):
         expected_sequences = {0: Sequence()}
         self.assertEqual(repr(expected_sequences),
                          repr(req.request_output.sequences))
+
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
+    def test_hidden_states_path_set_when_kv_transfer_params_present(self):
+        """kv_transfer_params.hidden_states_path (set by vLLM's
+        extract_hidden_states feature) should be copied onto the Sequence."""
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        parameters = {"max_new_tokens": 3}
+        request_input = TextInput(request_id=0,
+                                  input_text="I am a",
+                                  parameters=parameters.copy(),
+                                  tokenizer=tokenizer)
+        req = Request(request_input)
+        mock_request_cache = OrderedDict({
+            "test_hidden_states_request_id": {
+                "request_output": req.request_output
+            }
+        })
+
+        for vllm_request_output in example_hidden_states_request_output:
+            djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
+                mock_request_cache, vllm_request_output, tokenizer)
+
+        self.assertEqual(
+            "/tmp/hidden_states/test.safetensors",
+            req.request_output.sequences[0].hidden_states_path)
+
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch(
+        'djl_python.rolling_batch.rolling_batch_vllm_utils.vLLMRequestOutput',
+        new=MockRequestOutput)
+    def test_hidden_states_path_absent_when_kv_transfer_params_none(self):
+        """kv_transfer_params is None for every config that doesn't use
+        extract_hidden_states (the common case) - hidden_states_path must
+        stay None, i.e. this must be a no-op."""
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        parameters = {"max_new_tokens": 3}
+        request_input = TextInput(request_id=0,
+                                  input_text="I am a",
+                                  parameters=parameters.copy(),
+                                  tokenizer=tokenizer)
+        req = Request(request_input)
+        mock_request_cache = OrderedDict({
+            "test_no_hidden_states_request_id": {
+                "request_output": req.request_output
+            }
+        })
+
+        for vllm_request_output in example_no_hidden_states_request_output:
+            djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
+                mock_request_cache, vllm_request_output, tokenizer)
+
+        self.assertIsNone(
+            req.request_output.sequences[0].hidden_states_path)
 
 
 if __name__ == '__main__':

--- a/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
+++ b/engines/python/setup/djl_python/tests/test_rb_vllm_utils.py
@@ -326,13 +326,14 @@ example_no_hidden_states_request_output = [
                       prompt_token_ids=[1, 315, 837, 264],
                       prompt_logprobs=None,
                       outputs=[
-                          MockCompletionOutput(index=0,
-                                               text=' member',
-                                               token_ids=[4292],
-                                               cumulative_logprob=-4.2740092277526855,
-                                               logprobs=None,
-                                               finish_reason='length',
-                                               stop_reason=None)
+                          MockCompletionOutput(
+                              index=0,
+                              text=' member',
+                              token_ids=[4292],
+                              cumulative_logprob=-4.2740092277526855,
+                              logprobs=None,
+                              finish_reason='length',
+                              stop_reason=None)
                       ],
                       finished=True,
                       kv_transfer_params=None),
@@ -688,9 +689,8 @@ class TestVllmUtils(unittest.TestCase):
             djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
                 mock_request_cache, vllm_request_output, tokenizer)
 
-        self.assertEqual(
-            "/tmp/hidden_states/test.safetensors",
-            req.request_output.sequences[0].hidden_states_path)
+        self.assertEqual("/tmp/hidden_states/test.safetensors",
+                         req.request_output.sequences[0].hidden_states_path)
 
     @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
     @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
@@ -720,8 +720,51 @@ class TestVllmUtils(unittest.TestCase):
             djl_python.rolling_batch.rolling_batch_vllm_utils.update_request_cache_with_output(
                 mock_request_cache, vllm_request_output, tokenizer)
 
-        self.assertIsNone(
-            req.request_output.sequences[0].hidden_states_path)
+        self.assertIsNone(req.request_output.sequences[0].hidden_states_path)
+
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.sampling_params': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils.counter': MagicMock()})
+    def test_translate_vllm_params_routes_kv_transfer_params_to_extra_args(
+            self):
+        """kv_transfer_params is not itself a SamplingParams field, so it
+        must be moved under extra_args before filter_unused_generation_params
+        runs, or it would be silently dropped (see vllm_rolling_batch.py)."""
+        from djl_python.rolling_batch.vllm_rolling_batch import VLLMRollingBatch
+
+        parameters = {
+            "max_new_tokens": 3,
+            "kv_transfer_params": {
+                "include_output_tokens": True
+            },
+        }
+        result = VLLMRollingBatch.translate_vllm_params(Mock(), parameters)
+
+        self.assertNotIn("kv_transfer_params", result)
+        self.assertEqual({"include_output_tokens": True},
+                         result["extra_args"]["kv_transfer_params"])
+
+    @mock.patch.dict(sys.modules, {'vllm': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.inputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.outputs': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.lora.request': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.sampling_params': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils': MagicMock()})
+    @mock.patch.dict(sys.modules, {'vllm.utils.counter': MagicMock()})
+    def test_translate_vllm_params_no_kv_transfer_params_is_noop(self):
+        """No kv_transfer_params in the request parameters (the common case)
+        must not add an extra_args key that wasn't already there."""
+        from djl_python.rolling_batch.vllm_rolling_batch import VLLMRollingBatch
+
+        parameters = {"max_new_tokens": 3}
+        result = VLLMRollingBatch.translate_vllm_params(Mock(), parameters)
+
+        self.assertNotIn("kv_transfer_params", result)
+        self.assertNotIn("extra_args", result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Follow-up to #3066. vLLM's `extract_hidden_states` feature already works and
returns per-request hidden states via
`RequestOutput.kv_transfer_params["hidden_states_path"]`, but djl-serving's
`VLLMRollingBatch` never reads that field, so nothing built on top of
`rolling_batch=vllm` (e.g. a custom `@output_formatter`) can access it today.

This PR closes that gap:

- `request_io.py`: adds an optional `hidden_states_path` field to `Sequence`.
- `rolling_batch_vllm_utils.py`: copies `kv_transfer_params.hidden_states_path`
  onto the `Sequence` when present. No-op when absent (the default case).
- `vllm_rolling_batch.py`: lets a caller pass `kv_transfer_params` per request
  (e.g. `include_output_tokens`), routed through `SamplingParams.extra_args`
  since it isn't itself a `SamplingParams` field.

Nothing here changes default behavior — everything is opt-in and a no-op for
existing `rolling_batch=vllm` deployments that don't configure
`extract_hidden_states`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Integration Tests Executor run
- [x] Manually built the docker image (`serving/docker/lmi.Dockerfile`) and
  verified the change (see Testing below)
- [x] Run related tests
- [x] Added tests that prove the change works
- [x] Code commented where non-obvious
- [ ] Documentation update

## Testing

- Two new unit tests in `test_rb_vllm_utils.py` covering `hidden_states_path`
  set/unset, plus two more covering `translate_vllm_params`'s
  `kv_transfer_params` routing. All existing tests in the file still pass.
  7/7 passing locally (`python -m unittest djl_python.tests.test_rb_vllm_utils`).
- Built `lmi.Dockerfile` locally and validated on our own model (Llama-3.2-3B
  + LoRA) on an A10G:
  - Plain `rolling_batch=vllm` baseline: real inference request, HTTP 200.
  - With `speculative_config={"method": "extract_hidden_states", ...}` +
    `kv_transfer_config` (`ExampleHiddenStatesConnector`): connector
    initializes correctly, requests schedule successfully against the
    modified code.
- Benchmarked the real throughput cost of `extract_hidden_states` (chunked
  prefill must be disabled for it) vs. plain `rolling_batch=vllm`, same
  model/GPU, three concurrency levels:

  | Batch size | Baseline tok/s | Extract tok/s | Cost |
  |---|---|---|---|
  | 32  | 1322.2 | 1179.3 | -10.8% |
  | 64  | 2005.6 | 1543.0 | -23.1% |
  | 128 | 2486.2 | 1724.4 | -30.6% |

  Cost scales with concurrency (chunked prefill disabled means large prefill
  batches block decode for in-flight requests) rather than being flat.

## Note on custom output formatters

Earlier I thought custom `@output_formatter` support was broken for
`rolling_batch=vllm` in general. Turns out that's only true for the legacy
sync engine path — I tested the recommended async path directly
(`option.async_mode=true`, which is the default for vLLM since LMI v17) and a
custom formatter there reads `hidden_states_path` correctly with no changes
needed. So no open gap here for how most people actually run this.

