### PR TITLE
fix(python): `output` -> `outputs` in ts_service_loader — empty TorchServe result raises NameError

### DIFF
--- a/engines/python/setup/djl_python/ts_service_loader.py
+++ b/engines/python/setup/djl_python/ts_service_loader.py
@@ -78,7 +78,7 @@ class TorchServeService(ModelService):
 
         if not ts_out:
             outputs.message = "No content"
-            output.add("No content")
+            outputs.add("No content")
         else:
             val = ts_out[0]
             if isinstance(val, torch.Tensor):


### PR DESCRIPTION
### What

`engines/python/setup/djl_python/ts_service_loader.py:81` calls `.add()` on
`output`, but the local built a few lines earlier is called `outputs`:

```python
outputs = Output(code, msg)
if content_type is not None:
    outputs.add_property("content-type", content_type)

if not ts_out:
    outputs.message = "No content"
    output.add("No content")      # <- NameError
else:
    ...
    outputs.add(val)

return outputs
```

`output` is not bound anywhere in the module. `pyflakes` on current `master`:

```
engines/python/setup/djl_python/ts_service_loader.py:81:13: undefined name 'output'
```

That is the only pyflakes finding in the file.

### Why it matters

`invoke_handler` is the `ModelService` entry point the Python engine calls for
every inference request, so any TorchServe handler that returns an empty result
(`ts_out` falsy) fails with `NameError: name 'output' is not defined` instead of
producing the intended "No content" response.

### Verification

`invoke_handler` was lifted verbatim out of `master` with
`ast.get_source_segment` and driven with stub `Output` / `Service` / `Inputs`
objects whose `_entry_point` returns `[]`:

```
### UNPATCHED (upstream master)
    -> NameError: name 'output' is not defined
### PATCHED  (outputs.add)
    -> OK  code=200 message='No content' content=['No content']
```

### Fix

One character — `output` → `outputs`, matching the `outputs.add(val)` in the
sibling branch.

If the intent was actually the empty-body shape the other engines use
(`python_sync_engine.py:164` / `python_async_engine.py:80` build
`Output(code=204, message="No content")` with no content), then deleting line 81
would be the better fix instead. Happy to switch — either way the current line
cannot run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
