### PR TITLE
PERF Optimization - p50/p99 latency fixes

### DIFF
--- a/engines/python/setup/djl_python/__init__.py
+++ b/engines/python/setup/djl_python/__init__.py
@@ -15,3 +15,5 @@ from .inputs import Input
 from .outputs import Output
 from .pair_list import PairList
 from .session_manager import SessionManager, Session
+
+__version__ = "0.36.0"

--- a/engines/python/setup/djl_python/__init__.py
+++ b/engines/python/setup/djl_python/__init__.py
@@ -15,5 +15,3 @@ from .inputs import Input
 from .outputs import Output
 from .pair_list import PairList
 from .session_manager import SessionManager, Session
-
-__version__ = "0.36.0"

--- a/engines/python/setup/djl_python/python_async_engine.py
+++ b/engines/python/setup/djl_python/python_async_engine.py
@@ -20,7 +20,6 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from threading import Thread
 from queue import Queue
-from asyncio.queues import Queue as AsyncQueue
 
 from djl_python.inputs import Input
 from djl_python.outputs import Output
@@ -40,7 +39,17 @@ class PythonAsyncEngine(PythonSyncEngine):
 
     def __init__(self, args, service):
         super().__init__(args, service)
-        self.output_queue = AsyncQueue()
+        # A plain thread-safe queue.Queue, not asyncio.Queue: outputs are
+        # produced on the event-loop thread (invoke_handler) and consumed on a
+        # dedicated OS thread (send_responses). queue.Queue.put_nowait/get are
+        # safe to call across threads with no event-loop involvement, unlike
+        # asyncio.Queue, which requires scheduling every access back onto the
+        # loop via run_coroutine_threadsafe - that added a cross-thread round
+        # trip (and a wakeup of whichever coroutine loses the GIL race for it)
+        # per streamed token, serializing all concurrent requests' token
+        # delivery through the event loop for no reason: the queue itself
+        # doesn't need the loop, only the blocking socket write does.
+        self.output_queue = Queue()
         self.exception_queue = Queue()
         self.loop = None
         # Todo: for async mode we should maybe consider
@@ -93,21 +102,19 @@ class PythonAsyncEngine(PythonSyncEngine):
             async for output in outputs:
                 output.add_property(REQUEST_TRACKING_ID_KEY,
                                     request_tracking_id)
-                await self.output_queue.put(output)
+                self.output_queue.put_nowait(output)
             return
         # Request tracking ID is needed always for async
         # Do this here so that users in custom handlers do not need to worry about it
         outputs.add_property(REQUEST_TRACKING_ID_KEY, request_tracking_id)
         logging.debug(f"putting result of inference to output queue")
-        await self.output_queue.put(outputs)
+        self.output_queue.put_nowait(outputs)
 
     def send_responses(self):
         logging.info("starting send responses thread")
         while True:
-            future = asyncio.run_coroutine_threadsafe(self.output_queue.get(),
-                                                      self.loop)
             logging.debug("waiting for new inference response")
-            output = future.result()
+            output = self.output_queue.get()
             output.send(self.cl_socket)
 
     def run_server(self):

--- a/engines/python/setup/djl_python/tests/test_python_async_engine.py
+++ b/engines/python/setup/djl_python/tests/test_python_async_engine.py
@@ -1,12 +1,13 @@
 import queue
 import threading
+import time
 import unittest
-from unittest.mock import MagicMock
-from queue import Queue
+from unittest.mock import MagicMock, patch
 
 from djl_python.inputs import Input
 from djl_python.outputs import Output
 from djl_python.python_async_engine import PythonAsyncEngine, REQUEST_TRACKING_ID_KEY
+from djl_python.python_sync_engine import PythonSyncEngine
 
 
 async def fake_async_generator(items):
@@ -20,13 +21,14 @@ async def fake_async_generator(items):
 
 
 def make_engine():
-    # PythonAsyncEngine.__init__ chains into PythonSyncEngine.__init__, which
-    # opens a real socket - not needed to exercise output_queue/send_responses,
-    # so build the object without running __init__ and set only what's used.
-    engine = PythonAsyncEngine.__new__(PythonAsyncEngine)
-    engine.output_queue = Queue()
-    engine.exception_queue = Queue()
-    engine.loop = None
+    # Run the real PythonAsyncEngine.__init__ (with PythonSyncEngine.__init__
+    # stubbed out, since it opens a real socket and needs a full `args`
+    # object) so output_queue/exception_queue/loop are whatever production
+    # actually constructs. Bypassing __init__ entirely and setting
+    # output_queue = Queue() ourselves would still pass even if production
+    # reverted to asyncio.Queue.
+    with patch.object(PythonSyncEngine, "__init__", return_value=None):
+        engine = PythonAsyncEngine(MagicMock(), MagicMock())
     engine.service = MagicMock()
     engine.cl_socket = MagicMock()
     return engine
@@ -136,24 +138,22 @@ class TestSendResponsesCrossThreadHandoff(unittest.TestCase):
         for o in outputs:
             o.send = lambda sock, o=o: sent.append((o, sock))
 
-        def run_send_responses_briefly():
-            # send_responses() loops forever; run it on a background thread
-            # and stop pulling once we've observed all items, then let the
-            # thread die naturally when the test process exits (mirrors how
-            # the real engine treats this as a daemon-lifetime thread).
-            for _ in range(n_items):
-                item = engine.output_queue.get()
-                item.send(engine.cl_socket)
-
         for o in outputs:
             engine.output_queue.put_nowait(o)
 
-        t = threading.Thread(target=run_send_responses_briefly, daemon=True)
+        # Run the real production method - not a reimplementation of its
+        # loop - so a regression in send_responses() itself (e.g. reverting
+        # to the asyncio.Queue/run_coroutine_threadsafe round trip) would
+        # actually be caught here. It loops forever, so run it on a
+        # background daemon thread and just wait for it to drain everything
+        # enqueued above, rather than for it to return.
+        t = threading.Thread(target=engine.send_responses, daemon=True)
         t.start()
-        t.join(timeout=5)
 
-        self.assertFalse(t.is_alive(),
-                         "send_responses consumer did not finish in time")
+        deadline = time.time() + 5
+        while len(sent) < n_items and time.time() < deadline:
+            time.sleep(0.01)
+
         self.assertEqual(len(sent), n_items)
         self.assertEqual([o for o, _ in sent], outputs)
         self.assertTrue(all(sock is engine.cl_socket for _, sock in sent))

--- a/engines/python/setup/djl_python/tests/test_python_async_engine.py
+++ b/engines/python/setup/djl_python/tests/test_python_async_engine.py
@@ -1,0 +1,176 @@
+import queue
+import threading
+import unittest
+from unittest.mock import MagicMock
+from queue import Queue
+
+from djl_python.inputs import Input
+from djl_python.outputs import Output
+from djl_python.python_async_engine import PythonAsyncEngine, REQUEST_TRACKING_ID_KEY
+
+
+async def fake_async_generator(items):
+    """A real async generator (types.AsyncGeneratorType), since invoke_handler
+    checks isinstance(outputs, types.AsyncGeneratorType) specifically - a
+    class merely implementing __aiter__/__anext__ does not satisfy that
+    check, only an object produced by an `async def ... yield` function does.
+    """
+    for item in items:
+        yield item
+
+
+def make_engine():
+    # PythonAsyncEngine.__init__ chains into PythonSyncEngine.__init__, which
+    # opens a real socket - not needed to exercise output_queue/send_responses,
+    # so build the object without running __init__ and set only what's used.
+    engine = PythonAsyncEngine.__new__(PythonAsyncEngine)
+    engine.output_queue = Queue()
+    engine.exception_queue = Queue()
+    engine.loop = None
+    engine.service = MagicMock()
+    engine.cl_socket = MagicMock()
+    return engine
+
+
+def make_input(tracking_id="req-1"):
+    inputs = Input()
+    inputs.properties[REQUEST_TRACKING_ID_KEY] = tracking_id
+    return inputs
+
+
+class TestPythonAsyncEngineOutputQueue(unittest.IsolatedAsyncioTestCase):
+    """Regression coverage for the output_queue producer/consumer handoff in
+    PythonAsyncEngine. This queue used to be an asyncio.Queue, requiring every
+    dequeue in send_responses() to round-trip through asyncio.run_coroutine_threadsafe
+    back onto the event loop - a cross-thread wakeup per streamed token that
+    serialized token delivery for all concurrent requests through the loop
+    for no reason, since only the blocking socket write actually needs to be
+    off the loop. It is now a plain, thread-safe queue.Queue: invoke_handler
+    (running on the event loop) calls put_nowait() directly with no await, and
+    send_responses (running on its own OS thread) calls a plain blocking get()
+    with no event-loop interaction at all.
+    """
+
+    async def test_invoke_handler_non_streaming_output_reaches_queue(self):
+        engine = make_engine()
+        output = Output(code=200, message="OK")
+        engine.service.invoke_handler_async = MagicMock(
+            return_value=_awaitable(output))
+
+        await engine.invoke_handler("infer", make_input("req-1"))
+
+        self.assertEqual(engine.output_queue.qsize(), 1)
+        queued = engine.output_queue.get_nowait()
+        self.assertIs(queued, output)
+        self.assertEqual(queued.get_property(REQUEST_TRACKING_ID_KEY), "req-1")
+
+    async def test_invoke_handler_streaming_outputs_all_reach_queue_in_order(
+            self):
+        engine = make_engine()
+        chunks = [Output(message=f"chunk-{i}") for i in range(5)]
+        engine.service.invoke_handler_async = MagicMock(
+            return_value=_awaitable(fake_async_generator(chunks)))
+
+        await engine.invoke_handler("infer", make_input("req-2"))
+
+        self.assertEqual(engine.output_queue.qsize(), 5)
+        for expected_chunk in chunks:
+            queued = engine.output_queue.get_nowait()
+            self.assertIs(queued, expected_chunk)
+            self.assertEqual(queued.get_property(REQUEST_TRACKING_ID_KEY),
+                             "req-2")
+
+    async def test_invoke_handler_oom_error_queues_507(self):
+        engine = make_engine()
+
+        async def raise_oom(*_args, **_kwargs):
+            raise MemoryError("CUDA error: out of memory")
+
+        engine.service.invoke_handler_async = raise_oom
+
+        await engine.invoke_handler("infer", make_input("req-3"))
+
+        queued = engine.output_queue.get_nowait()
+        self.assertEqual(queued.code, 507)
+
+    async def test_invoke_handler_generic_error_queues_424(self):
+        engine = make_engine()
+
+        async def raise_generic(*_args, **_kwargs):
+            raise ValueError("boom")
+
+        engine.service.invoke_handler_async = raise_generic
+
+        await engine.invoke_handler("infer", make_input("req-4"))
+
+        queued = engine.output_queue.get_nowait()
+        self.assertEqual(queued.code, 424)
+
+    async def test_invoke_handler_none_output_queues_204(self):
+        engine = make_engine()
+        engine.service.invoke_handler_async = MagicMock(
+            return_value=_awaitable(None))
+
+        await engine.invoke_handler("infer", make_input("req-5"))
+
+        queued = engine.output_queue.get_nowait()
+        self.assertEqual(queued.code, 204)
+
+
+class TestSendResponsesCrossThreadHandoff(unittest.TestCase):
+    """Exercises the real thread boundary: outputs enqueued from one thread
+    (simulating the event-loop thread) must be dequeued and sent by
+    send_responses() running on a separate OS thread, with no asyncio loop
+    involved on the consumer side at all - engine.loop is deliberately left
+    None to prove send_responses no longer depends on it."""
+
+    def test_send_responses_drains_queue_across_threads_without_event_loop(
+            self):
+        engine = make_engine()
+        self.assertIsNone(engine.loop)
+
+        n_items = 50
+        outputs = [Output(message=str(i)) for i in range(n_items)]
+        sent = []
+        engine.cl_socket = object()  # sentinel, just needs identity
+        for o in outputs:
+            o.send = lambda sock, o=o: sent.append((o, sock))
+
+        def run_send_responses_briefly():
+            # send_responses() loops forever; run it on a background thread
+            # and stop pulling once we've observed all items, then let the
+            # thread die naturally when the test process exits (mirrors how
+            # the real engine treats this as a daemon-lifetime thread).
+            for _ in range(n_items):
+                item = engine.output_queue.get()
+                item.send(engine.cl_socket)
+
+        for o in outputs:
+            engine.output_queue.put_nowait(o)
+
+        t = threading.Thread(target=run_send_responses_briefly, daemon=True)
+        t.start()
+        t.join(timeout=5)
+
+        self.assertFalse(t.is_alive(),
+                         "send_responses consumer did not finish in time")
+        self.assertEqual(len(sent), n_items)
+        self.assertEqual([o for o, _ in sent], outputs)
+        self.assertTrue(all(sock is engine.cl_socket for _, sock in sent))
+
+    def test_output_queue_is_plain_thread_safe_queue_not_asyncio_queue(self):
+        # Guards against regressing back to asyncio.Queue, which would
+        # silently reintroduce the cross-thread round trip this fix removes:
+        # asyncio.Queue.get()/put() are coroutines and are not safe to call
+        # directly from a non-loop thread without run_coroutine_threadsafe.
+        engine = make_engine()
+        self.assertIsInstance(engine.output_queue, queue.Queue)
+        self.assertNotIn("asyncio", type(engine.output_queue).__module__)
+
+
+async def _awaitable(value):
+    return value
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -328,7 +328,7 @@ public class ModelServer {
 
         ServerBootstrap b = new ServerBootstrap();
         b.channel(channelClass);
-        configureSocketOptions(b);
+        configureSocketOptions(b, connector.isUds());
         b.group(serverGroup, workerGroup);
 
         SslContext sslCtx = null;
@@ -376,21 +376,26 @@ public class ModelServer {
      * Applies the server's socket options to the given {@link ServerBootstrap}.
      *
      * <p>Package-private (rather than folded inline into {@link #initializeServer(Connector,
-     * EventLoopGroup, EventLoopGroup)}) so the option set can be asserted directly in tests
-     * without needing to bind a real listening socket.
+     * EventLoopGroup, EventLoopGroup)}) so the option set can be asserted directly in tests without
+     * needing to bind a real listening socket.
      *
      * @param b the bootstrap to configure
+     * @param isUds {@code true} if {@code b} will bind a unix domain socket channel; domain-socket
+     *     child channels don't support TCP-level options such as {@code TCP_NODELAY}, so it's only
+     *     applied for TCP channels
      */
-    static void configureSocketOptions(ServerBootstrap b) {
+    static void configureSocketOptions(ServerBootstrap b, boolean isUds) {
         b.option(ChannelOption.SO_BACKLOG, 1024)
                 .childOption(ChannelOption.SO_LINGER, 0)
                 .childOption(ChannelOption.SO_REUSEADDR, true)
-                .childOption(ChannelOption.SO_KEEPALIVE, true)
-                // Streaming responses write one small HTTP chunk per token; without
-                // TCP_NODELAY, Nagle's algorithm combined with client-side delayed ACK
-                // can stall each chunk by tens of milliseconds, inflating inter-token
-                // latency and p99 for every streaming/chat-completions request.
-                .childOption(ChannelOption.TCP_NODELAY, true);
+                .childOption(ChannelOption.SO_KEEPALIVE, true);
+        if (!isUds) {
+            // Streaming responses write one small HTTP chunk per token; without
+            // TCP_NODELAY, Nagle's algorithm combined with client-side delayed ACK
+            // can stall each chunk by tens of milliseconds, inflating inter-token
+            // latency and p99 for every streaming/chat-completions request.
+            b.childOption(ChannelOption.TCP_NODELAY, true);
+        }
     }
 
     private void loadModels(List<Workflow> workflows) {

--- a/serving/src/main/java/ai/djl/serving/ModelServer.java
+++ b/serving/src/main/java/ai/djl/serving/ModelServer.java
@@ -327,11 +327,8 @@ public class ModelServer {
                 channelClass.getSimpleName());
 
         ServerBootstrap b = new ServerBootstrap();
-        b.option(ChannelOption.SO_BACKLOG, 1024)
-                .channel(channelClass)
-                .childOption(ChannelOption.SO_LINGER, 0)
-                .childOption(ChannelOption.SO_REUSEADDR, true)
-                .childOption(ChannelOption.SO_KEEPALIVE, true);
+        b.channel(channelClass);
+        configureSocketOptions(b);
         b.group(serverGroup, workerGroup);
 
         SslContext sslCtx = null;
@@ -373,6 +370,27 @@ public class ModelServer {
 
         logger.info("{} API bind to: {}", connector.getType(), connector);
         return f;
+    }
+
+    /**
+     * Applies the server's socket options to the given {@link ServerBootstrap}.
+     *
+     * <p>Package-private (rather than folded inline into {@link #initializeServer(Connector,
+     * EventLoopGroup, EventLoopGroup)}) so the option set can be asserted directly in tests
+     * without needing to bind a real listening socket.
+     *
+     * @param b the bootstrap to configure
+     */
+    static void configureSocketOptions(ServerBootstrap b) {
+        b.option(ChannelOption.SO_BACKLOG, 1024)
+                .childOption(ChannelOption.SO_LINGER, 0)
+                .childOption(ChannelOption.SO_REUSEADDR, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                // Streaming responses write one small HTTP chunk per token; without
+                // TCP_NODELAY, Nagle's algorithm combined with client-side delayed ACK
+                // can stall each chunk by tens of milliseconds, inflating inter-token
+                // latency and p99 for every streaming/chat-completions request.
+                .childOption(ChannelOption.TCP_NODELAY, true);
     }
 
     private void loadModels(List<Workflow> workflows) {

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -53,7 +53,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -78,6 +79,13 @@ public class InferenceRequestHandler extends HttpRequestHandler {
     private static final String X_MAX_ITEMS = "x-max-items";
     private static final String X_CUSTOM_ATTRIBUTES = "X-Amzn-SageMaker-Custom-Attributes";
 
+    /** System property to cap the number of threads {@link #RESPONSE_EXECUTOR} may create. */
+    private static final String RESPONSE_EXECUTOR_MAX_THREADS_PROPERTY =
+            "ai.djl.serving.responseExecutorMaxThreads";
+
+    private static final int RESPONSE_EXECUTOR_MAX_THREADS =
+            Integer.getInteger(RESPONSE_EXECUTOR_MAX_THREADS_PROPERTY, 4096);
+
     /**
      * Executor for delivering inference responses to the client.
      *
@@ -89,17 +97,32 @@ public class InferenceRequestHandler extends HttpRequestHandler {
      * availableProcessors() - 1} and is shared with unrelated JVM-wide async work. That caps the
      * number of concurrent streaming responses the server can actually deliver to roughly the CPU
      * count, regardless of how many requests the backend (e.g. vLLM rolling batch) is willing to
-     * serve concurrently, producing a sharp p99 latency cliff under load. A dedicated, unbounded
-     * cached pool removes that ceiling; threads here are almost always parked in a blocking queue
-     * poll, not doing CPU work, so pool size is not bound by core count.
+     * serve concurrently, producing a sharp p99 latency cliff under load. A dedicated pool removes
+     * that ceiling; threads here are almost always parked in a blocking queue poll, not doing CPU
+     * work, so pool size is not bound by core count.
+     *
+     * <p>The pool is still bounded (at {@link #RESPONSE_EXECUTOR_MAX_THREADS}, overridable via the
+     * {@code ai.djl.serving.responseExecutorMaxThreads} system property) rather than unbounded like
+     * {@link java.util.concurrent.Executors#newCachedThreadPool()}: a burst of stalled or
+     * long-lived streams must not be able to create threads proportional to client concurrency and
+     * exhaust native-thread or heap limits. The {@link SynchronousQueue} hands each task straight
+     * to a thread instead of queueing it, so once the cap is hit, {@link
+     * ThreadPoolExecutor.CallerRunsPolicy} runs the response delivery on the completing thread
+     * rather than dropping it or throwing.
      */
     private static final ExecutorService RESPONSE_EXECUTOR =
-            Executors.newCachedThreadPool(
+            new ThreadPoolExecutor(
+                    0,
+                    RESPONSE_EXECUTOR_MAX_THREADS,
+                    60L,
+                    TimeUnit.SECONDS,
+                    new SynchronousQueue<>(),
                     r -> {
                         Thread t = new Thread(r, "inference-response-sender");
                         t.setDaemon(true);
                         return t;
-                    });
+                    },
+                    new ThreadPoolExecutor.CallerRunsPolicy());
 
     private RequestParser requestParser;
     private int chunkReadTime;

--- a/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
+++ b/serving/src/main/java/ai/djl/serving/http/InferenceRequestHandler.java
@@ -52,6 +52,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -75,6 +77,29 @@ public class InferenceRequestHandler extends HttpRequestHandler {
     private static final String X_NEXT_TOKEN = "x-next-token";
     private static final String X_MAX_ITEMS = "x-max-items";
     private static final String X_CUSTOM_ATTRIBUTES = "X-Amzn-SageMaker-Custom-Attributes";
+
+    /**
+     * Executor for delivering inference responses to the client.
+     *
+     * <p>Streaming (and chunked non-streaming) responses are drained by blocking on {@link
+     * ai.djl.inference.streaming.ChunkedBytesSupplier#nextChunk(long, TimeUnit)} in {@link
+     * #sendOutput(Output, ChannelHandlerContext)} for the full duration of generation. Using the
+     * default {@code whenCompleteAsync} (no-arg) would run that blocking loop on {@link
+     * java.util.concurrent.ForkJoinPool#commonPool()}, whose parallelism is capped at {@code
+     * availableProcessors() - 1} and is shared with unrelated JVM-wide async work. That caps the
+     * number of concurrent streaming responses the server can actually deliver to roughly the CPU
+     * count, regardless of how many requests the backend (e.g. vLLM rolling batch) is willing to
+     * serve concurrently, producing a sharp p99 latency cliff under load. A dedicated, unbounded
+     * cached pool removes that ceiling; threads here are almost always parked in a blocking queue
+     * poll, not doing CPU work, so pool size is not bound by core count.
+     */
+    private static final ExecutorService RESPONSE_EXECUTOR =
+            Executors.newCachedThreadPool(
+                    r -> {
+                        Thread t = new Thread(r, "inference-response-sender");
+                        t.setDaemon(true);
+                        return t;
+                    });
 
     private RequestParser requestParser;
     private int chunkReadTime;
@@ -312,7 +337,8 @@ public class InferenceRequestHandler extends HttpRequestHandler {
                                 if (o != null) {
                                     sendOutput(o, ctx);
                                 }
-                            })
+                            },
+                            RESPONSE_EXECUTOR)
                     .exceptionally(
                             t -> {
                                 onException(t.getCause(), ctx);

--- a/serving/src/test/java/ai/djl/serving/ModelServerSocketOptionsTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerSocketOptionsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving;
+
+import static org.testng.Assert.assertEquals;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.bootstrap.ServerBootstrapConfig;
+import io.netty.channel.ChannelOption;
+
+import org.testng.annotations.Test;
+
+/**
+ * Regression coverage for {@link ModelServer#configureSocketOptions(ServerBootstrap)}. Calls the
+ * real production method directly (rather than duplicating its option list in the test) so a
+ * future edit to the socket options cannot silently drop {@code TCP_NODELAY} without failing this
+ * test.
+ */
+public class ModelServerSocketOptionsTest {
+
+    @Test
+    public void testTcpNoDelayIsEnabledOnChildChannels() {
+        ServerBootstrap b = new ServerBootstrap();
+        ModelServer.configureSocketOptions(b);
+
+        ServerBootstrapConfig config = b.config();
+        assertEquals(
+                config.childOptions().get(ChannelOption.TCP_NODELAY),
+                Boolean.TRUE,
+                "TCP_NODELAY must be enabled on accepted child channels: without it, Nagle's"
+                        + " algorithm combined with client-side delayed ACK can stall each"
+                        + " streamed HTTP chunk by tens of milliseconds, inflating inter-token"
+                        + " latency and p99 for streaming/chat-completions responses");
+    }
+
+    @Test
+    public void testExistingSocketOptionsAreUnaffected() {
+        ServerBootstrap b = new ServerBootstrap();
+        ModelServer.configureSocketOptions(b);
+
+        ServerBootstrapConfig config = b.config();
+        assertEquals(config.options().get(ChannelOption.SO_BACKLOG), 1024);
+        assertEquals(config.childOptions().get(ChannelOption.SO_LINGER), 0);
+        assertEquals(config.childOptions().get(ChannelOption.SO_REUSEADDR), Boolean.TRUE);
+        assertEquals(config.childOptions().get(ChannelOption.SO_KEEPALIVE), Boolean.TRUE);
+    }
+
+    @Test
+    public void testConfigureSocketOptionsIsIdempotentAndReturnsSameBootstrap() {
+        ServerBootstrap b = new ServerBootstrap();
+        ModelServer.configureSocketOptions(b);
+        ModelServer.configureSocketOptions(b);
+
+        assertEquals(
+                b.config().childOptions().get(ChannelOption.TCP_NODELAY),
+                Boolean.TRUE,
+                "calling configureSocketOptions twice should not toggle the option off");
+    }
+}

--- a/serving/src/test/java/ai/djl/serving/ModelServerSocketOptionsTest.java
+++ b/serving/src/test/java/ai/djl/serving/ModelServerSocketOptionsTest.java
@@ -13,6 +13,7 @@
 package ai.djl.serving;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.bootstrap.ServerBootstrapConfig;
@@ -21,17 +22,17 @@ import io.netty.channel.ChannelOption;
 import org.testng.annotations.Test;
 
 /**
- * Regression coverage for {@link ModelServer#configureSocketOptions(ServerBootstrap)}. Calls the
- * real production method directly (rather than duplicating its option list in the test) so a
- * future edit to the socket options cannot silently drop {@code TCP_NODELAY} without failing this
- * test.
+ * Regression coverage for {@link ModelServer#configureSocketOptions(ServerBootstrap, boolean)}.
+ * Calls the real production method directly (rather than duplicating its option list in the test)
+ * so a future edit to the socket options cannot silently drop {@code TCP_NODELAY} without failing
+ * this test.
  */
 public class ModelServerSocketOptionsTest {
 
     @Test
     public void testTcpNoDelayIsEnabledOnChildChannels() {
         ServerBootstrap b = new ServerBootstrap();
-        ModelServer.configureSocketOptions(b);
+        ModelServer.configureSocketOptions(b, false);
 
         ServerBootstrapConfig config = b.config();
         assertEquals(
@@ -44,9 +45,22 @@ public class ModelServerSocketOptionsTest {
     }
 
     @Test
+    public void testTcpNoDelayIsNotSetOnUdsChannels() {
+        ServerBootstrap b = new ServerBootstrap();
+        ModelServer.configureSocketOptions(b, true);
+
+        ServerBootstrapConfig config = b.config();
+        assertNull(
+                config.childOptions().get(ChannelOption.TCP_NODELAY),
+                "TCP_NODELAY is a TCP-only option: domain-socket child channels don't support it,"
+                        + " so setting it on a unix-socket bootstrap can break UDS"
+                        + " initialization");
+    }
+
+    @Test
     public void testExistingSocketOptionsAreUnaffected() {
         ServerBootstrap b = new ServerBootstrap();
-        ModelServer.configureSocketOptions(b);
+        ModelServer.configureSocketOptions(b, false);
 
         ServerBootstrapConfig config = b.config();
         assertEquals(config.options().get(ChannelOption.SO_BACKLOG), 1024);
@@ -56,10 +70,10 @@ public class ModelServerSocketOptionsTest {
     }
 
     @Test
-    public void testConfigureSocketOptionsIsIdempotentAndReturnsSameBootstrap() {
+    public void testConfigureSocketOptionsIsIdempotent() {
         ServerBootstrap b = new ServerBootstrap();
-        ModelServer.configureSocketOptions(b);
-        ModelServer.configureSocketOptions(b);
+        ModelServer.configureSocketOptions(b, false);
+        ModelServer.configureSocketOptions(b, false);
 
         assertEquals(
                 b.config().childOptions().get(ChannelOption.TCP_NODELAY),

--- a/serving/src/test/java/ai/djl/serving/http/InferenceRequestHandlerTest.java
+++ b/serving/src/test/java/ai/djl/serving/http/InferenceRequestHandlerTest.java
@@ -12,23 +12,44 @@
  */
 package ai.djl.serving.http;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.serving.Arguments;
+import ai.djl.serving.models.ModelManager;
+import ai.djl.serving.util.ConfigManager;
+import ai.djl.serving.util.NettyUtils;
+import ai.djl.serving.workflow.Workflow;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+import org.apache.commons.cli.CommandLine;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
-
-import org.testng.annotations.Test;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Regression coverage for {@code InferenceRequestHandler}'s streaming-response delivery
- * executor. Every streaming (or chunked non-streaming) response blocks its delivery thread on
- * {@code ChunkedBytesSupplier.nextChunk(...)} for the entire generation duration, so the executor
- * used to run that loop directly bounds how many concurrent responses the server can actually
- * deliver. The no-argument {@code CompletableFuture.whenCompleteAsync} defaults to {@code
+ * Regression coverage for {@code InferenceRequestHandler}'s streaming-response delivery executor.
+ * Every streaming (or chunked non-streaming) response blocks its delivery thread on {@code
+ * ChunkedBytesSupplier.nextChunk(...)} for the entire generation duration, so the executor used to
+ * run that loop directly bounds how many concurrent responses the server can actually deliver. The
+ * no-argument {@code CompletableFuture.whenCompleteAsync} defaults to {@code
  * ForkJoinPool.commonPool()}, whose parallelism is {@code availableProcessors() - 1}; on a small
  * host this becomes a hard concurrency ceiling regardless of backend capacity. These tests assert
  * the actual behavior that matters -- that the dedicated executor can run more concurrent blocking
@@ -37,6 +58,11 @@ import org.testng.annotations.Test;
  * another unbounded/adequately-sized executor.
  */
 public class InferenceRequestHandlerTest {
+
+    @BeforeClass
+    public void setUp() {
+        ConfigManager.init(new Arguments(CommandLine.builder().build()));
+    }
 
     @Test
     public void testResponseExecutorIsNotForkJoinCommonPool() throws Exception {
@@ -104,6 +130,47 @@ public class InferenceRequestHandlerTest {
                 isDaemon[0],
                 "response-delivery threads must be daemon threads so they never block JVM"
                         + " shutdown");
+    }
+
+    @Test
+    public void testRunJobSchedulesDeliveryOnResponseExecutor() throws Exception {
+        // Regression coverage for the completion chain itself: the previous tests only inspect
+        // RESPONSE_EXECUTOR directly, so they'd still pass even if runJob's
+        // whenCompleteAsync(callback, RESPONSE_EXECUTOR) call were accidentally reverted to the
+        // no-arg overload (which runs the callback on ForkJoinPool.commonPool() instead).
+        ModelManager modelManager = mock(ModelManager.class);
+        Workflow workflow = mock(Workflow.class);
+        Input input = new Input();
+        CompletableFuture<Output> future = new CompletableFuture<>();
+        when(modelManager.runJob(workflow, input)).thenReturn(future);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+        NettyUtils.requestReceived(
+                channel,
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/predictions"));
+        ChannelHandlerContext ctx = channel.pipeline().firstContext();
+
+        AtomicReference<Thread> deliveryThread = new AtomicReference<>();
+        CountDownLatch delivered = new CountDownLatch(1);
+        InferenceRequestHandler handler =
+                new InferenceRequestHandler() {
+                    @Override
+                    void sendOutput(Output output, ChannelHandlerContext c) {
+                        deliveryThread.set(Thread.currentThread());
+                        delivered.countDown();
+                    }
+                };
+
+        handler.runJob(modelManager, ctx, workflow, input);
+        future.complete(new Output(200, "OK"));
+
+        assertTrue(delivered.await(5, TimeUnit.SECONDS), "delivery callback never ran");
+        assertTrue(
+                deliveryThread.get().getName().startsWith("inference-response-sender"),
+                "runJob's delivery callback must be scheduled on RESPONSE_EXECUTOR (thread name"
+                        + " \"inference-response-sender-*\"), not on the completing thread or"
+                        + " ForkJoinPool.commonPool(); actual thread: "
+                        + deliveryThread.get().getName());
     }
 
     private static ExecutorService getResponseExecutor() throws Exception {

--- a/serving/src/test/java/ai/djl/serving/http/InferenceRequestHandlerTest.java
+++ b/serving/src/test/java/ai/djl/serving/http/InferenceRequestHandlerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.serving.http;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+
+/**
+ * Regression coverage for {@code InferenceRequestHandler}'s streaming-response delivery
+ * executor. Every streaming (or chunked non-streaming) response blocks its delivery thread on
+ * {@code ChunkedBytesSupplier.nextChunk(...)} for the entire generation duration, so the executor
+ * used to run that loop directly bounds how many concurrent responses the server can actually
+ * deliver. The no-argument {@code CompletableFuture.whenCompleteAsync} defaults to {@code
+ * ForkJoinPool.commonPool()}, whose parallelism is {@code availableProcessors() - 1}; on a small
+ * host this becomes a hard concurrency ceiling regardless of backend capacity. These tests assert
+ * the actual behavior that matters -- that the dedicated executor can run more concurrent blocking
+ * tasks than the common pool's parallelism -- rather than asserting an implementation detail (e.g.
+ * the concrete executor class), so the test still passes if the implementation is swapped for
+ * another unbounded/adequately-sized executor.
+ */
+public class InferenceRequestHandlerTest {
+
+    @Test
+    public void testResponseExecutorIsNotForkJoinCommonPool() throws Exception {
+        ExecutorService executor = getResponseExecutor();
+        assertFalse(
+                isForkJoinCommonPool(executor),
+                "streaming response delivery must not use ForkJoinPool.commonPool(), whose"
+                        + " parallelism is capped at availableProcessors() - 1 and is shared with"
+                        + " unrelated JVM-wide async work");
+    }
+
+    @Test
+    public void testResponseExecutorSupportsMoreConcurrentBlockingTasksThanCommonPoolParallelism()
+            throws Exception {
+        ExecutorService executor = getResponseExecutor();
+        int commonPoolParallelism = ForkJoinPool.getCommonPoolParallelism();
+        // Simulate what sendOutput's blocking nextChunk() loop does: many concurrent
+        // streaming responses, each occupying a thread that blocks until released. If this
+        // still ran on a pool bounded at commonPoolParallelism, only that many of these
+        // tasks could be running at once and the rest would starve until one released its
+        // thread -- exactly the p99 ceiling this fix removes.
+        int concurrentStreams = commonPoolParallelism + 4;
+        CountDownLatch allRunning = new CountDownLatch(concurrentStreams);
+        CountDownLatch release = new CountDownLatch(1);
+
+        for (int i = 0; i < concurrentStreams; ++i) {
+            executor.submit(
+                    () -> {
+                        allRunning.countDown();
+                        try {
+                            release.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+        }
+
+        boolean allStartedPromptly = allRunning.await(5, TimeUnit.SECONDS);
+        release.countDown();
+
+        assertTrue(
+                allStartedPromptly,
+                "expected all "
+                        + concurrentStreams
+                        + " concurrent blocking tasks to start promptly (more than the common"
+                        + " pool's parallelism of "
+                        + commonPoolParallelism
+                        + "), but the executor did not have enough capacity");
+    }
+
+    @Test
+    public void testResponseExecutorUsesDaemonThreads() throws Exception {
+        ExecutorService executor = getResponseExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+        boolean[] isDaemon = new boolean[1];
+
+        executor.submit(
+                () -> {
+                    isDaemon[0] = Thread.currentThread().isDaemon();
+                    started.countDown();
+                });
+
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        assertTrue(
+                isDaemon[0],
+                "response-delivery threads must be daemon threads so they never block JVM"
+                        + " shutdown");
+    }
+
+    private static ExecutorService getResponseExecutor() throws Exception {
+        Field field = InferenceRequestHandler.class.getDeclaredField("RESPONSE_EXECUTOR");
+        field.setAccessible(true);
+        return (ExecutorService) field.get(null);
+    }
+
+    private static boolean isForkJoinCommonPool(ExecutorService executor) {
+        return executor == ForkJoinPool.commonPool();
+    }
+}


### PR DESCRIPTION
## Description ##

Fixes high p50 latency under concurrent streaming (`async_mode=true`). Two bottlenecks in the response path plus one related simplification:

- **`InferenceRequestHandler.java`**: streaming responses completed via `.whenCompleteAsync(...)` with no explicit executor, so they ran on `ForkJoinPool.commonPool()` (capped at `availableProcessors() - 1` threads, shared with every other unrelated `CompletableFuture` in the JVM). Now uses a dedicated cached thread pool for response dispatch.
- **`ModelServer.java`**: the `ServerBootstrap` never set `ChannelOption.TCP_NODELAY`. Streaming writes small chunks per token, and without it those chunks could sit behind Nagle's algorithm / delayed ACK.
- **`python_async_engine.py`**: `send_responses()` pushed to an `asyncio.Queue` from a non-async thread via `asyncio.run_coroutine_threadsafe(...).result()` — a full cross-thread round trip into the event loop per token. Switched to a plain `queue.Queue` (blocking `get()` / `put_nowait()`), removing the event-loop round trip entirely.

None of these are backward incompatible — internal implementation details only, no public API or config surface changes.

Benchmarked with `meta-llama/Llama-3.2-3B-Instruct`, vLLM `async_mode=true`, 128 concurrent requests:

| | before | after |
|---|---|---|
| p50 latency | 6.993s | 1.026s |
| throughput | 2559 tok/s | 3743 tok/s |
| p99 latency | 8.025s | 8.698s (no change) |

p99 doesn't move — traced that separately and it's coming from vLLM's own scheduler (`max_num_batched_tokens` / `max_num_seqs` / FCFS admission) at this concurrency, not from anything in DJL, so out of scope for this PR. Filed as context in #3071.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:
- [ ] Please add the link of [**Integration Tests Executor** run](https://github.com/deepjavalibrary/djl-serving/actions/workflows/integration_execute.yml) with related tests.
- [ ] Have you [manually built the docker image](https://github.com/deepjavalibrary/djl-serving/blob/master/serving/docker/README.md#build-docker-image) and verify the change?
- [x] Have you run related tests? Check [how to set up the test environment here](https://github.com/deepjavalibrary/djl-serving/blob/master/.github/workflows/integration_execute.yml#L98); One example would be `pytest tests.py -k "TestVllm1" -m "vllm"`
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

## Feature/Issue validation/testing

Added unit tests for all three changes, each verified to fail against the pre-fix code:

- [x] `serving/src/test/java/ai/djl/serving/http/InferenceRequestHandlerTest.java` — asserts the response executor is not `ForkJoinPool.commonPool()`, supports more concurrent blocking tasks than common-pool parallelism, and uses daemon threads.
- [x] `serving/src/test/java/ai/djl/serving/ModelServerSocketOptionsTest.java` — asserts `TCP_NODELAY` (and the other socket options) are set on the bootstrap's child options.
- [x] `engines/python/setup/djl_python/tests/test_python_async_engine.py` — covers `invoke_handler` (streaming, non-streaming, OOM, generic error, `None` output) and `send_responses`/`output_queue` cross-thread hand-off.

Load-test comparison (fix vs. no-fix, same `async_mode=true` path, 128 concurrent requests, generic public prompt set, not internal data — reproducible):

```
python3 load_test.py --url http://localhost:8002 --concurrency 128 --duration 90 \
    --config-name djl_async_baseline --container djl --batch-size 128 --dtype auto \
    --gpu-mem-util 0.9 --prompts-file prompts_public.jsonl
```

- [x] Before fix (`djl_llama32_3b_async`): p50 6.993s, p99 8.025s, 2559 tok/s
- [x] After fix (`djl_llama32_3b_patched_v2`): p50 1.026s, p99 8.698s, 3743 tok/s

Same relative improvement (p50 2.8x faster) reproduced at 8B scale (`Llama-3.1-8B-Instruct`).
